### PR TITLE
Add an option to switch to custom version of Xenia

### DIFF
--- a/Xenia Manager/Classes/JSONParse.cs
+++ b/Xenia Manager/Classes/JSONParse.cs
@@ -61,11 +61,18 @@ namespace Xenia_Manager.Classes
         public string? ConfigFilePath { get; set; }
 
         /// <summary>
-        /// This tells the Xenia Manager which Xenia version (Stable/Canary) the game wants to use
+        /// This tells the Xenia Manager which Xenia version (Stable/Canary/Netplay/Custom) the game wants to use
         /// null if it doesn't exist
         /// </summary>
         [JsonProperty("emulator_version")]
         public string? EmulatorVersion { get; set; }
+
+        /// <summary>
+        /// This is mostly to store the location to the executable of the Custom version of Xenia
+        /// null if it doesn't exist or not needed
+        /// </summary>
+        [JsonProperty("emulator_executable_location")]
+        public string? EmulatorExecutableLocation { get; set; }
     }
 
     /// <summary>

--- a/Xenia Manager/Pages/Library.xaml.cs
+++ b/Xenia Manager/Pages/Library.xaml.cs
@@ -688,13 +688,29 @@ namespace Xenia_Manager.Pages
             // Add "Add shortcut to desktop" option
             contextMenu.Items.Add(CreateMenuItem("Add shortcut to desktop", null, (sender, e) =>
             {
-                if (game.EmulatorVersion == "Stable")
+                switch (game.EmulatorVersion)
                 {
-                    ShortcutCreator.CreateShortcutOnDesktop(game.Title, Path.Combine(App.baseDirectory, App.appConfiguration.XeniaStable.ExecutableLocation), Path.Combine(App.baseDirectory, App.appConfiguration.XeniaStable.EmulatorLocation), $@"""{game.GameFilePath}"" --config ""{Path.Combine(App.baseDirectory, game.ConfigFilePath)}""", Path.Combine(App.baseDirectory, game.IconFilePath));
-                }
-                else if (game.EmulatorVersion == "Canary")
-                {
-                    ShortcutCreator.CreateShortcutOnDesktop(game.Title, Path.Combine(App.baseDirectory, App.appConfiguration.XeniaCanary.ExecutableLocation), Path.Combine(App.baseDirectory, App.appConfiguration.XeniaCanary.EmulatorLocation), $@"""{game.GameFilePath}"" --config ""{Path.Combine(App.baseDirectory, game.ConfigFilePath)}""", Path.Combine(App.baseDirectory, game.IconFilePath));
+                    case "Stable":
+                        ShortcutCreator.CreateShortcutOnDesktop(game.Title, Path.Combine(App.baseDirectory, App.appConfiguration.XeniaStable.ExecutableLocation), Path.Combine(App.baseDirectory, App.appConfiguration.XeniaStable.EmulatorLocation), $@"""{game.GameFilePath}"" --config ""{Path.Combine(App.baseDirectory, game.ConfigFilePath)}""", Path.Combine(App.baseDirectory, game.IconFilePath));
+                        break;
+                    case "Canary":
+                        ShortcutCreator.CreateShortcutOnDesktop(game.Title, Path.Combine(App.baseDirectory, App.appConfiguration.XeniaCanary.ExecutableLocation), Path.Combine(App.baseDirectory, App.appConfiguration.XeniaCanary.EmulatorLocation), $@"""{game.GameFilePath}"" --config ""{Path.Combine(App.baseDirectory, game.ConfigFilePath)}""", Path.Combine(App.baseDirectory, game.IconFilePath));
+                        break;
+                    case "Netplay":
+                        ShortcutCreator.CreateShortcutOnDesktop(game.Title, Path.Combine(App.baseDirectory, App.appConfiguration.XeniaNetplay.ExecutableLocation), Path.Combine(App.baseDirectory, App.appConfiguration.XeniaNetplay.EmulatorLocation), $@"""{game.GameFilePath}"" --config ""{Path.Combine(App.baseDirectory, game.ConfigFilePath)}""", Path.Combine(App.baseDirectory, game.IconFilePath));
+                        break;
+                    case "Custom":
+                        if (game.GameFilePath != null)
+                        {
+                            ShortcutCreator.CreateShortcutOnDesktop(game.Title, game.EmulatorExecutableLocation, Path.GetDirectoryName(game.EmulatorExecutableLocation), $@"""{game.GameFilePath}"" --config ""{game.ConfigFilePath}""", Path.Combine(App.baseDirectory, game.IconFilePath));
+                        }
+                        else
+                        {
+                            ShortcutCreator.CreateShortcutOnDesktop(game.Title, game.EmulatorExecutableLocation, Path.GetDirectoryName(game.EmulatorExecutableLocation), $@"""{game.GameFilePath}""", Path.Combine(App.baseDirectory, game.IconFilePath));
+                        };
+                        break;
+                    default:
+                        break;
                 }
             }));
 

--- a/Xenia Manager/Pages/Library.xaml.cs
+++ b/Xenia Manager/Pages/Library.xaml.cs
@@ -582,16 +582,19 @@ namespace Xenia_Manager.Pages
                 await LoadGames();
             }));
 
-            // Add 'Install content' option
-            contextMenu.Items.Add(CreateMenuItem("Install Content", $"Install various game content like DLC, Title Updates etc.", (sender, e) => InstallContent(game)));
-
-            // Add 'Show installed content' option
-            contextMenu.Items.Add(CreateMenuItem("Show Installed Content", $"Allows the user to see what's installed in game content folder and to export save files", async (sender, e) =>
+            if (game.EmulatorVersion != "Custom")
             {
-                Log.Information("Opening 'ShowInstalledContent' window");
-                ShowInstalledContent showInstalledContent = new ShowInstalledContent(game);
-                await showInstalledContent.WaitForCloseAsync();
-            }));
+                // Add 'Install content' option
+                contextMenu.Items.Add(CreateMenuItem("Install Content", $"Install various game content like DLC, Title Updates etc.", (sender, e) => InstallContent(game)));
+
+                // Add 'Show installed content' option
+                contextMenu.Items.Add(CreateMenuItem("Show Installed Content", $"Allows the user to see what's installed in game content folder and to export save files", async (sender, e) =>
+                {
+                    Log.Information("Opening 'ShowInstalledContent' window");
+                    ShowInstalledContent showInstalledContent = new ShowInstalledContent(game);
+                    await showInstalledContent.WaitForCloseAsync();
+                }));
+            }
 
             // Check what version of Xenia the game uses
             switch (game.EmulatorVersion)

--- a/Xenia Manager/Pages/Library.xaml.cs
+++ b/Xenia Manager/Pages/Library.xaml.cs
@@ -237,13 +237,23 @@ namespace Xenia_Manager.Pages
                 case "Netplay":
                     xenia.StartInfo.FileName = Path.Combine(App.baseDirectory, App.appConfiguration.XeniaNetplay.ExecutableLocation);
                     break;
+                case "Custom":
+                    xenia.StartInfo.FileName = game.EmulatorExecutableLocation;
+                    break;
                 default:
                     break;
             }
             Log.Information($"Xenia Executable Location: {xenia.StartInfo.FileName}");
 
             // Adding default launch arguments
-            xenia.StartInfo.Arguments = $@"""{game.GameFilePath}"" --config ""{Path.Combine(App.baseDirectory, game.ConfigFilePath)}""";
+            if (game.EmulatorVersion != "Custom" && game.ConfigFilePath != null)
+            {
+                xenia.StartInfo.Arguments = $@"""{game.GameFilePath}"" --config ""{Path.Combine(App.baseDirectory, game.ConfigFilePath)}""";
+            }
+            else if (game.ConfigFilePath != null)
+            {
+                xenia.StartInfo.Arguments = $@"""{game.GameFilePath}"" --config ""{game.ConfigFilePath}""";
+            }
             //xenia.StartInfo.ArgumentList.Add(game.GameFilePath);
             //xenia.StartInfo.ArgumentList.Add("--config");
             //xenia.StartInfo.ArgumentList.Add(game.ConfigFilePath);

--- a/Xenia Manager/Windows/EditGameInfo.xaml
+++ b/Xenia Manager/Windows/EditGameInfo.xaml
@@ -255,6 +255,37 @@
                             </Button>
                         </Grid>
                     </Border>
+
+                    <!-- Switch to Custom Xenia -->
+                    <Border x:Name="SwitchToXeniaCustomOption" 
+                            Background="{DynamicResource SettingBackgroundColor}"
+                            BorderBrush="{DynamicResource SettingBorderBrush}" 
+                            BorderThickness="2" 
+                            CornerRadius="10"
+                            Margin="5,2">
+                        <Grid Height="50">
+                            <Button x:Name="SwitchXeniaCustom" 
+                                    Grid.Column="2"
+                                    HorizontalAlignment="Center"
+                                    Margin="0"
+                                    Style="{StaticResource ButtonStyle}"
+                                    VerticalAlignment="Center"
+                                    Click="SwitchXeniaCustom_Click">
+                                <Button.Content>
+                                    <TextBlock FontSize="24"
+                                               Style="{StaticResource AddGameText}"
+                                               Text="Switch to Custom Xenia"/>
+                                </Button.Content>
+                                <Button.ToolTip>
+                                    <ToolTip>
+                                        <TextBlock TextAlignment="Left">
+                                            The game will use custom Xenia defined by the user
+                                        </TextBlock>
+                                    </ToolTip>
+                                </Button.ToolTip>
+                            </Button>
+                        </Grid>
+                    </Border>
                 </StackPanel>
             </ScrollViewer>
         </Grid>

--- a/Xenia Manager/Windows/EditGameInfo.xaml.cs
+++ b/Xenia Manager/Windows/EditGameInfo.xaml.cs
@@ -624,5 +624,66 @@ namespace Xenia_Manager.Windows
                 MessageBox.Show(ex.Message);
             }
         }
+
+        /// <summary>
+        /// Makes the game use custom version of Xenia
+        /// </summary>
+        private async void SwitchXeniaCustom_Click(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                if (game.Title != GameTitle.Text)
+                {
+                    Log.Information("There is a change in game title");
+                    AdjustGameTitle();
+                }
+
+                // OpenFileDialog to select custom Xenia executable
+                OpenFileDialog CustomXeniaExecutableSelector = new OpenFileDialog();
+                CustomXeniaExecutableSelector.Title = "Select Xenia executable";
+                CustomXeniaExecutableSelector.Filter = "Supported Files|*.exe";
+                bool? CustomXeniaExecutableSelectorResult = CustomXeniaExecutableSelector.ShowDialog();
+                if (CustomXeniaExecutableSelectorResult == true)
+                {
+                    Log.Information($"Selected Xenia executable: {CustomXeniaExecutableSelector.FileName}");
+                    game.EmulatorVersion = "Custom";
+                    game.EmulatorExecutableLocation = CustomXeniaExecutableSelector.FileName;
+
+                    // Trying to find the appropriate configuration file next to the emulator executable
+                    Log.Information("Trying to find the configuration file");
+                    if (File.Exists(Path.Combine(Path.GetDirectoryName(CustomXeniaExecutableSelector.FileName), $"{Path.GetFileNameWithoutExtension(CustomXeniaExecutableSelector.FileName).Replace('_','-')}.config.toml")))
+                    {
+                        Log.Information($"Found configuration file: {Path.Combine(Path.GetDirectoryName(CustomXeniaExecutableSelector.FileName), $"{Path.GetFileNameWithoutExtension(CustomXeniaExecutableSelector.FileName).Replace('_', '-')}.config.toml")}");
+                        game.ConfigFilePath = Path.Combine(Path.GetDirectoryName(CustomXeniaExecutableSelector.FileName), $"{Path.GetFileNameWithoutExtension(CustomXeniaExecutableSelector.FileName).Replace('_', '-')}.config.toml");
+                    }
+                    else
+                    {
+                        // Incase it can't find it, ask user to find it himself
+                        Log.Information($"Not able to find a configuration file");
+                        OpenFileDialog CustomXeniaConfigurationSelector = new OpenFileDialog();
+                        CustomXeniaConfigurationSelector.Title = "Select Xenia configuration file";
+                        CustomXeniaConfigurationSelector.Filter = "Supported Files|*.toml";
+                        bool? CustomXeniaConfigurationSelectorResult = CustomXeniaConfigurationSelector.ShowDialog();
+                        if (CustomXeniaConfigurationSelectorResult == true)
+                        {
+                            Log.Information($"Selected configuration file: {CustomXeniaConfigurationSelector.FileName}");
+                            game.ConfigFilePath = CustomXeniaConfigurationSelector.FileName;
+                        }
+                        else
+                        {
+                            game.ConfigFilePath = null;
+                        }
+                    }
+                }
+                //await TransferGame(game, game.EmulatorVersion, "Custom", sourceEmulatorLocation, App.appConfiguration.XeniaNetplay.EmulatorLocation, App.appConfiguration.XeniaNetplay.ConfigurationFileLocation);
+                await CheckXeniaVersion();
+                MessageBox.Show($"{game.Title} transfer is complete. Now the game will use Xenia {game.EmulatorVersion}.");
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex.Message + "\nFull Error:\n" + ex);
+                MessageBox.Show(ex.Message);
+            }
+        }
     }
 }

--- a/Xenia Manager/Windows/EditGameInfo.xaml.cs
+++ b/Xenia Manager/Windows/EditGameInfo.xaml.cs
@@ -444,6 +444,10 @@ namespace Xenia_Manager.Windows
         /// <param name="defaultConfigFileLocation">Location to the default configuration file of the new Xenia version</param>
         private async Task TransferGame(InstalledGame game, string SourceVersion, string TargetVersion, string sourceEmulatorLocation, string targetEmulatorLocation, string defaultConfigFileLocation)
         {
+            if (SourceVersion == "Custom")
+            {
+                game.EmulatorExecutableLocation = null;
+            }
             Log.Information($"Moving the game to Xenia {TargetVersion}");
             game.EmulatorVersion = TargetVersion; // Set the emulator version
 
@@ -554,6 +558,7 @@ namespace Xenia_Manager.Windows
                 {
                     "Stable" => App.appConfiguration.XeniaStable.EmulatorLocation,
                     "Netplay" => App.appConfiguration.XeniaNetplay.EmulatorLocation,
+                    "Custom" => "",
                     _ => throw new InvalidOperationException("Unexpected build type")
                 };
                 await TransferGame(game, game.EmulatorVersion, "Canary", sourceEmulatorLocation, App.appConfiguration.XeniaCanary.EmulatorLocation, App.appConfiguration.XeniaCanary.ConfigurationFileLocation);
@@ -583,6 +588,7 @@ namespace Xenia_Manager.Windows
                 {
                     "Canary" => App.appConfiguration.XeniaCanary.EmulatorLocation,
                     "Netplay" => App.appConfiguration.XeniaNetplay.EmulatorLocation,
+                    "Custom" => "",
                     _ => throw new InvalidOperationException("Unexpected build type")
                 };
                 await TransferGame(game, game.EmulatorVersion, "Stable", sourceEmulatorLocation, App.appConfiguration.XeniaStable.EmulatorLocation, App.appConfiguration.XeniaStable.ConfigurationFileLocation);
@@ -612,6 +618,7 @@ namespace Xenia_Manager.Windows
                 {
                     "Canary" => App.appConfiguration.XeniaCanary.EmulatorLocation,
                     "Stable" => App.appConfiguration.XeniaStable.EmulatorLocation,
+                    "Custom" => "",
                     _ => throw new InvalidOperationException("Unexpected build type")
                 };
                 await TransferGame(game, game.EmulatorVersion, "Netplay", sourceEmulatorLocation, App.appConfiguration.XeniaNetplay.EmulatorLocation, App.appConfiguration.XeniaNetplay.ConfigurationFileLocation);


### PR DESCRIPTION
In "Edit Game" window, now you can switch the game to use different version of Xenia that is locally installed.

![KEJPLRB5c3](https://github.com/user-attachments/assets/20a17e35-2036-48b1-b3df-45e16005364d)

Do note that with using "Custom" build, you are losing access to these Xenia Manager features (Might add the support for these features in the future, but no promises because "Custom" should be used for advanced users):

- "Install Content"
- "Show Installed Content"
- "All patch settings"