### PR TITLE
Add "Add Additional Patches" option to the game ContextMenu 

### DIFF
--- a/Xenia Manager/Classes/JSONParse.cs
+++ b/Xenia Manager/Classes/JSONParse.cs
@@ -124,6 +124,27 @@ namespace Xenia_Manager.Classes
     }
 
     /// <summary>
+    /// Patch class used to read and edit patches
+    /// </summary>
+    public class Patch
+    {
+        /// <summary>
+        /// Name of the patch
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Disabled/Enabled patch
+        /// </summary>
+        public bool IsEnabled { get; set; }
+
+        /// <summary>
+        /// Explains what patch does, can be null
+        /// </summary>
+        public string? Description { get; set; }
+    }
+
+    /// <summary>
     /// Class that contains everything about content that is going to be installed
     /// </summary>
     public class GameContent

--- a/Xenia Manager/Pages/Library.xaml.cs
+++ b/Xenia Manager/Pages/Library.xaml.cs
@@ -347,12 +347,11 @@ namespace Xenia_Manager.Pages
         /// </summary>
         /// <param name="game"></param>
         /// <returns></returns>
-        private async Task AddAdditionalPatches(string gamePatchFileLocation, string newPatchFileLocation)
+        private void AddAdditionalPatches(string gamePatchFileLocation, string newPatchFileLocation)
         {
             try
             {
-                await Task.Delay(1);
-
+                Mouse.OverrideCursor = Cursors.Wait;
                 // Reading .toml files as TomlTable
                 TomlTable originalPatchFile = Toml.ToModel(File.ReadAllText(gamePatchFileLocation));
                 TomlTable newPatchFile = Toml.ToModel(File.ReadAllText(newPatchFileLocation));
@@ -383,6 +382,7 @@ namespace Xenia_Manager.Pages
                     Log.Error("Patches do not match");
                     MessageBox.Show("Hashes do not match.\nThis patch file is not supported.");
                 }
+                Mouse.OverrideCursor = null;
             }
             catch (Exception ex)
             {
@@ -592,6 +592,24 @@ namespace Xenia_Manager.Pages
                     // Check if the game has any game patches installed
                     if (game.PatchFilePath != null)
                     {
+                        // Add "Add Additional Patches" option
+                        contextMenu.Items.Add(CreateMenuItem("Add Additional Patches", "Add additional patches to the existing patch file from another local file\nNOTE: Useful if you have a patch file that is not in game-patches repository", (sender, e) =>
+                        {
+                            Log.Information("Open file dialog");
+                            OpenFileDialog openFileDialog = new OpenFileDialog();
+                            openFileDialog.Title = "Select a game";
+                            openFileDialog.Filter = "Supported Files|*.toml";
+                            openFileDialog.Multiselect = true;
+                            bool? result = openFileDialog.ShowDialog();
+                            if (result == true)
+                            {
+                                foreach (string file in openFileDialog.FileNames)
+                                {
+                                    AddAdditionalPatches(game.PatchFilePath, file);
+                                }
+                            }
+                        }));
+
                         // Add "Patch Settings" option
                         contextMenu.Items.Add(CreateMenuItem("Patch Settings", "Enable or disable game patches", async (sender, e) =>
                         {
@@ -615,7 +633,7 @@ namespace Xenia_Manager.Pages
                     if (game.PatchFilePath != null)
                     {
                         // Add "Add Additional Patches" option
-                        contextMenu.Items.Add(CreateMenuItem("Add Additional Patches", "Add additional patches to the existing patch file from another local file\nNOTE: Useful if you have a patch file that is not in game-patches repository", async (sender, e) =>
+                        contextMenu.Items.Add(CreateMenuItem("Add Additional Patches", "Add additional patches to the existing patch file from another local file\nNOTE: Useful if you have a patch file that is not in game-patches repository", (sender, e) =>
                         {
                             Log.Information("Open file dialog");
                             OpenFileDialog openFileDialog = new OpenFileDialog();
@@ -627,7 +645,7 @@ namespace Xenia_Manager.Pages
                             {
                                 foreach (string file in openFileDialog.FileNames)
                                 {
-                                    await AddAdditionalPatches(game.PatchFilePath, file);
+                                    AddAdditionalPatches(game.PatchFilePath, file);
                                 }
                             }
                         }));

--- a/Xenia Manager/Windows/EditGamePatch.xaml.cs
+++ b/Xenia Manager/Windows/EditGamePatch.xaml.cs
@@ -14,27 +14,6 @@ using Xenia_Manager.Classes;
 namespace Xenia_Manager.Windows
 {
     /// <summary>
-    /// Patch class used to read and edit patches
-    /// </summary>
-    public class Patch
-    {
-        /// <summary>
-        /// Name of the patch
-        /// </summary>
-        public string Name { get; set; }
-
-        /// <summary>
-        /// Disabled/Enabled patch
-        /// </summary>
-        public bool IsEnabled { get; set; }
-
-        /// <summary>
-        /// Explains what patch does, can be null
-        /// </summary>
-        public string? Description { get; set; }
-    }
-
-    /// <summary>
     /// Interaction logic for EditGamePatch.xaml
     /// </summary>
     public partial class EditGamePatch : Window


### PR DESCRIPTION
This is useful if user has another patch file for a specific game and it shares the same 'hash' as the original one or if the user is playing a game that requires a 'Netplay' specific patch to be able to play it.