### PR TITLE
Addition of 'Install Content' and 'Show Installed Content'

### DIFF
--- a/Xenia Manager/Classes/JSONParse.cs
+++ b/Xenia Manager/Classes/JSONParse.cs
@@ -111,6 +111,22 @@ namespace Xenia_Manager.Classes
     }
 
     /// <summary>
+    /// Class that contains everything about content that is going to be installed
+    /// </summary>
+    public class GameContent
+    {
+        public string GameId { get; set; }
+
+        public string ContentTitle { get; set; }
+
+        public string ContentDisplayName { get; set; }
+
+        public string ContentType { get; set; }
+
+        public string ContentTypeValue { get; set; }
+    }
+
+    /// <summary>
     /// This is used for parsing Xenia Manager settings which are stored in a .JSON file
     /// </summary>
     public class Configuration

--- a/Xenia Manager/Classes/JSONParse.cs
+++ b/Xenia Manager/Classes/JSONParse.cs
@@ -124,6 +124,8 @@ namespace Xenia_Manager.Classes
         public string ContentType { get; set; }
 
         public string ContentTypeValue { get; set; }
+
+        public string ContentPath { get; set; }
     }
 
     /// <summary>

--- a/Xenia Manager/Classes/STFS.cs
+++ b/Xenia Manager/Classes/STFS.cs
@@ -1,0 +1,170 @@
+﻿using System;
+using System.IO;
+
+// Imported
+using Serilog;
+
+namespace Xenia_Manager.Classes
+{
+    public class STFS
+    {
+        /// <summary>
+        /// Enumeration of all supported content types by Xenia according to their FAQ.
+        /// </summary>
+        public enum ContentType : uint
+        {
+            /// <summary>
+            /// Saved game data.
+            /// </summary>
+            SavedGame = 0x0000001,
+
+            /// <summary>
+            /// Content available on the marketplace.
+            /// </summary>
+            MarketplaceContent = 0x0000002,
+
+            /// <summary>
+            /// Content published by a third party.
+            /// </summary>
+            //Publisher = 0x0000003,
+
+            /// <summary>
+            /// Xbox 360 title.
+            /// </summary>
+            Xbox360Title = 0x0001000,
+
+            /// <summary>
+            /// Installed game.
+            /// </summary>
+            InstalledGame = 0x0004000,
+
+            /// <summary>
+            /// Xbox Original game.
+            /// </summary>
+            //XboxOriginalGame = 0x0005000,
+
+            /// <summary>
+            /// Xbox Title, also used for Xbox Original games.
+            /// </summary>
+            //XboxTitle = 0x0005000,
+
+            /// <summary>
+            /// Game on Demand content.
+            /// </summary>
+            GameOnDemand = 0x0007000,
+
+            /// <summary>
+            /// Avatar item.
+            /// </summary>
+            //AvatarItem = 0x0009000,
+
+            /// <summary>
+            /// User profile data.
+            /// </summary>
+            //Profile = 0x0010000,
+
+            /// <summary>
+            /// Gamer picture.
+            /// </summary>
+            //GamerPicture = 0x0020000,
+
+            /// <summary>
+            /// Theme for Xbox dashboard or games.
+            /// </summary>
+            //Theme = 0x0030000,
+
+            /// <summary>
+            /// Storage download, typically for storage devices.
+            /// </summary>
+            //StorageDownload = 0x0050000,
+
+            /// <summary>
+            /// Xbox saved game data.
+            /// </summary>
+            //XboxSavedGame = 0x0060000,
+
+            /// <summary>
+            /// Downloadable content for Xbox.
+            /// </summary>
+            //XboxDownload = 0x0070000,
+
+            /// <summary>
+            /// Game demo content.
+            /// </summary>
+            //GameDemo = 0x0080000,
+
+            /// <summary>
+            /// Full game title.
+            /// </summary>
+            //GameTitle = 0x00A0000,
+
+            /// <summary>
+            /// Installer for games or applications.
+            /// </summary>
+            Installer = 0x00B0000,
+
+            /// <summary>
+            /// Arcade title, typically a game from the Xbox Live Arcade.
+            /// </summary>
+            ArcadeTitle = 0x00D0000,
+        }
+
+        /// <summary>
+        /// Gets or sets the content type value from the STFS file.
+        /// </summary>
+        public uint ContentTypeValue { get; private set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="STFS"/> class and reads the content type from the specified file path.
+        /// </summary>
+        /// <param name="filePath">The path to the STFS file.</param>
+        public STFS(string filePath)
+        {
+            ReadContentType(filePath);
+        }
+
+        // Functions
+        /// <summary>
+        /// Reads the content type from the specified STFS file.
+        /// </summary>
+        /// <param name="filePath">The path to the STFS file.</param>
+        private void ReadContentType(string filePath)
+        {
+            Log.Information($"Reading the {Path.GetFileNameWithoutExtension(filePath)}");
+            using (FileStream fs = new FileStream(filePath, FileMode.Open, FileAccess.Read))
+            using (BinaryReader reader = new BinaryReader(fs))
+            {
+                // Move to the position of Content Type
+                reader.BaseStream.Seek(0x344, SeekOrigin.Begin);
+
+                // Read the Content Type value
+                byte[] contentTypeBytes = reader.ReadBytes(4);
+                if (BitConverter.IsLittleEndian)
+                {
+                    Array.Reverse(contentTypeBytes);
+                }
+                ContentTypeValue = BitConverter.ToUInt32(contentTypeBytes, 0);
+            }
+        }
+
+        /// <summary>
+        /// Gets the content type enumeration value based on the content type value read from the STFS file.
+        /// </summary>
+        /// <returns>The <see cref="ContentType"/> corresponding to the content type value.</returns>
+        /// <exception cref="ArgumentException">Thrown when the content type value is not defined in the <see cref="ContentType"/> enum.</exception>
+        public (ContentType? ContentTypeEnum, uint ContentTypeValue) GetContentType()
+        {
+            // Check if the ContentTypeValue exists in the enum and return it
+            if (Enum.IsDefined(typeof(ContentType), ContentTypeValue))
+            {
+                Log.Information($"Content Type: {(ContentType)ContentTypeValue} {ContentTypeValue:X8}");
+                return ((ContentType)ContentTypeValue, ContentTypeValue);
+            }
+            else
+            {
+                Log.Information($"Unknown content type: {ContentTypeValue:X8}");
+                return (null, ContentTypeValue);
+            }
+        }
+    }
+}

--- a/Xenia Manager/Classes/STFS.cs
+++ b/Xenia Manager/Classes/STFS.cs
@@ -110,9 +110,39 @@ namespace Xenia_Manager.Classes
         }
 
         /// <summary>
+        /// All of the types of headers in STFS format
+        /// </summary>
+        private static string[] SupportedHeaders { get; } = { "CON", "PIRS", "LIVE" };
+
+        /// <summary>
+        /// Check if the file has supported Header
+        /// </summary>
+        public bool SupportedFile { get; private set; }
+
+        /// <summary>
+        /// Stores title extracted from the STFS file
+        /// </summary>
+        public string Title { get; private set; }
+
+        /// <summary>
+        /// Stores the display name extracted from the STFS file
+        /// </summary>
+        public string DisplayName { get; private set; }
+
+        /// <summary>
         /// Gets or sets the content type value from the STFS file.
         /// </summary>
         public uint ContentTypeValue { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the FileStream used to access the STFS file.
+        /// </summary>
+        public FileStream FileStream { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the BinaryReader used to read from the STFS file.
+        /// </summary>
+        public BinaryReader BinaryReader { get; private set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="STFS"/> class and reads the content type from the specified file path.
@@ -120,31 +150,122 @@ namespace Xenia_Manager.Classes
         /// <param name="filePath">The path to the STFS file.</param>
         public STFS(string filePath)
         {
-            ReadContentType(filePath);
+            OpenFile(filePath);
+            CheckIfSupported();
         }
 
         // Functions
         /// <summary>
-        /// Reads the content type from the specified STFS file.
+        /// Opens the file and initializes FileStream and BinaryReader.
         /// </summary>
-        /// <param name="filePath">The path to the STFS file.</param>
-        private void ReadContentType(string filePath)
+        /// <param name="filePath">The path to the file.</param>
+        private void OpenFile(string filePath)
         {
-            Log.Information($"Reading the {Path.GetFileNameWithoutExtension(filePath)}");
-            using (FileStream fs = new FileStream(filePath, FileMode.Open, FileAccess.Read))
-            using (BinaryReader reader = new BinaryReader(fs))
-            {
-                // Move to the position of Content Type
-                reader.BaseStream.Seek(0x344, SeekOrigin.Begin);
+            Log.Information($"Opening the file: {Path.GetFileNameWithoutExtension(filePath)}");
+            FileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read);
+            BinaryReader = new BinaryReader(FileStream);
+        }
 
-                // Read the Content Type value
-                byte[] contentTypeBytes = reader.ReadBytes(4);
-                if (BitConverter.IsLittleEndian)
-                {
-                    Array.Reverse(contentTypeBytes);
-                }
-                ContentTypeValue = BitConverter.ToUInt32(contentTypeBytes, 0);
+        /// <summary>
+        /// Checks if the header is either LIVE, PARS or CON
+        /// </summary>
+        private void CheckIfSupported()
+        {
+            if (FileStream == null || BinaryReader == null)
+            {
+                throw new InvalidOperationException("FileStream and BinaryReader must be initialized before reading content type.");
             }
+
+            Log.Information("Checking if the file is supported");
+            // Move to the position of Header
+            BinaryReader.BaseStream.Seek(0x0, SeekOrigin.Begin);
+
+            // Read the UTF-8 string
+            byte[] stringBytes = BinaryReader.ReadBytes(0x4);
+            byte[] filteredBytes = stringBytes.Where(b => b != 0).ToArray();
+            string header = System.Text.Encoding.ASCII.GetString(filteredBytes);
+            Log.Information($"Header: {header}");
+            if (SupportedHeaders.Contains(header))
+            {
+                SupportedFile = true;
+            }
+        }
+
+        /// <summary>
+        /// Reads the title from the STFS file.
+        /// </summary>
+        public void ReadTitle()
+        {
+            if (FileStream == null || BinaryReader == null)
+            {
+                throw new InvalidOperationException("FileStream and BinaryReader must be initialized before reading content type.");
+            }
+
+            Log.Information("Reading title name from file");
+            // Move to the position of Title Name
+            BinaryReader.BaseStream.Seek(0x1691, SeekOrigin.Begin);
+
+            // Read the UTF-8 string
+            byte[] stringBytes = BinaryReader.ReadBytes(0x80);
+            byte[] filteredBytes = stringBytes.Where(b => b != 0).ToArray();
+
+            // Convert the bytes to a UTF-8 string
+            Title = System.Text.Encoding.UTF8.GetString(filteredBytes);
+            if (Title == "")
+            {
+                Log.Information("Title not found");
+                ReadDisplayName();
+            }
+            else
+            {
+                Log.Information(Title);
+            }
+        }
+
+        /// <summary>
+        /// Reads the display name from the STFS file.
+        /// </summary>
+        public void ReadDisplayName()
+        {
+            if (FileStream == null || BinaryReader == null)
+            {
+                throw new InvalidOperationException("FileStream and BinaryReader must be initialized before reading content type.");
+            }
+
+            Log.Information("Reading display name from file");
+            // Move to the position of Display Name
+            BinaryReader.BaseStream.Seek(0x411, SeekOrigin.Begin);
+
+            // Read the UTF-8 string
+            byte[] stringBytes = BinaryReader.ReadBytes(0x80);
+            byte[] filteredBytes = stringBytes.Where(b => b != 0).ToArray();
+
+            // Convert the bytes to a UTF-8 string
+            DisplayName = System.Text.Encoding.UTF8.GetString(filteredBytes);
+            Log.Information(DisplayName);
+        }
+
+        /// <summary>
+        /// Reads the content type from the STFS file.
+        /// </summary>
+        public void ReadContentType()
+        {
+            if (FileStream == null || BinaryReader == null)
+            {
+                throw new InvalidOperationException("FileStream and BinaryReader must be initialized before reading content type.");
+            }
+
+            Log.Information($"Reading content type from file");
+            // Move to the position of Content Type
+            BinaryReader.BaseStream.Seek(0x344, SeekOrigin.Begin);
+
+            // Read the Content Type value
+            byte[] contentTypeBytes = BinaryReader.ReadBytes(4);
+            if (BitConverter.IsLittleEndian)
+            {
+                Array.Reverse(contentTypeBytes);
+            }
+            ContentTypeValue = BitConverter.ToUInt32(contentTypeBytes, 0);
         }
 
         /// <summary>

--- a/Xenia Manager/Classes/STFS.cs
+++ b/Xenia Manager/Classes/STFS.cs
@@ -16,12 +16,12 @@ namespace Xenia_Manager.Classes
             /// <summary>
             /// Saved game data.
             /// </summary>
-            SavedGame = 0x0000001,
+            Saved_Game = 0x0000001,
 
             /// <summary>
             /// Content available on the marketplace.
             /// </summary>
-            MarketplaceContent = 0x0000002,
+            Downloadable_Content = 0x0000002,
 
             /// <summary>
             /// Content published by a third party.
@@ -31,12 +31,12 @@ namespace Xenia_Manager.Classes
             /// <summary>
             /// Xbox 360 title.
             /// </summary>
-            Xbox360Title = 0x0001000,
+            Xbox360_Title = 0x0001000,
 
             /// <summary>
             /// Installed game.
             /// </summary>
-            InstalledGame = 0x0004000,
+            Installed_Game = 0x0004000,
 
             /// <summary>
             /// Xbox Original game.
@@ -51,7 +51,7 @@ namespace Xenia_Manager.Classes
             /// <summary>
             /// Game on Demand content.
             /// </summary>
-            GameOnDemand = 0x0007000,
+            Game_On_Demand = 0x0007000,
 
             /// <summary>
             /// Avatar item.
@@ -106,7 +106,7 @@ namespace Xenia_Manager.Classes
             /// <summary>
             /// Arcade title, typically a game from the Xbox Live Arcade.
             /// </summary>
-            ArcadeTitle = 0x00D0000,
+            Arcade_Title = 0x00D0000,
         }
 
         /// <summary>
@@ -214,7 +214,6 @@ namespace Xenia_Manager.Classes
             if (Title == "")
             {
                 Log.Information("Title not found");
-                ReadDisplayName();
             }
             else
             {

--- a/Xenia Manager/Pages/Library.xaml.cs
+++ b/Xenia Manager/Pages/Library.xaml.cs
@@ -523,6 +523,7 @@ namespace Xenia_Manager.Pages
                             content.ContentDisplayName = stfs.DisplayName;
                             content.ContentType = contentType.ToString().Replace('_', ' ');
                             content.ContentTypeValue = $"{contentTypeValue:X8}";
+                            content.ContentPath = file;
                             if (content.ContentType != null)
                             {
                                 gameContent.Add(content);

--- a/Xenia Manager/Pages/Library.xaml.cs
+++ b/Xenia Manager/Pages/Library.xaml.cs
@@ -756,9 +756,9 @@ namespace Xenia_Manager.Pages
                     contextMenu.Items.Add(CreateMenuItem("Install Content", $"Install various game content like DLC, Title Updates etc.", (sender, e) => InstallContent(game)));
 
                     // Add 'Show installed content' option
-                    contextMenu.Items.Add(CreateMenuItem("Show Installed Content", $"Install various game content like DLC, Title Updates etc.", async (sender, e) =>
+                    contextMenu.Items.Add(CreateMenuItem("Show Installed Content", $"Allows the user to see what's installed in game content folder and to export save files", async (sender, e) =>
                     {
-                        ShowInstalledContent showInstalledContent = new ShowInstalledContent();
+                        ShowInstalledContent showInstalledContent = new ShowInstalledContent(game);
                         await showInstalledContent.WaitForCloseAsync();
                     }));
 

--- a/Xenia Manager/Pages/Library.xaml.cs
+++ b/Xenia Manager/Pages/Library.xaml.cs
@@ -925,7 +925,7 @@ namespace Xenia_Manager.Pages
                 Log.Information("Open file dialog");
                 OpenFileDialog openFileDialog = new OpenFileDialog();
                 openFileDialog.Title = "Select a game";
-                openFileDialog.Filter = "Supported Files|*.iso;*.xex;*.zar|ISO Files (*.iso)|*.iso|XEX Files (*.xex)|*.xex|ZAR Files (*.zar)|*.zar|All Files|*";
+                openFileDialog.Filter = "All Files|*|Supported Files|*.iso;*.xex;*.zar";
                 bool? result = openFileDialog.ShowDialog();
                 if (result == true)
                 {

--- a/Xenia Manager/Pages/Library.xaml.cs
+++ b/Xenia Manager/Pages/Library.xaml.cs
@@ -691,6 +691,34 @@ namespace Xenia_Manager.Pages
                         contextMenu.Items.Add(CreateMenuItem("Install Title updates", $"Allows the user to install game updates for {game.Title}", async (sender, e) => await InstallTitleUpdate(game)));
                     }
 
+                    // Install content
+                    /*
+                    contextMenu.Items.Add(CreateMenuItem("Install Content", $"Install various game content like DLC, Install discs, Title Updates etc.", (sender, e) =>
+                    {
+                        Log.Information("Open file dialog");
+                        OpenFileDialog openFileDialog = new OpenFileDialog();
+                        openFileDialog.Title = "Select a game";
+                        openFileDialog.Filter = "All Files|*";
+                        openFileDialog.Multiselect = true;
+                        bool? result = openFileDialog.ShowDialog();
+                        if (result == true)
+                        {
+                            foreach (string file in openFileDialog.FileNames)
+                            {
+                                try
+                                {
+                                    STFS stfs = new STFS(file);
+                                    var (contentType, contentTypeValue) = stfs.GetContentType();
+                                }
+                                catch (Exception ex)
+                                {
+                                    Log.Information($"Error: {ex.Message}");
+                                }
+                            }
+                        };
+                    }));
+                    */
+
                     // Check if Xenia Stable is installed
                     if (App.appConfiguration.XeniaStable != null && Directory.Exists(App.appConfiguration.XeniaStable.EmulatorLocation))
                     {

--- a/Xenia Manager/Pages/Library.xaml.cs
+++ b/Xenia Manager/Pages/Library.xaml.cs
@@ -692,7 +692,7 @@ namespace Xenia_Manager.Pages
                     }
 
                     // Install content
-                    /*
+                    
                     contextMenu.Items.Add(CreateMenuItem("Install Content", $"Install various game content like DLC, Install discs, Title Updates etc.", (sender, e) =>
                     {
                         Log.Information("Open file dialog");
@@ -707,8 +707,18 @@ namespace Xenia_Manager.Pages
                             {
                                 try
                                 {
-                                    STFS stfs = new STFS(file);
-                                    var (contentType, contentTypeValue) = stfs.GetContentType();
+                                    FileFormats stfs = new FileFormats(file);
+                                    if (stfs.SupportedFile)
+                                    {
+                                        stfs.ReadTitle();
+                                        stfs.ReadContentType();
+                                        var (contentType, contentTypeValue) = stfs.GetContentType();
+                                    }
+                                    else
+                                    {
+                                        Log.Information($"{Path.GetFileNameWithoutExtension(file)} is currently not supported");
+                                        MessageBox.Show($"{Path.GetFileNameWithoutExtension(file)} is currently not supported");
+                                    }
                                 }
                                 catch (Exception ex)
                                 {
@@ -717,7 +727,6 @@ namespace Xenia_Manager.Pages
                             }
                         };
                     }));
-                    */
 
                     // Check if Xenia Stable is installed
                     if (App.appConfiguration.XeniaStable != null && Directory.Exists(App.appConfiguration.XeniaStable.EmulatorLocation))

--- a/Xenia Manager/Pages/Library.xaml.cs
+++ b/Xenia Manager/Pages/Library.xaml.cs
@@ -752,8 +752,15 @@ namespace Xenia_Manager.Pages
                     }
                     */
 
-                    // Install content
-                    contextMenu.Items.Add(CreateMenuItem("Install Content", $"Install various game content like DLC, Title Updates etc. (Currently only Title Updates)", (sender, e) => InstallContent(game)));
+                    // Add 'Install content' option
+                    contextMenu.Items.Add(CreateMenuItem("Install Content", $"Install various game content like DLC, Title Updates etc.", (sender, e) => InstallContent(game)));
+
+                    // Add 'Show installed content' option
+                    contextMenu.Items.Add(CreateMenuItem("Show Installed Content", $"Install various game content like DLC, Title Updates etc.", async (sender, e) =>
+                    {
+                        ShowInstalledContent showInstalledContent = new ShowInstalledContent();
+                        await showInstalledContent.WaitForCloseAsync();
+                    }));
 
                     // Check if Xenia Stable is installed
                     if (App.appConfiguration.XeniaStable != null && Directory.Exists(App.appConfiguration.XeniaStable.EmulatorLocation))

--- a/Xenia Manager/Pages/Library.xaml.cs
+++ b/Xenia Manager/Pages/Library.xaml.cs
@@ -926,28 +926,32 @@ namespace Xenia_Manager.Pages
                 OpenFileDialog openFileDialog = new OpenFileDialog();
                 openFileDialog.Title = "Select a game";
                 openFileDialog.Filter = "All Files|*|Supported Files|*.iso;*.xex;*.zar";
+                openFileDialog.Multiselect = true;
                 bool? result = openFileDialog.ShowDialog();
                 if (result == true)
                 {
-                    Log.Information($"Selected file: {openFileDialog.FileName}");
-                    if (App.appConfiguration.XeniaStable != null && App.appConfiguration.XeniaCanary != null)
+                    foreach (string game in openFileDialog.FileNames)
                     {
-                        Log.Information("Detected both Xenia installations");
-                        Log.Information("Asking user what Xenia version will the game use");
-                        XeniaSelection xs = new XeniaSelection();
-                        await xs.WaitForCloseAsync();
-                        Log.Information($"User selected Xenia {xs.UserSelection}");
-                        await GetGameTitle(openFileDialog.FileName, xs.UserSelection);
-                    }
-                    else if (App.appConfiguration.XeniaStable != null && App.appConfiguration.XeniaCanary == null)
-                    {
-                        Log.Information("Only Xenia Stable is installed");
-                        await GetGameTitle(openFileDialog.FileName, "Stable");
-                    }
-                    else
-                    {
-                        Log.Information("Only Xenia Canary is installed");
-                        await GetGameTitle(openFileDialog.FileName, "Canary");
+                        Log.Information($"Selected file: {openFileDialog.FileName}");
+                        if (App.appConfiguration.XeniaStable != null && App.appConfiguration.XeniaCanary != null)
+                        {
+                            Log.Information("Detected both Xenia installations");
+                            Log.Information("Asking user what Xenia version will the game use");
+                            XeniaSelection xs = new XeniaSelection();
+                            await xs.WaitForCloseAsync();
+                            Log.Information($"User selected Xenia {xs.UserSelection}");
+                            await GetGameTitle(game, xs.UserSelection);
+                        }
+                        else if (App.appConfiguration.XeniaStable != null && App.appConfiguration.XeniaCanary == null)
+                        {
+                            Log.Information("Only Xenia Stable is installed");
+                            await GetGameTitle(game, "Stable");
+                        }
+                        else
+                        {
+                            Log.Information("Only Xenia Canary is installed");
+                            await GetGameTitle(game, "Canary");
+                        }
                     }
                 }
                 await LoadGames();

--- a/Xenia Manager/Pages/Library.xaml.cs
+++ b/Xenia Manager/Pages/Library.xaml.cs
@@ -494,7 +494,7 @@ namespace Xenia_Manager.Pages
         /// <para>Checks every selected file and tries to determine what it is.</para>
         /// Opens 'InstallContent' window where all of the selected and supported items are shown with a 'Confirm' button below
         /// </summary>
-        private void InstallContent(InstalledGame game)
+        private async void InstallContent(InstalledGame game)
         {
             Log.Information("Open file dialog");
             OpenFileDialog openFileDialog = new OpenFileDialog();
@@ -543,7 +543,7 @@ namespace Xenia_Manager.Pages
                 if (gameContent.Count > 0)
                 {
                     InstallContent installContent = new InstallContent(gameContent);
-                    installContent.ShowDialog();
+                    await installContent.WaitForCloseAsync();
                 }
             };
         }

--- a/Xenia Manager/Pages/Library.xaml.cs
+++ b/Xenia Manager/Pages/Library.xaml.cs
@@ -692,12 +692,11 @@ namespace Xenia_Manager.Pages
                     }
 
                     // Install content
-                    
-                    contextMenu.Items.Add(CreateMenuItem("Install Content", $"Install various game content like DLC, Install discs, Title Updates etc.", (sender, e) =>
+                    contextMenu.Items.Add(CreateMenuItem("Install Content", $"Install various game content like DLC, Title Updates etc. (Currently only Title Updates)", (sender, e) =>
                     {
                         Log.Information("Open file dialog");
                         OpenFileDialog openFileDialog = new OpenFileDialog();
-                        openFileDialog.Title = "Select a game";
+                        openFileDialog.Title = "Select files";
                         openFileDialog.Filter = "All Files|*";
                         openFileDialog.Multiselect = true;
                         bool? result = openFileDialog.ShowDialog();
@@ -707,7 +706,7 @@ namespace Xenia_Manager.Pages
                             {
                                 try
                                 {
-                                    FileFormats stfs = new FileFormats(file);
+                                    STFS stfs = new STFS(file);
                                     if (stfs.SupportedFile)
                                     {
                                         stfs.ReadTitle();

--- a/Xenia Manager/Pages/Library.xaml.cs
+++ b/Xenia Manager/Pages/Library.xaml.cs
@@ -504,6 +504,7 @@ namespace Xenia_Manager.Pages
             bool? result = openFileDialog.ShowDialog();
             if (result == true)
             {
+                Mouse.OverrideCursor = Cursors.Wait;
                 List<GameContent> gameContent = new List<GameContent>();
                 foreach (string file in openFileDialog.FileNames)
                 {
@@ -538,6 +539,7 @@ namespace Xenia_Manager.Pages
                         Log.Information($"Error: {ex.Message}");
                     }
                 }
+                Mouse.OverrideCursor = null;
                 if (gameContent.Count > 0)
                 {
                     InstallContent installContent = new InstallContent(gameContent);

--- a/Xenia Manager/Windows/InstallContent.xaml
+++ b/Xenia Manager/Windows/InstallContent.xaml
@@ -54,14 +54,16 @@
             
             <!-- List of content to install -->
             <Grid Grid.Row="2">
-                <ListBox x:Name="ListOfContentToInstall"/>
+                <ListBox x:Name="ListOfContentToInstall"
+                         SelectionChanged="ListOfContentToInstall_SelectionChanged"
+                         PreviewMouseDown="ListOfContentToInstall_PreviewMouseDown"/>
             </Grid>
 
             <!-- Seperation Line -->
             <Border Grid.Row="3" 
                     Style="{StaticResource SeperationLine}"/>
 
-            <!--  -->
+            <!-- Action buttons -->
             <Grid Grid.Row="4">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition />

--- a/Xenia Manager/Windows/InstallContent.xaml
+++ b/Xenia Manager/Windows/InstallContent.xaml
@@ -10,7 +10,7 @@
         WindowStyle="None" ResizeMode="NoResize"
         WindowStartupLocation="CenterScreen"
         Background="Transparent" AllowsTransparency="True"
-        Visibility="Visible">
+        Visibility="Visible" IsVisibleChanged="Window_IsVisibleChanged">
     <Border Background="{DynamicResource BackgroundColor}"
             BorderBrush="{DynamicResource BorderBrush}"
             BorderThickness="2"
@@ -61,14 +61,35 @@
             <Border Grid.Row="3" 
                     Style="{StaticResource SeperationLine}"/>
 
-            <!-- Confirm button -->
+            <!--  -->
             <Grid Grid.Row="4">
-                <Button x:Name="AddGame" 
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition />
+                    <ColumnDefinition />
+                </Grid.ColumnDefinitions>
+
+                <!-- Confirm button -->
+                <Button x:Name="Confirm" 
+                        Grid.Column="0"
                         Style="{StaticResource ButtonStyle}"
                         HorizontalAlignment="Center"
-                        VerticalAlignment="Center">
+                        VerticalAlignment="Center"
+                        Margin="0,5,0,5">
                     <Button.Content>
                         <TextBlock Text="Confirm"
+                                   Style="{StaticResource AddGameText}"/>
+                    </Button.Content>
+                </Button>
+
+                <!-- Remove button -->
+                <Button x:Name="Remove" 
+                        Grid.Column="1"
+                        Style="{StaticResource ButtonStyle}"
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center"
+                        Margin="0,5,0,5">
+                    <Button.Content>
+                        <TextBlock Text="Remove"
                                    Style="{StaticResource AddGameText}"/>
                     </Button.Content>
                 </Button>

--- a/Xenia Manager/Windows/InstallContent.xaml
+++ b/Xenia Manager/Windows/InstallContent.xaml
@@ -6,7 +6,7 @@
         xmlns:local="clr-namespace:Xenia_Manager.Windows"
         mc:Ignorable="d"
         Title="Xenia Manager - Install Content" 
-        Height="550" Width="600"
+        Height="550" Width="800"
         WindowStyle="None" ResizeMode="NoResize"
         WindowStartupLocation="CenterScreen"
         Background="Transparent" AllowsTransparency="True"

--- a/Xenia Manager/Windows/InstallContent.xaml
+++ b/Xenia Manager/Windows/InstallContent.xaml
@@ -76,7 +76,8 @@
                         Style="{StaticResource ButtonStyle}"
                         HorizontalAlignment="Center"
                         VerticalAlignment="Center"
-                        Margin="0,5,0,5">
+                        Margin="0,5,0,5"
+                        Click="Confirm_Click">
                     <Button.Content>
                         <TextBlock Text="Confirm"
                                    Style="{StaticResource AddGameText}"/>

--- a/Xenia Manager/Windows/InstallContent.xaml
+++ b/Xenia Manager/Windows/InstallContent.xaml
@@ -89,7 +89,8 @@
                         Style="{StaticResource ButtonStyle}"
                         HorizontalAlignment="Center"
                         VerticalAlignment="Center"
-                        Margin="0,5,0,5">
+                        Margin="0,5,0,5"
+                        Click="Remove_Click">
                     <Button.Content>
                         <TextBlock Text="Remove"
                                    Style="{StaticResource AddGameText}"/>

--- a/Xenia Manager/Windows/InstallContent.xaml
+++ b/Xenia Manager/Windows/InstallContent.xaml
@@ -20,6 +20,7 @@
                 <RowDefinition Height="50"/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition />
+                <RowDefinition Height="Auto"/>
                 <RowDefinition Height="50"/>
             </Grid.RowDefinitions>
 
@@ -56,8 +57,12 @@
                 <ListBox x:Name="ListOfContentToInstall"/>
             </Grid>
 
+            <!-- Seperation Line -->
+            <Border Grid.Row="3" 
+                    Style="{StaticResource SeperationLine}"/>
+
             <!-- Confirm button -->
-            <Grid Grid.Row="3">
+            <Grid Grid.Row="4">
                 <Button x:Name="AddGame" 
                         Style="{StaticResource ButtonStyle}"
                         HorizontalAlignment="Center"

--- a/Xenia Manager/Windows/InstallContent.xaml
+++ b/Xenia Manager/Windows/InstallContent.xaml
@@ -1,0 +1,73 @@
+﻿<Window x:Class="Xenia_Manager.Windows.InstallContent"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:Xenia_Manager.Windows"
+        mc:Ignorable="d"
+        Title="Xenia Manager - Install Content" 
+        Height="550" Width="600"
+        WindowStyle="None" ResizeMode="NoResize"
+        WindowStartupLocation="CenterScreen"
+        Background="Transparent" AllowsTransparency="True"
+        Visibility="Visible">
+    <Border Background="{DynamicResource BackgroundColor}"
+            BorderBrush="{DynamicResource BorderBrush}"
+            BorderThickness="2"
+            CornerRadius="10">
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="50"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition />
+                <RowDefinition Height="50"/>
+            </Grid.RowDefinitions>
+
+            <!-- Game name and close button-->
+            <Grid Grid.Row="0">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+
+                <!-- Game Name-->
+                <TextBlock x:Name="GameTitle"
+                           Grid.Column="0"
+                           Grid.ColumnSpan="2"
+                           Style="{StaticResource TitleTextBlock}"
+                           FontSize="28"
+                           Text="Install Content"
+                           HorizontalAlignment="Center"/>
+
+                <!-- Close button -->
+                <Button Grid.Column="1" 
+                        x:Name="Exit"
+                        Style="{StaticResource ExitButton}"
+                        HorizontalAlignment="Right"
+                        Click="Exit_Click"/>
+            </Grid>
+
+            <!-- Seperation Line -->
+            <Border Grid.Row="1" 
+                    Style="{StaticResource SeperationLine}"/>
+            
+            <!-- List of content to install -->
+            <Grid Grid.Row="2">
+                <ListBox x:Name="ListOfContentToInstall"/>
+            </Grid>
+
+            <!-- Confirm button -->
+            <Grid Grid.Row="3">
+                <Button x:Name="AddGame" 
+                        Style="{StaticResource ButtonStyle}"
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center">
+                    <Button.Content>
+                        <TextBlock Text="Confirm"
+                                   Style="{StaticResource AddGameText}"/>
+                    </Button.Content>
+                </Button>
+            </Grid>
+        </Grid>
+    </Border>
+</Window>

--- a/Xenia Manager/Windows/InstallContent.xaml.cs
+++ b/Xenia Manager/Windows/InstallContent.xaml.cs
@@ -196,12 +196,38 @@ namespace Xenia_Manager.Windows
             }
         }
 
+        // Buttons
         /// <summary>
         /// Closes this window
         /// </summary>
         private async void Exit_Click(object sender, RoutedEventArgs e)
         {
             await ClosingAnimation();
+        }
+
+        /// <summary>
+        /// If there's a selected item in the ListBox, it will remove it from the list
+        /// </summary>
+        private async void Remove_Click(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                await Task.Delay(1);
+                if (ListOfContentToInstall.SelectedIndex >= 0)
+                {
+                    Log.Information("Reseting the selection in the ListBox");
+                    ListOfContentToInstall.SelectedIndex = -1;
+
+                    Log.Information($"Removing {gameContent[ListOfContentToInstall.SelectedIndex].ContentDisplayName}");
+                    gameContent.RemoveAt(ListOfContentToInstall.SelectedIndex);
+                    ListOfContentToInstall.Items.RemoveAt(ListOfContentToInstall.SelectedIndex);
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex.Message + "\nFull Error:\n" + ex);
+                MessageBox.Show(ex.Message);
+            }
         }
     }
 }

--- a/Xenia Manager/Windows/InstallContent.xaml.cs
+++ b/Xenia Manager/Windows/InstallContent.xaml.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Shapes;
+
+namespace Xenia_Manager.Windows
+{
+    /// <summary>
+    /// Interaction logic for InstallContent.xaml
+    /// </summary>
+    public partial class InstallContent : Window
+    {
+        public InstallContent()
+        {
+            InitializeComponent();
+        }
+
+        private void Exit_Click(object sender, RoutedEventArgs e)
+        {
+            this.Close();
+        }
+    }
+}

--- a/Xenia Manager/Windows/InstallContent.xaml.cs
+++ b/Xenia Manager/Windows/InstallContent.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.IO;
+using System.Text.RegularExpressions;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
@@ -246,7 +247,7 @@ namespace Xenia_Manager.Windows
                 XeniaVFSDumpTool.StartInfo.FileName = Path.Combine(App.baseDirectory, App.appConfiguration.VFSDumpToolLocation);
                 XeniaVFSDumpTool.StartInfo.CreateNoWindow = true;
                 XeniaVFSDumpTool.StartInfo.UseShellExecute = false;
-                XeniaVFSDumpTool.StartInfo.Arguments = $@"""{content.ContentPath}"" ""{Path.Combine(App.baseDirectory, App.appConfiguration.XeniaCanary.EmulatorLocation)}content\{content.GameId}\{content.ContentTypeValue}\{Path.GetFileName(content.ContentPath)}""";
+                XeniaVFSDumpTool.StartInfo.Arguments = $@"""{content.ContentPath}"" ""{Path.Combine(App.baseDirectory, App.appConfiguration.XeniaCanary.EmulatorLocation)}content\{content.GameId}\{content.ContentTypeValue}\{Regex.Replace(content.ContentDisplayName, @"[\\/:*?""<>|]", " -")}""";
                 XeniaVFSDumpTool.Start();
                 await XeniaVFSDumpTool.WaitForExitAsync();
                 Log.Information("Installation completed");
@@ -278,7 +279,7 @@ namespace Xenia_Manager.Windows
                     }
                 }
                 Mouse.OverrideCursor = null;
-                MessageBox.Show($"Installation completed.\nItems that were installed:\n{installedItems}");
+                MessageBox.Show($"Installed content:\n{installedItems}");
 
                 // Close this window
                 await ClosingAnimation();

--- a/Xenia Manager/Windows/InstallContent.xaml.cs
+++ b/Xenia Manager/Windows/InstallContent.xaml.cs
@@ -14,6 +14,7 @@ namespace Xenia_Manager.Windows
     /// </summary>
     public partial class InstallContent : Window
     {
+        // Contains every selected content for installation
         List<GameContent> gameContent = new List<GameContent>();
 
         // Used to send a signal that this window has been closed

--- a/Xenia Manager/Windows/InstallContent.xaml.cs
+++ b/Xenia Manager/Windows/InstallContent.xaml.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Input;
+using System.Windows.Media;
 using System.Windows.Media.Animation;
 
 // Imported
@@ -127,22 +129,79 @@ namespace Xenia_Manager.Windows
 
         // UI
         /// <summary>
+        /// Handles the PreviewMouseDown event for the ListBox.
+        /// Clears the selection if the click is outside of any ListBoxItem.
+        /// </summary>
+        /// <param name="sender">The source of the event, which is the ListBox.</param>
+        /// <param name="e">The MouseButtonEventArgs that contains the event data.</param>
+        private void ListOfContentToInstall_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (ListOfContentToInstall.SelectedIndex >= 0)
+            {
+                Log.Information("Selected item");
+                Log.Information(gameContent[ListOfContentToInstall.SelectedIndex].ContentTitle);
+                Log.Information(gameContent[ListOfContentToInstall.SelectedIndex].ContentDisplayName);
+                Log.Information(gameContent[ListOfContentToInstall.SelectedIndex].ContentType);
+                Log.Information(gameContent[ListOfContentToInstall.SelectedIndex].ContentTypeValue);
+                Log.Information(gameContent[ListOfContentToInstall.SelectedIndex].ContentPath);
+            }
+        }
+
+        /// <summary>
+        /// Traverses the visual tree to find an ancestor of the specified type.
+        /// </summary>
+        /// <typeparam name="T">The type of the ancestor to find.</typeparam>
+        /// <param name="current">The starting element to begin the search from.</param>
+        /// <returns>The found ancestor of type T, or null if not found.</returns>
+        private static T FindAncestor<T>(DependencyObject current) where T : DependencyObject
+        {
+            // Traverse the visual tree to find an ancestor of the specified type
+            while (current != null)
+            {
+                if (current is T)
+                {
+                    return (T)current;
+                }
+                current = VisualTreeHelper.GetParent(current);
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Handles the PreviewMouseDown event for the ListBox.
+        /// Clears the selection if the click is outside of any ListBoxItem.
+        /// </summary>
+        /// <param name="sender">The source of the event, which is the ListBox.</param>
+        /// <param name="e">The MouseButtonEventArgs that contains the event data.</param>
+        private void ListOfContentToInstall_PreviewMouseDown(object sender, MouseButtonEventArgs e)
+        {
+            // Get the ListBox
+            ListBox listBox = sender as ListBox;
+
+            // Get the clicked point
+            Point point = e.GetPosition(listBox);
+
+            // Get the element under the mouse at the clicked point
+            var result = VisualTreeHelper.HitTest(listBox, point);
+
+            if (result != null)
+            {
+                // Check if the clicked element is a ListBoxItem
+                ListBoxItem listBoxItem = FindAncestor<ListBoxItem>((DependencyObject)result.VisualHit);
+                if (listBoxItem == null)
+                {
+                    // If no ListBoxItem found, clear the selection
+                    listBox.SelectedIndex = -1;
+                }
+            }
+        }
+
+        /// <summary>
         /// Closes this window
         /// </summary>
         private async void Exit_Click(object sender, RoutedEventArgs e)
         {
             await ClosingAnimation();
-        }
-
-        private void ListOfContentToInstall_SelectionChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
-        {
-            if (ListOfContentToInstall.SelectedIndex >= 0)
-            {
-                Log.Information(gameContent[ListOfContentToInstall.SelectedIndex].ContentTitle);
-                Log.Information(gameContent[ListOfContentToInstall.SelectedIndex].ContentDisplayName);
-                Log.Information(gameContent[ListOfContentToInstall.SelectedIndex].ContentType);
-                Log.Information(gameContent[ListOfContentToInstall.SelectedIndex].ContentTypeValue);
-            }
         }
     }
 }

--- a/Xenia Manager/Windows/InstallContent.xaml.cs
+++ b/Xenia Manager/Windows/InstallContent.xaml.cs
@@ -1,17 +1,11 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
 using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Shapes;
+using System.Windows.Media.Animation;
+
+// Imported
+using Serilog;
+using Xenia_Manager.Classes;
 
 namespace Xenia_Manager.Windows
 {
@@ -20,14 +14,134 @@ namespace Xenia_Manager.Windows
     /// </summary>
     public partial class InstallContent : Window
     {
-        public InstallContent()
+        List<GameContent> gameContent = new List<GameContent>();
+
+        // Used to send a signal that this window has been closed
+        private TaskCompletionSource<bool> _closeTaskCompletionSource = new TaskCompletionSource<bool>();
+
+        public InstallContent(List<GameContent> gameContent)
         {
             InitializeComponent();
+            this.gameContent = gameContent;
+            InitializeAsync();
+            Closed += (sender, args) => _closeTaskCompletionSource.TrySetResult(true);
         }
 
-        private void Exit_Click(object sender, RoutedEventArgs e)
+        /// <summary>
+        /// Used to read the content from the list into the UI (ListBox)
+        /// </summary>
+        private async Task ReadContent()
         {
-            this.Close();
+            try
+            {
+                foreach (GameContent content in gameContent)
+                {
+                    string test = "";
+                    if (!content.ContentDisplayName.Contains(content.ContentTitle) && content.ContentTitle != "")
+                    {
+                        test += $"{content.ContentTitle} ";
+                    }
+                    test += $"{content.ContentDisplayName} ";
+                    test += $"({content.ContentType})";
+                    ListOfContentToInstall.Items.Add(test);
+                }
+                await Task.Delay(1);
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex.Message + "\nFull Error:\n" + ex);
+                MessageBox.Show(ex.Message);
+            }
+        }
+
+        /// <summary>
+        /// Function that executes other functions asynchronously
+        /// </summary>
+        private async void InitializeAsync()
+        {
+            try
+            {
+                await Dispatcher.InvokeAsync(() =>
+                {
+                    this.Visibility = Visibility.Hidden;
+                    Mouse.OverrideCursor = Cursors.Wait;
+                });
+                await ReadContent();
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex.Message + "\nFull Error:\n" + ex);
+                MessageBox.Show(ex.Message);
+            }
+            finally
+            {
+                await Dispatcher.InvokeAsync(() =>
+                {
+                    this.Visibility = Visibility.Visible;
+                    Mouse.OverrideCursor = null;
+                });
+            }
+        }
+
+        /// <summary>
+        /// Used to execute fade in animation when loading is finished
+        /// </summary>
+        private void Window_IsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)
+        {
+            if (this.Visibility == Visibility.Visible)
+            {
+                Storyboard fadeInStoryboard = ((Storyboard)Application.Current.FindResource("FadeInAnimation")).Clone();
+                if (fadeInStoryboard != null)
+                {
+                    fadeInStoryboard.Begin(this);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Used to emulate a WaitForCloseAsync function that is similar to the one Process Class has
+        /// </summary>
+        /// <returns></returns>
+        public Task WaitForCloseAsync()
+        {
+            return _closeTaskCompletionSource.Task;
+        }
+
+        /// <summary>
+        /// Does fade out animation before closing the window
+        /// </summary>
+        private async Task ClosingAnimation()
+        {
+            Storyboard FadeOutClosingAnimation = ((Storyboard)Application.Current.FindResource("FadeOutAnimation")).Clone();
+
+            FadeOutClosingAnimation.Completed += (sender, e) =>
+            {
+                Log.Information("Closing SelectGame window");
+                this.Close();
+            };
+
+            FadeOutClosingAnimation.Begin(this);
+            await Task.Delay(1);
+        }
+
+        // UI
+        /// <summary>
+        /// Closes this window
+        /// </summary>
+        private async void Exit_Click(object sender, RoutedEventArgs e)
+        {
+            await ClosingAnimation();
+        }
+
+        private void ListOfContentToInstall_SelectionChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
+        {
+            if (ListOfContentToInstall.SelectedIndex >= 0)
+            {
+                Log.Information(gameContent[ListOfContentToInstall.SelectedIndex].ContentTitle);
+                Log.Information(gameContent[ListOfContentToInstall.SelectedIndex].ContentDisplayName);
+                Log.Information(gameContent[ListOfContentToInstall.SelectedIndex].ContentType);
+                Log.Information(gameContent[ListOfContentToInstall.SelectedIndex].ContentTypeValue);
+            }
         }
     }
 }

--- a/Xenia Manager/Windows/SelectGame.xaml.cs
+++ b/Xenia Manager/Windows/SelectGame.xaml.cs
@@ -204,7 +204,11 @@ namespace Xenia_Manager.Windows
                 if (AndyDecarliGames.Items.Count == 0 && WikipediaGames.Items.Count == 0)
                 {
                     Log.Information("No game found in both of the databases");
-                    await AddUnknownGames();
+                    MessageBoxResult result = MessageBox.Show($"Couldn't find {gameTitle} in our list of games. This can be due to formatting.\nDo you want to use the default disc icon? (Press No if you want to search for the game yourself)", "Confirmation", MessageBoxButton.YesNo, MessageBoxImage.Question);
+                    if (result == MessageBoxResult.Yes)
+                    {
+                        await AddUnknownGames();
+                    }
                 }
             }
             catch (Exception ex)

--- a/Xenia Manager/Windows/ShowInstalledContent.xaml
+++ b/Xenia Manager/Windows/ShowInstalledContent.xaml
@@ -34,7 +34,7 @@
                 </Grid.ColumnDefinitions>
 
                 <!-- Title -->
-                <TextBlock x:Name="Title"
+                <TextBlock x:Name="TitleText"
                            Grid.Column="0"
                            Grid.ColumnSpan="2"
                            Style="{StaticResource TitleTextBlock}"
@@ -90,7 +90,8 @@
                         Style="{StaticResource ButtonStyle}"
                         HorizontalAlignment="Center"
                         VerticalAlignment="Center"
-                        Margin="0,5,0,5">
+                        Margin="0,5,0,5"
+                        Click="Delete_Click">
                     <Button.Content>
                         <TextBlock Text="Delete"
                                    Style="{StaticResource AddGameText}"/>

--- a/Xenia Manager/Windows/ShowInstalledContent.xaml
+++ b/Xenia Manager/Windows/ShowInstalledContent.xaml
@@ -1,0 +1,91 @@
+﻿<Window x:Class="Xenia_Manager.Windows.ShowInstalledContent"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:Xenia_Manager.Windows"
+        mc:Ignorable="d"
+        Title="ShowInstalledContent" 
+        Height="650" Width="500"
+        WindowStyle="None" ResizeMode="NoResize"
+        WindowStartupLocation="CenterScreen"
+        Background="Transparent" AllowsTransparency="True"
+        Visibility="Visible" IsVisibleChanged="Window_IsVisibleChanged">
+    <Border Background="{DynamicResource BackgroundColor}"
+            BorderBrush="{DynamicResource BorderBrush}"
+            BorderThickness="2"
+            CornerRadius="10">
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="50"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="60"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition />
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="50"/>
+            </Grid.RowDefinitions>
+
+            <!-- Title and close button-->
+            <Grid Grid.Row="0">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+
+                <!-- Title -->
+                <TextBlock x:Name="Title"
+                           Grid.Column="0"
+                           Grid.ColumnSpan="2"
+                           Style="{StaticResource TitleTextBlock}"
+                           FontSize="28"
+                           Text="Installed Content"
+                           HorizontalAlignment="Center"/>
+
+                <!-- Close button -->
+                <Button Grid.Column="1" 
+                        x:Name="Exit"
+                        Style="{StaticResource ExitButton}"
+                        HorizontalAlignment="Right"
+                        Click="Exit_Click"/>
+            </Grid>
+
+            <!-- Seperation Line -->
+            <Border Grid.Row="1" 
+                    Style="{StaticResource SeperationLine}"/>
+
+            <!-- List of content types -->
+            <ComboBox x:Name="ContentTypeList"
+                      Grid.Row="2"
+                      Style="{StaticResource ComboBoxStyle}"
+                      Margin="70,10,70,10"/>
+
+            <!-- Seperation Line -->
+            <Border Grid.Row="3" 
+                    Style="{StaticResource SeperationLine}"/>
+            
+            <!-- List of installed content -->
+            <ListBox x:Name="InstalledContentList"
+                     Grid.Row="4"/>
+
+            <!-- Seperation Line -->
+            <Border Grid.Row="5" 
+                    Style="{StaticResource SeperationLine}"/>
+
+            <!-- Buttons -->
+            <Grid Grid.Row="6">
+                <!-- Remove button -->
+                <Button x:Name="Button" 
+                        Style="{StaticResource ButtonStyle}"
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center"
+                        Margin="0,5,0,5">
+                    <Button.Content>
+                        <TextBlock Text="Button1"
+                                   Style="{StaticResource AddGameText}"/>
+                    </Button.Content>
+                </Button>
+            </Grid>
+        </Grid>
+    </Border>
+</Window>

--- a/Xenia Manager/Windows/ShowInstalledContent.xaml
+++ b/Xenia Manager/Windows/ShowInstalledContent.xaml
@@ -148,7 +148,8 @@
                         Style="{StaticResource ButtonStyle}"
                         HorizontalAlignment="Center"
                         VerticalAlignment="Center"
-                        Margin="0,5,0,5">
+                        Margin="0,5,0,5"
+                        Click="Export_Click">
                     <Button.Content>
                         <TextBlock Text="Export"
                                    Style="{StaticResource AddGameText}"/>

--- a/Xenia Manager/Windows/ShowInstalledContent.xaml
+++ b/Xenia Manager/Windows/ShowInstalledContent.xaml
@@ -58,7 +58,9 @@
             <ComboBox x:Name="ContentTypeList"
                       Grid.Row="2"
                       Style="{StaticResource ComboBoxStyle}"
-                      Margin="70,10,70,10"/>
+                      FontSize="20"
+                      Margin="70,10,70,10"
+                      SelectionChanged="ContentTypeList_SelectionChanged"/>
 
             <!-- Seperation Line -->
             <Border Grid.Row="3" 
@@ -66,22 +68,66 @@
             
             <!-- List of installed content -->
             <ListBox x:Name="InstalledContentList"
-                     Grid.Row="4"/>
+                     Grid.Row="4" 
+                     SelectionMode="Extended"
+                     PreviewMouseDown="InstalledContentList_PreviewMouseDown">
+                <ListBox.ItemTemplate>
+                    <DataTemplate>
+                        <TextBlock Text="{Binding Name}"/>
+                    </DataTemplate>
+                </ListBox.ItemTemplate>
+            </ListBox>
 
             <!-- Seperation Line -->
             <Border Grid.Row="5" 
                     Style="{StaticResource SeperationLine}"/>
 
             <!-- Buttons -->
-            <Grid Grid.Row="6">
-                <!-- Remove button -->
-                <Button x:Name="Button" 
+            <Grid x:Name="DefaultButtons" 
+                  Grid.Row="6">
+                <!-- Delete button -->
+                <Button x:Name="Delete" 
                         Style="{StaticResource ButtonStyle}"
                         HorizontalAlignment="Center"
                         VerticalAlignment="Center"
                         Margin="0,5,0,5">
                     <Button.Content>
-                        <TextBlock Text="Button1"
+                        <TextBlock Text="Delete"
+                                   Style="{StaticResource AddGameText}"/>
+                    </Button.Content>
+                </Button>
+            </Grid>
+
+            <!-- Buttons -->
+            <Grid x:Name="SavedGamesButtons" 
+                  Grid.Row="6">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition/>
+                    <ColumnDefinition/>
+                </Grid.ColumnDefinitions>
+                
+                <!-- Import button -->
+                <Button x:Name="Import" 
+                        Grid.Column="0"
+                        Style="{StaticResource ButtonStyle}"
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center"
+                        Margin="0,5,0,5">
+                    <Button.Content>
+                        <TextBlock Text="Import"
+                                   Style="{StaticResource AddGameText}"/>
+                    </Button.Content>
+                </Button>
+
+                <!-- Export button -->
+                <Button x:Name="Export" 
+                        Grid.Column="1"
+                        Style="{StaticResource ButtonStyle}"
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center"
+                        Margin="0,5,0,5">
+                    <Button.Content>
+                        <TextBlock Text="Export"
                                    Style="{StaticResource AddGameText}"/>
                     </Button.Content>
                 </Button>

--- a/Xenia Manager/Windows/ShowInstalledContent.xaml
+++ b/Xenia Manager/Windows/ShowInstalledContent.xaml
@@ -68,7 +68,7 @@
                           Margin="10,10,10,10"
                           SelectionChanged="ContentTypeList_SelectionChanged"/>
 
-                <!-- Import button -->
+                <!-- Open Folder button -->
                 <Button x:Name="OpenDirectory" 
                         Grid.Column="1"
                         Style="{StaticResource ButtonStyle}"
@@ -135,7 +135,8 @@
                         Style="{StaticResource ButtonStyle}"
                         HorizontalAlignment="Center"
                         VerticalAlignment="Center"
-                        Margin="0,5,0,5">
+                        Margin="0,5,0,5"
+                        Click="Import_Click">
                     <Button.Content>
                         <TextBlock Text="Import"
                                    Style="{StaticResource AddGameText}"/>

--- a/Xenia Manager/Windows/ShowInstalledContent.xaml
+++ b/Xenia Manager/Windows/ShowInstalledContent.xaml
@@ -54,13 +54,35 @@
             <Border Grid.Row="1" 
                     Style="{StaticResource SeperationLine}"/>
 
-            <!-- List of content types -->
-            <ComboBox x:Name="ContentTypeList"
-                      Grid.Row="2"
-                      Style="{StaticResource ComboBoxStyle}"
-                      FontSize="20"
-                      Margin="70,10,70,10"
-                      SelectionChanged="ContentTypeList_SelectionChanged"/>
+            <!-- List of storage types and button to open them in file explorer -->
+            <Grid Grid.Row="2">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="300"/>
+                    <ColumnDefinition/>
+                </Grid.ColumnDefinitions>
+                
+                <!-- List of content types -->
+                <ComboBox x:Name="ContentTypeList"
+                          Style="{StaticResource ComboBoxStyle}"
+                          FontSize="20"
+                          Margin="10,10,10,10"
+                          SelectionChanged="ContentTypeList_SelectionChanged"/>
+
+                <!-- Import button -->
+                <Button x:Name="OpenDirectory" 
+                        Grid.Column="1"
+                        Style="{StaticResource ButtonStyle}"
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center"
+                        Margin="0,5,0,5"
+                        Click="OpenDirectory_Click">
+                    <Button.Content>
+                        <TextBlock Text="Open Folder"
+                                   FontSize="26"
+                                   Style="{StaticResource AddGameText}"/>
+                    </Button.Content>
+                </Button>
+            </Grid>
 
             <!-- Seperation Line -->
             <Border Grid.Row="3" 

--- a/Xenia Manager/Windows/ShowInstalledContent.xaml.cs
+++ b/Xenia Manager/Windows/ShowInstalledContent.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.IO;
 using System.Windows;
 using System.Windows.Controls;
@@ -242,7 +243,7 @@ namespace Xenia_Manager.Windows
             }
             else if (game.EmulatorVersion == "Stable")
             {
-                folderPath = Path.Combine(App.baseDirectory, App.appConfiguration.XeniaCanary.EmulatorLocation, $@"content\{game.GameId}\{((uint)contentType).ToString("X8")}");
+                folderPath = Path.Combine(App.baseDirectory, App.appConfiguration.XeniaStable.EmulatorLocation, $@"content\{game.GameId}\{((uint)contentType).ToString("X8")}");
             }
 
             if (Directory.Exists(folderPath))
@@ -340,6 +341,39 @@ namespace Xenia_Manager.Windows
         }
 
         // Buttons
+        /// <summary>
+        /// Opens the selected storage folder
+        /// </summary>
+        private void OpenDirectory_Click(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                if (ContentTypeList.SelectedIndex >= 0)
+                {
+                    if (ContentTypeList.SelectedValue is ContentType selectedContentType)
+                    {
+                        Process process = new Process();
+                        process.StartInfo.FileName = "explorer.exe";
+
+                        // Checking what version of Xenia the game uses and then launching the correct directory
+                        if (game.EmulatorVersion == "Canary")
+                        {
+                            process.StartInfo.Arguments = Path.Combine(App.baseDirectory, App.appConfiguration.XeniaCanary.EmulatorLocation, $@"content\{game.GameId}\{((uint)selectedContentType).ToString("X8")}");
+                        }
+                        else if (game.EmulatorVersion == "Stable")
+                        {
+                            process.StartInfo.Arguments = Path.Combine(App.baseDirectory, App.appConfiguration.XeniaStable.EmulatorLocation, $@"content\{game.GameId}\{((uint)selectedContentType).ToString("X8")}");
+                        }
+                        process.Start();
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex.Message + "\nFull Error:\n" + ex);
+                MessageBox.Show(ex.Message);
+            }
+        }
         /// <summary>
         /// Closes this window
         /// </summary>

--- a/Xenia Manager/Windows/ShowInstalledContent.xaml.cs
+++ b/Xenia Manager/Windows/ShowInstalledContent.xaml.cs
@@ -1,0 +1,113 @@
+﻿using Serilog;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Animation;
+using System.Windows.Media.Imaging;
+using System.Windows.Shapes;
+
+namespace Xenia_Manager.Windows
+{
+    /// <summary>
+    /// Interaction logic for ShowInstalledContent.xaml
+    /// </summary>
+    public partial class ShowInstalledContent : Window
+    {
+        // Used to send a signal that this window has been closed
+        private TaskCompletionSource<bool> _closeTaskCompletionSource = new TaskCompletionSource<bool>();
+
+        public ShowInstalledContent()
+        {
+            InitializeComponent();
+            InitializeAsync();
+            Closed += (sender, args) => _closeTaskCompletionSource.TrySetResult(true);
+        }
+
+        /// <summary>
+        /// Function that executes other functions asynchronously
+        /// </summary>
+        private async void InitializeAsync()
+        {
+            try
+            {
+                await Dispatcher.InvokeAsync(() =>
+                {
+                    this.Visibility = Visibility.Hidden;
+                    Mouse.OverrideCursor = Cursors.Wait;
+                });
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex.Message + "\nFull Error:\n" + ex);
+                MessageBox.Show(ex.Message);
+            }
+            finally
+            {
+                await Dispatcher.InvokeAsync(() =>
+                {
+                    this.Visibility = Visibility.Visible;
+                    Mouse.OverrideCursor = null;
+                });
+            }
+        }
+
+        /// <summary>
+        /// Used to execute fade in animation when loading is finished
+        /// </summary>
+        private void Window_IsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)
+        {
+            if (this.Visibility == Visibility.Visible)
+            {
+                Storyboard fadeInStoryboard = ((Storyboard)Application.Current.FindResource("FadeInAnimation")).Clone();
+                if (fadeInStoryboard != null)
+                {
+                    fadeInStoryboard.Begin(this);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Used to emulate a WaitForCloseAsync function that is similar to the one Process Class has
+        /// </summary>
+        /// <returns></returns>
+        public Task WaitForCloseAsync()
+        {
+            return _closeTaskCompletionSource.Task;
+        }
+
+        /// <summary>
+        /// Does fade out animation before closing the window
+        /// </summary>
+        private async Task ClosingAnimation()
+        {
+            Storyboard FadeOutClosingAnimation = ((Storyboard)Application.Current.FindResource("FadeOutAnimation")).Clone();
+
+            FadeOutClosingAnimation.Completed += (sender, e) =>
+            {
+                Log.Information("Closing SelectGame window");
+                this.Close();
+            };
+
+            FadeOutClosingAnimation.Begin(this);
+            await Task.Delay(1);
+        }
+
+        // UI
+        // Buttons
+        /// <summary>
+        /// Closes this window
+        /// </summary>
+        private async void Exit_Click(object sender, RoutedEventArgs e)
+        {
+            await ClosingAnimation();
+        }
+    }
+}

--- a/Xenia Manager/Windows/ShowInstalledContent.xaml.cs
+++ b/Xenia Manager/Windows/ShowInstalledContent.xaml.cs
@@ -347,5 +347,55 @@ namespace Xenia_Manager.Windows
         {
             await ClosingAnimation();
         }
+
+        /// <summary>
+        /// Removes selected item/items from the ListBox
+        /// </summary>
+        private async void Delete_Click(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                Log.Information("Grabbing all of the selected items");
+                // Grabbing all of the selected items to delete
+                List<FileItem> selectedItems = InstalledContentList.SelectedItems.Cast<FileItem>().ToList();
+
+                string deletedItems = "";
+                // Checking if there is something selected
+                if (selectedItems.Count > 0)
+                {
+                    Log.Information($"There are {selectedItems.Count} items to delete");
+                    // If there are items selected, go through the list and delete each one seperately
+                    foreach (FileItem item in selectedItems)
+                    {
+                        Log.Information($"Deleting: {item.Name}");
+
+                        // Checking if it's a folder or a file
+                        if (Directory.Exists(item.FullPath))
+                        {
+                            Directory.Delete(item.FullPath, true); // Delete the directory recursively
+                        }
+                        else if (File.Exists(item.FullPath))
+                        {
+                            File.Delete(item.FullPath); // Delete the file
+                        }
+                        deletedItems += $" - {item.Name}\n";
+                    }
+                }
+                else
+                {
+                    Log.Information($"No items have been selected to delete");
+                }
+
+                // Update UI by reading again
+                UpdateListBox((ContentType)ContentTypeList.SelectedValue);
+                await Task.Delay(1);
+                MessageBox.Show($"Deleted items:\n{deletedItems}");
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex.Message + "\nFull Error:\n" + ex);
+                MessageBox.Show(ex.Message);
+            }
+        }
     }
 }


### PR DESCRIPTION
- Added the basic ability to read header and what type of content the file is (Title Update, DLC, etc).
- Added 'Install Content' which uses the STFS Class alongside Xenia VFS Dump tool to install DLC, Title Updates and other supported stuff. If user selected something he didn't want to install, he can remove it from install process before it starts.
- Added 'Show Installed Content' that opens a window with a way to see what content is installed for the specific game. Also it allows the user to import and export their save files (The reason why those 2 are missing from the context menu). Another thing is you can delete things like DLC and Title Updates from this window by selecting them and then clicking on the 'Delete' button.
- With the new way of importing and exporting save files, user can now select what files from the save file he wants to export.