### PR TITLE
Version 1.11.0

### DIFF
--- a/.github/workflows/build-experimental.yml
+++ b/.github/workflows/build-experimental.yml
@@ -29,14 +29,6 @@ jobs:
           git config --global user.email "github-actions@example.com"
           git config --global user.name "GitHub Actions"
 
-      - name: Update version in .csproj
-        run: |
-          (Get-Content "Xenia Manager/Xenia Manager.csproj") -replace '<Version>.*</Version>', '<Version>experimental</Version>' |
-          Set-Content "Xenia Manager/Xenia Manager.csproj"
-          (Get-Content "Xenia Manager/Xenia Manager.csproj") -replace '<AssemblyVersion>.*</AssemblyVersion>', '<AssemblyVersion>experimental</AssemblyVersion>' |
-          Set-Content "Xenia Manager/Xenia Manager.csproj"
-        shell: pwsh
-
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:

--- a/.github/workflows/build-experimental.yml
+++ b/.github/workflows/build-experimental.yml
@@ -29,6 +29,14 @@ jobs:
           git config --global user.email "github-actions@example.com"
           git config --global user.name "GitHub Actions"
 
+      - name: Update version in .csproj
+        run: |
+          (Get-Content "Xenia Manager/Xenia Manager.csproj") -replace '<Version>.*</Version>', '<Version>experimental</Version>' |
+          Set-Content "Xenia Manager/Xenia Manager.csproj"
+          (Get-Content "Xenia Manager/Xenia Manager.csproj") -replace '<AssemblyVersion>.*</AssemblyVersion>', '<AssemblyVersion>experimental</AssemblyVersion>' |
+          Set-Content "Xenia Manager/Xenia Manager.csproj"
+        shell: pwsh
+
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:

--- a/Xenia Manager/Classes/JSONParse.cs
+++ b/Xenia Manager/Classes/JSONParse.cs
@@ -61,11 +61,18 @@ namespace Xenia_Manager.Classes
         public string? ConfigFilePath { get; set; }
 
         /// <summary>
-        /// This tells the Xenia Manager which Xenia version (Stable/Canary) the game wants to use
+        /// This tells the Xenia Manager which Xenia version (Stable/Canary/Netplay/Custom) the game wants to use
         /// null if it doesn't exist
         /// </summary>
         [JsonProperty("emulator_version")]
         public string? EmulatorVersion { get; set; }
+
+        /// <summary>
+        /// This is mostly to store the location to the executable of the Custom version of Xenia
+        /// null if it doesn't exist or not needed
+        /// </summary>
+        [JsonProperty("emulator_executable_location")]
+        public string? EmulatorExecutableLocation { get; set; }
     }
 
     /// <summary>

--- a/Xenia Manager/Classes/JSONParse.cs
+++ b/Xenia Manager/Classes/JSONParse.cs
@@ -24,6 +24,12 @@ namespace Xenia_Manager.Classes
         public string? GameId { get; set; }
 
         /// <summary>
+        /// The unique identifier for the game
+        /// </summary>
+        [JsonProperty("media_id")]
+        public string? MediaId { get; set; }
+
+        /// <summary>
         /// URL to the github issues page for the game
         /// </summary>
         [JsonProperty("gamecompatibility_url")]

--- a/Xenia Manager/Pages/Settings.xaml
+++ b/Xenia Manager/Pages/Settings.xaml
@@ -150,7 +150,9 @@
                                 Theme Switcher
                             </TextBlock>
                             
-                            <ComboBox x:Name="ThemeSelector" 
+                            <ComboBox x:Name="ThemeSelector"
+                                      AutomationProperties.Name="Theme Selector"
+                                      AutomationProperties.HelpText="Change the theme of Xenia Manager"
                                       Grid.Column="1" 
                                       FontSize="18"
                                       HorizontalContentAlignment="Center" 

--- a/Xenia Manager/Pages/XeniaSettings.xaml
+++ b/Xenia Manager/Pages/XeniaSettings.xaml
@@ -153,6 +153,7 @@
                             
                             <ComboBox x:Name="apuSelector" 
                                       Grid.Column="1" 
+                                      AutomationProperties.Name="Audio System"
                                       FontSize="18" 
                                       HorizontalContentAlignment="Center"
                                       Margin="0,10" 
@@ -196,6 +197,8 @@
 
                             <TextBox x:Name="apuMaxQueuedFramesTextBox" 
                                      Grid.Column="1"
+                                     AutomationProperties.Name="Max Queued Frames"
+                                     AutomationProperties.HelpText="Allows changing max buffered audio frames to reduce audio delay"
                                      FontSize="18" 
                                      HorizontalContentAlignment="Center"
                                      Margin="0,10"
@@ -228,6 +231,8 @@
                             
                             <CheckBox x:Name="Mute" 
                                       Grid.Column="1" 
+                                      AutomationProperties.Name="Mute"
+                                      AutomationProperties.HelpText="Mutes all audio output"
                                       Cursor="Hand"
                                       Margin="0,10" 
                                       Style="{StaticResource CheckboxStyle}"
@@ -260,6 +265,8 @@
                             
                             <CheckBox x:Name="UseXMAThread" 
                                       Grid.Column="1" 
+                                      AutomationProperties.Name="Use Dedicated XMA Thread"
+                                      AutomationProperties.HelpText="Enables XMA decoding on separate thread. Disabled should produce better results, but decrease performance a bit."
                                       Cursor="Hand"
                                       Margin="0,10" 
                                       Style="{StaticResource CheckboxStyle}"
@@ -292,6 +299,8 @@
                             
                             <CheckBox x:Name="UseNewDecoder" 
                                       Grid.Column="1" 
+                                      AutomationProperties.Name="XMA Audio Decoder"
+                                      AutomationProperties.HelpText="Enables the usage of new experimental XMA audio decoder."
                                       Cursor="Hand"
                                       Margin="0,10" 
                                       Style="{StaticResource CheckboxStyle}"
@@ -327,6 +336,8 @@
                             
                             <CheckBox x:Name="Fullscreen" 
                                       Grid.Column="1" 
+                                      AutomationProperties.Name="Fullscreen"
+                                      AutomationProperties.HelpText="If enabled, it opens the emulator in fullscreen."
                                       Cursor="Hand"
                                       Margin="0,10" 
                                       Style="{StaticResource CheckboxStyle}"
@@ -367,6 +378,7 @@
                             
                             <CheckBox x:Name="Letterbox" 
                                       Grid.Column="1" 
+                                      AutomationProperties.Name="Letterbox"
                                       Cursor="Hand"
                                       Margin="0,10" 
                                       Style="{StaticResource CheckboxStyle}"
@@ -401,6 +413,8 @@
                             
                             <ComboBox x:Name="InternalDisplayResolutionSelector" 
                                       Grid.Column="1" 
+                                      AutomationProperties.Name="Internal Display Resolution"
+                                      AutomationProperties.HelpText="Allows the game that support different resolutions to be rendered in specific resolution. The game has to actually support the resolution for this to work. 1280x720 will work in pretty much every game."
                                       FontSize="18" 
                                       HorizontalContentAlignment="Center"
                                       Margin="0,10" 
@@ -452,6 +466,7 @@
                             
                             <CheckBox x:Name="vSync" 
                                       Grid.Column="1"
+                                      AutomationProperties.Name="Vertical Sync"
                                       Cursor="Hand"
                                       Margin="0,10" 
                                       Style="{StaticResource CheckboxStyle}"
@@ -495,8 +510,10 @@
                                         Grid.Row="0"
                                         Minimum="0" Maximum="144"
                                         IsSnapToTickEnabled="True" TickFrequency="1"
-                                        Width="240"/>
-                                <TextBlock Grid.Row="1"
+                                        Width="240"
+                                        ValueChanged="FrameRateLimit_ValueChanged"/>
+                                <TextBlock x:Name="FrameRateLimiterValue" 
+                                           Grid.Row="1"
                                            FontSize="18" 
                                            HorizontalAlignment="Center"
                                            Style="{StaticResource SettingText}"
@@ -530,7 +547,7 @@
                                                 <TextBlock TextAlignment="Left">
                                                     Enable Vertical Sync from NVIDIA Control Panel
                                                     <LineBreak/>
-                                                    Turn off Xenia Vertical Sync if you plan on using this one
+                                                    Turn off Xenia's Vertical Sync if you plan on using this one
                                                     <LineBreak/>
                                                     <TextBlock FontWeight="SemiBold" 
                                                                Text="Options:"
@@ -554,6 +571,8 @@
                                     
                                     <ComboBox x:Name="NvidiaVSyncSelector" 
                                               Grid.Column="1" 
+                                              AutomationProperties.Name="NVIDIA Vertical Sync"
+                                              AutomationProperties.HelpText="Enable Vertical Sync from NVIDIA Control Panel. Turn off Xenia's Vertical Sync if you plan on using this one."
                                               FontSize="18"
                                               HorizontalContentAlignment="Center"
                                               Margin="0,10"          
@@ -648,6 +667,7 @@
                             
                             <ComboBox x:Name="gpuSelector" 
                                       Grid.Column="1" 
+                                      AutomationProperties.Name="Graphics API"
                                       FontSize="18"
                                       HorizontalContentAlignment="Center"
                                       Margin="0,10" 
@@ -703,6 +723,8 @@
                                     
                                     <CheckBox x:Name="D3D12VRR" 
                                               Grid.Column="1" 
+                                              AutomationProperties.Name="Direct3D 12 Variable Refresh Rate"
+                                              AutomationProperties.HelpText="Enabling this enables variable refresh rate"
                                               Cursor="Hand"
                                               Margin="0,10" 
                                               Style="{StaticResource CheckboxStyle}"
@@ -745,6 +767,7 @@
                                     
                                     <ComboBox x:Name="D3D12RenderTargetPathSelector" 
                                               Grid.Column="1" 
+                                              AutomationProperties.Name="Direct3D 12 Render Target Path"
                                               FontSize="18"
                                               HorizontalContentAlignment="Center"
                                               Margin="0,10" 
@@ -795,6 +818,8 @@
                                     
                                     <CheckBox x:Name="D3D12ReadbackResolve" 
                                               Grid.Column="1" 
+                                              AutomationProperties.Name="Direct3D 12 Readback Resolve"
+                                              AutomationProperties.HelpText="CPU readback after render target resolving."
                                               Cursor="Hand"
                                               Margin="0,10" 
                                               Style="{StaticResource CheckboxStyle}"
@@ -839,6 +864,8 @@
                                     
                                     <ComboBox x:Name="D3D12QueuePrioritySelector" 
                                               Grid.Column="1"
+                                              AutomationProperties.Name="Direct3D 12 Queue Priority"
+                                              AutomationProperties.HelpText="Setting this higher than normal may improve performance."
                                               FontSize="18" 
                                               HorizontalContentAlignment="Center"
                                               Margin="0,10" 
@@ -895,6 +922,7 @@
                                     
                                     <ComboBox x:Name="VulkanRenderTargetPathSelector" 
                                               Grid.Column="1" 
+                                              AutomationProperties.Name="Vulkan Render Target Path"
                                               FontSize="18"
                                               HorizontalContentAlignment="Center"
                                               Margin="0,10" 
@@ -951,6 +979,8 @@
                                     
                                     <CheckBox x:Name="VulkanPresentModeImmediate" 
                                               Grid.Column="1"
+                                              AutomationProperties.Name="Vulkan Present Mode Immediate"
+                                              AutomationProperties.HelpText="Allows the immediate presentation mode, offering the lowest latency with the possibility of tearing in certain cases, and, depending on the configuration, variable refresh rate. If this one doesn't work, try the other 2 present modes."
                                               Cursor="Hand"
                                               Margin="0,10" 
                                               Style="{StaticResource CheckboxStyle}"
@@ -999,6 +1029,8 @@
                                     
                                     <CheckBox x:Name="VulkanPresentModeMailbox" 
                                               Grid.Column="1" 
+                                              AutomationProperties.Name="Vulkan Present Mode Mailbox"
+                                              AutomationProperties.HelpText="Allows the mailbox presentation mode (2nd priority), offering low latency without the possibility of tearing. If this one doesn't work, try FIFO Relaxed present mode."
                                               Cursor="Hand"
                                               Margin="0,10" 
                                               Style="{StaticResource CheckboxStyle}"
@@ -1042,7 +1074,9 @@
                                     </TextBlock>
                                     
                                     <CheckBox x:Name="VulkanPresentModeFIFORelaxed" 
-                                              Grid.Column="1" 
+                                              Grid.Column="1"
+                                              AutomationProperties.Name="Vulkan Present Mode FIFO Relaxed"
+                                              AutomationProperties.HelpText="Allows the relaxed first-in-first-out presentation mode, which causes waiting for host display vertical sync, but may present with tearing if frames don't meet the host display refresh rate."
                                               Cursor="Hand"
                                               Margin="0,10" 
                                               Style="{StaticResource CheckboxStyle}"
@@ -1091,7 +1125,8 @@
                                         Grid.Row="0"
                                         Minimum="1" Maximum="7" Value="1"
                                         Width="240"
-                                        IsSnapToTickEnabled="True" TickFrequency="1"/>
+                                        IsSnapToTickEnabled="True" TickFrequency="1"
+                                        ValueChanged="DrawResolutionScale_ValueChanged"/>
                                 <TextBlock Grid.Row="1"
                                            FontSize="18" 
                                            HorizontalAlignment="Center"
@@ -1138,6 +1173,8 @@
                             
                             <ComboBox x:Name="AntiAliasingSelector" 
                                       Grid.Column="1"
+                                      AutomationProperties.Name="Anti Aliasing"
+                                      AutomationProperties.HelpText="Post-processing anti-aliasing effect to apply to the image output of the game"
                                       FontSize="18"
                                       HorizontalContentAlignment="Center"
                                       Margin="0,10" 
@@ -1192,6 +1229,8 @@
                             
                             <ComboBox x:Name="ScalingAndSharpeningSelector" 
                                       Grid.Column="1"
+                                      AutomationProperties.Name="Scaling and sharpening"
+                                      AutomationProperties.HelpText="Post-processing effect to use for resampling and/or sharpening of the final display output"
                                       FontSize="18"
                                       HorizontalContentAlignment="Center"
                                       Margin="0,10"  
@@ -1333,7 +1372,8 @@
                                         Grid.Row="0"
                                         Minimum="1" Maximum="4" Value="1"
                                         Width="240"
-                                        IsSnapToTickEnabled="True" TickFrequency="1"/>
+                                        IsSnapToTickEnabled="True" TickFrequency="1"
+                                        ValueChanged="FSRMaxUpsamplingPasses_ValueChanged"/>
                                 <TextBlock Grid.Row="1"
                                            FontSize="18" 
                                            HorizontalAlignment="Center"
@@ -1369,6 +1409,8 @@
                             
                             <CheckBox x:Name="PostProcessDither" 
                                       Grid.Column="1" 
+                                      AutomationProperties.Name="Post Process Dither"
+                                      AutomationProperties.HelpText="Dither the final image output from the internal precision to 8 bits per channel so gradients are smoother"
                                       Cursor="Hand"
                                       Margin="0,10" 
                                       Style="{StaticResource CheckboxStyle}"
@@ -1402,6 +1444,7 @@
                             
                             <CheckBox x:Name="gammaRenderTargetAsSRGB" 
                                       Grid.Column="1" 
+                                      AutomationProperties.Name="Gamma render target as sRGB"
                                       Cursor="Hand"
                                       Margin="0,10" 
                                       Style="{StaticResource CheckboxStyle}"
@@ -1444,6 +1487,7 @@
                             
                             <CheckBox x:Name="AllowPlugins" 
                                       Grid.Column="1" 
+                                      AutomationProperties.Name="Allow Plugins"
                                       Cursor="Hand"
                                       Margin="0,10" 
                                       Style="{StaticResource CheckboxStyle}"
@@ -1464,7 +1508,7 @@
                                 <TextBlock.ToolTip>
                                     <ToolTip>
                                         <TextBlock TextAlignment="Left">
-                                            Enable Discord rich presence
+                                            Enable Discord Rich Presence
                                         </TextBlock>
                                     </ToolTip>
                                 </TextBlock.ToolTip>
@@ -1473,6 +1517,7 @@
                             
                             <CheckBox x:Name="DiscordRPC" 
                                       Grid.Column="1" 
+                                      AutomationProperties.Name="Discord Rich Presence"
                                       Cursor="Hand"
                                       Margin="0,10" 
                                       Style="{StaticResource CheckboxStyle}"
@@ -1505,6 +1550,8 @@
                             
                             <CheckBox x:Name="ApplyPatches" 
                                       Grid.Column="1"
+                                      AutomationProperties.Name="Game Patches"
+                                      AutomationProperties.HelpText="Enables custom patching functionality"
                                       Cursor="Hand"
                                       Margin="0,10" 
                                       Style="{StaticResource CheckboxStyle}"
@@ -1547,6 +1594,8 @@
                             
                             <ComboBox x:Name="licenseMaskSelector" 
                                       Grid.Column="1" 
+                                      AutomationProperties.Name="License Mask"
+                                      AutomationProperties.HelpText="Useful for mainly XBLA games that require licenses. Put this to First License to unlock full game."
                                       HorizontalContentAlignment="Center"
                                       Margin="0,10" 
                                       FontSize="18" 
@@ -1585,6 +1634,8 @@
                             
                             <CheckBox x:Name="ApplyTitleUpdate" 
                                       Grid.Column="1" 
+                                      AutomationProperties.Name="Title Updates"
+                                      AutomationProperties.HelpText="Enables title updates"
                                       Cursor="Hand"
                                       Margin="0,10" 
                                       Style="{StaticResource CheckboxStyle}"
@@ -1617,6 +1668,8 @@
                             
                             <CheckBox x:Name="ShowAchievementNotifications" 
                                       Grid.Column="1"
+                                      AutomationProperties.Name="Achievement Notifications"
+                                      AutomationProperties.HelpText="Show achievement notifications on screen."
                                       Cursor="Hand"
                                       Margin="0,10" 
                                       Style="{StaticResource CheckboxStyle}"
@@ -1646,6 +1699,8 @@
                             
                             <ComboBox x:Name="UserLanguageSelector" 
                                       Grid.Column="1" 
+                                      AutomationProperties.Name="User Language"
+                                      AutomationProperties.HelpText="Used for changing language in games if they support it."
                                       FontSize="18"
                                       HorizontalContentAlignment="Center"
                                       Margin="0,10" 
@@ -1705,6 +1760,8 @@
                                     
                                     <TextBox x:Name="apiAddressTextBox" 
                                              Grid.Column="1"
+                                             AutomationProperties.Name="API Address"
+                                             AutomationProperties.HelpText="Address that points to the Xenia WebServices which is required for online play"
                                              FontSize="18" 
                                              HorizontalContentAlignment="Left"
                                              Margin="0,10"
@@ -1737,6 +1794,8 @@
                                     
                                     <CheckBox x:Name="UPnP" 
                                               Grid.Column="1" 
+                                              AutomationProperties.Name="UPnP"
+                                              AutomationProperties.HelpText="UPnP must be enabled to host sessions"
                                               Cursor="Hand"
                                               Margin="0,10" 
                                               Style="{StaticResource CheckboxStyle}"
@@ -1770,6 +1829,8 @@
                                     
                                     <TextBox x:Name="user0GamerTagTextBox" 
                                              Grid.Column="1"
+                                             AutomationProperties.Name="User 0 Gamertag"
+                                             AutomationProperties.HelpText="Name that is displayed for user 0"
                                              FontSize="18" 
                                              HorizontalContentAlignment="Center"
                                              Margin="0,10"
@@ -1806,6 +1867,8 @@
                                     
                                     <TextBox x:Name="user1GamerTagTextBox" 
                                              Grid.Column="1"
+                                             AutomationProperties.Name="User 1 Gamertag"
+                                             AutomationProperties.HelpText="Name that is displayed for user 1"
                                              FontSize="18" 
                                              HorizontalContentAlignment="Center"
                                              Margin="0,10"
@@ -1842,6 +1905,8 @@
                                     
                                     <TextBox x:Name="user2GamerTagTextBox" 
                                              Grid.Column="1"
+                                             AutomationProperties.Name="User 2 Gamertag"
+                                             AutomationProperties.HelpText="Name that is displayed for user 2"
                                              FontSize="18" 
                                              HorizontalContentAlignment="Center"
                                              Margin="0,10"
@@ -1878,6 +1943,8 @@
                                     
                                     <TextBox x:Name="user3GamerTagTextBox" 
                                              Grid.Column="1"
+                                             AutomationProperties.Name="User 3 Gamertag"
+                                             AutomationProperties.HelpText="Name that is displayed for user 3"
                                              FontSize="18" 
                                              HorizontalContentAlignment="Center"
                                              Margin="0,10" 
@@ -1931,6 +1998,8 @@
                             
                             <ComboBox x:Name="InputSystemSelector" 
                                       Grid.Column="1" 
+                                      AutomationProperties.Name="Input System"
+                                      AutomationProperties.HelpText=""
                                       FontSize="18"
                                       HorizontalContentAlignment="Center"
                                       Margin="0,10" 
@@ -2060,6 +2129,8 @@
                             
                             <CheckBox x:Name="ControllerHotkeys" 
                                       Grid.Column="1" 
+                                      AutomationProperties.Name="Controller Hotkeys"
+                                      AutomationProperties.HelpText="Enables hotkeys for Xbox and PS Controllers, but it can interfere with the gameplay."
                                       Cursor="Hand"
                                       Margin="0,10" 
                                       Style="{StaticResource CheckboxStyle}"
@@ -2090,6 +2161,7 @@
                             
                             <CheckBox x:Name="ControllerVibration" 
                                       Grid.Column="1" 
+                                      AutomationProperties.Name="Controller Vibration"
                                       Cursor="Hand"
                                       Margin="0,10" 
                                       Style="{StaticResource CheckboxStyle}"
@@ -2127,6 +2199,8 @@
                             
                             <CheckBox x:Name="MountCache" 
                                       Grid.Column="1" 
+                                      AutomationProperties.Name="Mount Cache"
+                                      AutomationProperties.HelpText="Enabling mount cache can fix some games."
                                       Cursor="Hand"
                                       Margin="0,10" 
                                       Style="{StaticResource CheckboxStyle}"
@@ -2155,7 +2229,8 @@
                             </TextBlock>
                             
                             <CheckBox x:Name="MountScratch" 
-                                      Grid.Column="1" 
+                                      Grid.Column="1"
+                                      AutomationProperties.Name="Mount Scratch"
                                       Cursor="Hand"
                                       Margin="0,10" 
                                       Style="{StaticResource CheckboxStyle}"
@@ -2202,6 +2277,8 @@
                             
                             <CheckBox x:Name="ProtectZero" 
                                       Grid.Column="1"
+                                      AutomationProperties.Name="Protect Zero Page"
+                                      AutomationProperties.HelpText="Protect the zero page from reads and writes"
                                       Cursor="Hand"
                                       Margin="0,10" 
                                       Style="{StaticResource CheckboxStyle}"
@@ -2242,6 +2319,8 @@
                             
                             <CheckBox x:Name="BreakOnUnimplementedInstructions" 
                                       Grid.Column="1" 
+                                      AutomationProperties.Name="Break On Unimplemented Instructions"
+                                      AutomationProperties.HelpText="Break to the host debugger (or crash if no debugger attached) if an unimplemented PowerPC instruction is encountered"
                                       Cursor="Hand"
                                       Margin="0,10" 
                                       Style="{StaticResource CheckboxStyle}"
@@ -2283,6 +2362,8 @@
                             
                             <CheckBox x:Name="ClearGPUCache" 
                                       Grid.Column="1"
+                                      AutomationProperties.Name="Clear GPU Cache"
+                                      AutomationProperties.HelpText="Refresh the state of memory pages to enable gpu written data"
                                       Cursor="Hand"
                                       Margin="0,10" 
                                       Style="{StaticResource CheckboxStyle}"

--- a/Xenia Manager/Pages/XeniaSettings.xaml
+++ b/Xenia Manager/Pages/XeniaSettings.xaml
@@ -19,40 +19,61 @@
             <!-- List of configuration files & save button-->
             <Grid Grid.Row="0">
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition MinWidth="565"/>
+                    <ColumnDefinition MinWidth="500"/>
                     <ColumnDefinition/>
                 </Grid.ColumnDefinitions>
 
                 <!-- List of configuration files -->
-                <ComboBox x:Name="ConfigurationFilesList"
-                          Grid.Column="0"
-                          Height="40"
-                          Style="{StaticResource ComboBoxStyle}"
-                          SelectionChanged="ConfigurationFilesList_SelectionChanged">
-                    <ComboBox.ToolTip>
-                        <TextBlock TextAlignment="Left">
+                <StackPanel Grid.Column="0"
+                            VerticalAlignment="Center">
+                    <ComboBox x:Name="ConfigurationFilesList"
+                              Height="35"
+                              Style="{StaticResource ComboBoxStyle}"
+                              SelectionChanged="ConfigurationFilesList_SelectionChanged">
+                        <ComboBox.ToolTip>
+                            <TextBlock TextAlignment="Left">
                             <TextBlock FontWeight="Bold" 
                                        Text="NOTE:"/>
                             Profiles for Xenia Stable, Canary and Netplay are used as a base for generating game configuration files
                             <LineBreak/>
                             All changes made to them will be overridden by game configuration files on launch
                         </TextBlock>
-                    </ComboBox.ToolTip>
-                </ComboBox>
+                        </ComboBox.ToolTip>
+                    </ComboBox>
 
-                <Grid Grid.Column="1">
-                    <Grid.RowDefinitions>
-                        <RowDefinition/>
-                        <RowDefinition/>
-                    </Grid.RowDefinitions>
+                    <!-- Copy Default Settings -->
+                    <Button x:Name="CopyDefaultSettings" 
+                            HorizontalAlignment="Center"
+                            Margin="0,0,0,10"
+                            Style="{StaticResource ButtonStyle}"
+                            VerticalAlignment="Center"
+                            Visibility="Collapsed"
+                            Click="CopyDefaultSettings_Click">
+                        <Button.Content>
+                            <TextBlock FontSize="26"
+                                       Style="{StaticResource AddGameText}"
+                                       Text="Copy Settings From Default Profile"/>
+                        </Button.Content>
+                        <Button.ToolTip>
+                            <TextBlock TextAlignment="Left">
+                                Copies all of the settings from the default configuration file to the currently selected game configuration
+                                <LineBreak/>
+                                <TextBlock FontWeight="Bold" 
+                                           Text="NOTE:"/>
+                                This only reads the settings from the default profile into the UI, it will not save the changes
+                            </TextBlock>
+                        </Button.ToolTip>
+                    </Button>
+                </StackPanel>
 
+                <StackPanel Grid.Column="1">
                     <!-- Open in editor Button -->
                     <Button x:Name="OpenConfigurationFile" 
-                            Grid.Row="0"
                             HorizontalAlignment="Center"
                             Margin="0,10"
                             Style="{StaticResource ButtonStyle}" 
                             VerticalAlignment="Center" 
+                            MinWidth="200"
                             Click="OpenConfigurationFile_Click">
                         <Button.Content>
                             <TextBlock FontSize="26"
@@ -79,11 +100,11 @@
 
                     <!-- Save Button -->
                     <Button x:Name="SaveSettings" 
-                            Grid.Row="1"
                             HorizontalAlignment="Center"
                             Margin="0,0,0,10"
                             Style="{StaticResource ButtonStyle}"
                             VerticalAlignment="Center"
+                            MinWidth="200"
                             Click="SaveSettings_Click">
                         <Button.Content>
                             <TextBlock FontSize="26"
@@ -91,7 +112,7 @@
                                        Text="Save changes"/>
                         </Button.Content>
                     </Button>
-                </Grid>
+                </StackPanel>
             </Grid>
 
             <!-- Seperation Line -->

--- a/Xenia Manager/Pages/XeniaSettings.xaml.cs
+++ b/Xenia Manager/Pages/XeniaSettings.xaml.cs
@@ -797,6 +797,76 @@ namespace Xenia_Manager.Pages
             }
         }
 
+        // UI Interactions
+        /// <summary>
+        /// When selecting different profile, reload the UI with those settings
+        /// </summary>
+        private async void ConfigurationFilesList_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            try
+            {
+                if (ConfigurationFilesList.SelectedItem != null)
+                {
+                    HideNonUniversalSettings();
+                    switch (ConfigurationFilesList.SelectedItem.ToString())
+                    {
+                        case "Xenia Stable Profile":
+                            Log.Information("Loading Xenia Stable Profile");
+                            await ReadConfigFile(Path.Combine(App.baseDirectory, App.appConfiguration.XeniaStable.ConfigurationFileLocation));
+                            CopyDefaultSettings.Visibility = Visibility.Collapsed;
+                            break;
+                        case "Xenia Canary Profile":
+                            Log.Information("Loading Xenia Canary Profile");
+                            await ReadConfigFile(Path.Combine(App.baseDirectory, App.appConfiguration.XeniaCanary.ConfigurationFileLocation));
+                            CopyDefaultSettings.Visibility = Visibility.Collapsed;
+                            break;
+                        case "Xenia Netplay Profile":
+                            Log.Information("Loading Xenia Netplay Profile");
+                            await ReadConfigFile(Path.Combine(App.baseDirectory, App.appConfiguration.XeniaNetplay.ConfigurationFileLocation));
+                            CopyDefaultSettings.Visibility = Visibility.Collapsed;
+                            break;
+                        default:
+                            InstalledGame selectedGame = Games.First(game => game.Title == ConfigurationFilesList.SelectedItem.ToString());
+                            Log.Information($"Loading configuration file of {selectedGame.Title}");
+                            if (File.Exists(Path.Combine(App.baseDirectory, selectedGame.ConfigFilePath)))
+                            {
+                                await ReadConfigFile(Path.Combine(App.baseDirectory, selectedGame.ConfigFilePath));
+                            }
+                            else
+                            {
+                                Log.Information("Game configuration file not found");
+                                Log.Information("Creating a new configuration file");
+                                switch (selectedGame.EmulatorVersion)
+                                {
+                                    case "Stable":
+                                        File.Copy(Path.Combine(App.baseDirectory, App.appConfiguration.XeniaStable.ConfigurationFileLocation), Path.Combine(App.baseDirectory, App.appConfiguration.XeniaStable.EmulatorLocation, $@"config\{selectedGame.Title}.config.toml"), true);
+                                        break;
+                                    case "Canary":
+                                        File.Copy(Path.Combine(App.baseDirectory, App.appConfiguration.XeniaCanary.ConfigurationFileLocation), Path.Combine(App.baseDirectory, App.appConfiguration.XeniaCanary.EmulatorLocation, $@"config\{selectedGame.Title}.config.toml"), true);
+                                        break;
+                                    case "Netplay":
+                                        File.Copy(Path.Combine(App.baseDirectory, App.appConfiguration.XeniaNetplay.ConfigurationFileLocation), Path.Combine(App.baseDirectory, App.appConfiguration.XeniaNetplay.EmulatorLocation, $@"config\{selectedGame.Title}.config.toml"), true);
+                                        break;
+                                    default:
+                                        break;
+                                }
+                                Log.Information($"Loading new configuration file of {selectedGame.Title}");
+                                await ReadConfigFile(Path.Combine(App.baseDirectory, selectedGame.ConfigFilePath));
+                            }
+                            CopyDefaultSettings.Visibility = Visibility.Visible;
+                            break;
+                    }
+                    await ReadNVIDIAProfile();
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex.Message + "\nFull Error:\n" + ex);
+                MessageBox.Show(ex.Message);
+                return;
+            }
+        }
+
         /// <summary>
         /// Function that saves NVIDIA Settings into the Xenia profile
         /// </summary>
@@ -1236,72 +1306,6 @@ namespace Xenia_Manager.Pages
             }
         }
 
-        // UI Interactions
-        /// <summary>
-        /// When selecting different profile, reload the UI with those settings
-        /// </summary>
-        private async void ConfigurationFilesList_SelectionChanged(object sender, SelectionChangedEventArgs e)
-        {
-            try
-            {
-                if (ConfigurationFilesList.SelectedItem != null)
-                {
-                    HideNonUniversalSettings();
-                    switch (ConfigurationFilesList.SelectedItem.ToString())
-                    {
-                        case "Xenia Stable Profile":
-                            Log.Information("Loading Xenia Stable Profile");
-                            await ReadConfigFile(Path.Combine(App.baseDirectory, App.appConfiguration.XeniaStable.ConfigurationFileLocation));
-                            break;
-                        case "Xenia Canary Profile":
-                            Log.Information("Loading Xenia Canary Profile");
-                            await ReadConfigFile(Path.Combine(App.baseDirectory, App.appConfiguration.XeniaCanary.ConfigurationFileLocation));
-                            break;
-                        case "Xenia Netplay Profile":
-                            Log.Information("Loading Xenia Netplay Profile");
-                            await ReadConfigFile(Path.Combine(App.baseDirectory, App.appConfiguration.XeniaNetplay.ConfigurationFileLocation));
-                            break;
-                        default:
-                            InstalledGame selectedGame = Games.First(game => game.Title == ConfigurationFilesList.SelectedItem.ToString());
-                            Log.Information($"Loading configuration file of {selectedGame.Title}");
-                            if (File.Exists(Path.Combine(App.baseDirectory, selectedGame.ConfigFilePath)))
-                            {
-                                await ReadConfigFile(Path.Combine(App.baseDirectory, selectedGame.ConfigFilePath));
-                            }
-                            else
-                            {
-                                Log.Information("Game configuration file not found");
-                                Log.Information("Creating a new configuration file");
-                                switch (selectedGame.EmulatorVersion)
-                                {
-                                    case "Stable":
-                                        File.Copy(Path.Combine(App.baseDirectory, App.appConfiguration.XeniaStable.ConfigurationFileLocation), Path.Combine(App.baseDirectory, App.appConfiguration.XeniaStable.EmulatorLocation, $@"config\{selectedGame.Title}.config.toml"), true);
-                                        break;
-                                    case "Canary":
-                                        File.Copy(Path.Combine(App.baseDirectory, App.appConfiguration.XeniaCanary.ConfigurationFileLocation), Path.Combine(App.baseDirectory, App.appConfiguration.XeniaCanary.EmulatorLocation, $@"config\{selectedGame.Title}.config.toml"), true);
-                                        break;
-                                    case "Netplay":
-                                        File.Copy(Path.Combine(App.baseDirectory, App.appConfiguration.XeniaNetplay.ConfigurationFileLocation), Path.Combine(App.baseDirectory, App.appConfiguration.XeniaNetplay.EmulatorLocation, $@"config\{selectedGame.Title}.config.toml"), true);
-                                        break;
-                                    default:
-                                        break;
-                                }
-                                Log.Information($"Loading new configuration file of {selectedGame.Title}");
-                                await ReadConfigFile(Path.Combine(App.baseDirectory, selectedGame.ConfigFilePath));
-                            }
-                            break;
-                    }
-                    await ReadNVIDIAProfile();
-                }
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex.Message + "\nFull Error:\n" + ex);
-                MessageBox.Show(ex.Message);
-                return;
-            }
-        }
-
         /// <summary>
         /// When button "Save changes" is pressed, save changes to the configuration file
         /// </summary>
@@ -1399,6 +1403,37 @@ namespace Xenia_Manager.Pages
                 await process.WaitForExitAsync();
                 Log.Information("Reading changes made to the configuration file");
                 await ReadConfigFile(configPath);
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex.Message + "\nFull Error:\n" + ex);
+                MessageBox.Show(ex.Message);
+                return;
+            }
+        }
+
+        /// <summary>
+        /// Copies all of the settings from the default file to the currently selected game's configuration file
+        /// </summary>
+        private async void CopyDefaultSettings_Click(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                InstalledGame selectedGame = Games.First(game => game.Title == ConfigurationFilesList.SelectedItem.ToString());
+                switch (selectedGame.EmulatorVersion)
+                {
+                    case "Stable":
+                        await ReadConfigFile(Path.Combine(App.baseDirectory, App.appConfiguration.XeniaStable.ConfigurationFileLocation));
+                        break;
+                    case "Canary":
+                        await ReadConfigFile(Path.Combine(App.baseDirectory, App.appConfiguration.XeniaCanary.ConfigurationFileLocation));
+                        break;
+                    case "Netplay":
+                        await ReadConfigFile(Path.Combine(App.baseDirectory, App.appConfiguration.XeniaNetplay.ConfigurationFileLocation));
+                        break;
+                    default:
+                        break;
+                }
             }
             catch (Exception ex)
             {

--- a/Xenia Manager/Pages/XeniaSettings.xaml.cs
+++ b/Xenia Manager/Pages/XeniaSettings.xaml.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics;
 using System.IO;
 using System.Windows;
+using System.Windows.Automation;
 using System.Windows.Controls;
 using System.Windows.Input;
 
@@ -280,14 +281,17 @@ namespace Xenia_Manager.Pages
                             // "postprocess_ffx_cas_additional_sharpness" setting
                             Log.Information($"postprocess_ffx_cas_additional_sharpness - {sectionTable["postprocess_ffx_cas_additional_sharpness"].ToString()}");
                             CASAdditionalSharpness.Value = double.Parse(sectionTable["postprocess_ffx_cas_additional_sharpness"].ToString()) * 1000;
+                            AutomationProperties.SetName(CASAdditionalSharpness, $"CAS Additional Sharpness: {Math.Round((CASAdditionalSharpness.Value / 1000), 3)}");
 
                             // "postprocess_ffx_fsr_max_upsampling_passes" setting
                             Log.Information($"postprocess_ffx_fsr_max_upsampling_passes - {int.Parse(sectionTable["postprocess_ffx_fsr_max_upsampling_passes"].ToString())}");
                             FSRMaxUpsamplingPasses.Value = int.Parse(sectionTable["postprocess_ffx_fsr_max_upsampling_passes"].ToString());
+                            AutomationProperties.SetName(FSRMaxUpsamplingPasses, $"FSR MaxUpsampling Passes: {FSRMaxUpsamplingPasses.Value}");
 
                             // "postprocess_ffx_fsr_sharpness_reduction" setting
                             Log.Information($"postprocess_ffx_fsr_sharpness_reduction - {double.Parse(sectionTable["postprocess_ffx_fsr_sharpness_reduction"].ToString())}");
                             FSRSharpnessReduction.Value = double.Parse(sectionTable["postprocess_ffx_fsr_sharpness_reduction"].ToString()) * 1000;
+                            AutomationProperties.SetName(FSRSharpnessReduction, $"FSR Sharpness Reduction: {Math.Round((FSRSharpnessReduction.Value / 1000), 3)}");
 
                             // "postprocess_scaling_and_sharpening" setting
                             Log.Information($"postprocess_scaling_and_sharpening - {sectionTable["postprocess_scaling_and_sharpening"] as string}");
@@ -324,6 +328,7 @@ namespace Xenia_Manager.Pages
                             {
                                 Log.Information($"framerate_limit - {sectionTable["framerate_limit"].ToString()}");
                                 FrameRateLimit.Value = int.Parse(sectionTable["framerate_limit"].ToString());
+                                AutomationProperties.SetName(FrameRateLimit, $"Xenia Framerate Limiter: {FrameRateLimit.Value} FPS");
                                 XeniaFramerateLimiterOption.Visibility = Visibility.Visible;
                             }
                             else
@@ -472,6 +477,7 @@ namespace Xenia_Manager.Pages
                             {
                                 Log.Information($"left_stick_deadzone_percentage - {double.Parse(sectionTable["left_stick_deadzone_percentage"].ToString())}");
                                 LeftStickDeadzonePercentage.Value = Math.Round(double.Parse(sectionTable["left_stick_deadzone_percentage"].ToString()) * 10, 1);
+                                AutomationProperties.SetName(LeftStickDeadzonePercentage, $"Left Stick Deadzone Percentage: {Math.Round((LeftStickDeadzonePercentage.Value / 10), 1)}");
                                 LeftStickDeadzoneOption.Visibility = Visibility.Visible;
                             }
                             else
@@ -485,6 +491,7 @@ namespace Xenia_Manager.Pages
                             {
                                 Log.Information($"right_stick_deadzone_percentage - {double.Parse(sectionTable["left_stick_deadzone_percentage"].ToString())}");
                                 RightStickDeadzonePercentage.Value = Math.Round(double.Parse(sectionTable["right_stick_deadzone_percentage"].ToString()) * 10, 1);
+                                AutomationProperties.SetName(RightStickDeadzonePercentage, $"Right Stick Deadzone Percentage: {Math.Round((RightStickDeadzonePercentage.Value / 10), 1)}");
                                 RightStickDeadzoneOption.Visibility = Visibility.Visible;
                             }
                             else
@@ -733,6 +740,7 @@ namespace Xenia_Manager.Pages
                         NvidiaFrameRateLimiter.Value = 0;
                         NvidiaFrameRateLimiterValue.Text = "Off";
                     }
+                    AutomationProperties.SetName(NvidiaFrameRateLimiter, $"NVIDIA Framerate Limiter: {NvidiaFrameRateLimiter.Value} FPS");
                 }
                 else
                 {
@@ -1481,6 +1489,27 @@ namespace Xenia_Manager.Pages
         }
 
         /// <summary>
+        /// Displays the value on the textbox below this slider
+        /// </summary>
+        private void FrameRateLimit_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
+        {
+            Slider slider = sender as Slider;
+            if (slider != null)
+            {
+                // Text shown under the slider
+                if (slider.Value == 0)
+                {
+                    FrameRateLimiterValue.Text = "Off";
+                }
+                else
+                {
+                    FrameRateLimiterValue.Text = $"{slider.Value} FPS";
+                }
+                AutomationProperties.SetName(FrameRateLimit, $"Xenia Framerate Limiter: {slider.Value} FPS");
+            }
+        }
+
+        /// <summary>
         /// Checks if the value of NvidiaFrameRateLimiter slider isn't 1-19
         /// </summary>
         private void NvidiaFrameRateLimiter_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
@@ -1503,6 +1532,7 @@ namespace Xenia_Manager.Pages
                 {
                     NvidiaFrameRateLimiterValue.Text = $"{slider.Value} FPS";
                 }
+                AutomationProperties.SetName(NvidiaFrameRateLimiter, $"NVIDIA Framerate Limiter: {slider.Value} FPS");
             }
         }
 
@@ -1529,11 +1559,20 @@ namespace Xenia_Manager.Pages
         }
 
         /// <summary>
+        /// Checks for value changes on DrawResolutionScale
+        /// </summary>
+        private void DrawResolutionScale_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
+        {
+            AutomationProperties.SetName(DrawResolutionScale, $"Draw Resolution Scale: {DrawResolutionScale.Value}");
+        }
+
+        /// <summary>
         /// Checks for value changes on CASAdditionalSharpness and shows them on the textbox
         /// </summary>
         private void CASAdditionalSharpness_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
         {
             CASAdditionalSharpnessValue.Text = Math.Round((CASAdditionalSharpness.Value / 1000), 3).ToString();
+            AutomationProperties.SetName(CASAdditionalSharpness, $"CAS Additional Sharpness: {Math.Round((CASAdditionalSharpness.Value / 1000), 3)}");
         }
 
         /// <summary>
@@ -1542,13 +1581,20 @@ namespace Xenia_Manager.Pages
         private void FSRSharpnessReduction_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
         {
             FSRSharpnessReductionValue.Text = Math.Round((FSRSharpnessReduction.Value / 1000), 3).ToString();
+            AutomationProperties.SetName(FSRSharpnessReduction, $"FSR Sharpness Reduction: {Math.Round((FSRSharpnessReduction.Value / 1000), 3)}");
+        }
+
+        /// <summary>
+        /// Checks for value changes on FSRMaxUpsamplingPasses slider and shows them on the textbox
+        /// </summary>
+        private void FSRMaxUpsamplingPasses_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
+        {
+            AutomationProperties.SetName(FSRMaxUpsamplingPasses, $"FSR MaxUpsampling Passes: {FSRMaxUpsamplingPasses.Value}");
         }
 
         /// <summary>
         /// Check to see if there are less than 15 characters in the gamertag textbox
         /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
         private void GamerTagTextBox_TextChanged(object sender, TextChangedEventArgs e)
         {
             TextBox textBox = sender as TextBox;
@@ -1566,6 +1612,7 @@ namespace Xenia_Manager.Pages
         private void LeftStickDeadzonePercentage_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
         {
             LeftStickDeadzonePercentageValue.Text = Math.Round((LeftStickDeadzonePercentage.Value / 10), 1).ToString();
+            AutomationProperties.SetName(LeftStickDeadzonePercentage, $"Left Stick Deadzone Percentage: {Math.Round((LeftStickDeadzonePercentage.Value / 10), 1)}");
         }
 
         /// <summary>
@@ -1574,6 +1621,7 @@ namespace Xenia_Manager.Pages
         private void RightStickDeadzonePercentage_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
         {
             RightStickDeadzonePercentageValue.Text = Math.Round((RightStickDeadzonePercentage.Value / 10), 1).ToString();
+            AutomationProperties.SetName(RightStickDeadzonePercentage, $"Right Stick Deadzone Percentage: {Math.Round((RightStickDeadzonePercentage.Value / 10), 1)}");
         }
     }
 }

--- a/Xenia Manager/Windows/ChangelogWindow.xaml
+++ b/Xenia Manager/Windows/ChangelogWindow.xaml
@@ -5,6 +5,8 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:Xenia_Manager.Windows"
         mc:Ignorable="d"
+        AutomationProperties.Name="Changelog"
+        AutomationProperties.HelpText="Displays all of the changes made in different versions of Xenia Manager"
         Title="Xenia Manager - Changelog" 
         Height="550" Width="800"
         WindowStyle="None" ResizeMode="NoResize"
@@ -42,6 +44,8 @@
                 <!-- Close button -->
                 <Button x:Name="Exit"
                         Grid.Column="1"
+                        AutomationProperties.Name="Close Button"
+                        AutomationProperties.HelpText="Closes Changelog window"
                         Content="&#xE711;"
                         HorizontalAlignment="Right"
                         Style="{StaticResource TitleBarButton}"

--- a/Xenia Manager/Windows/EditGameInfo.xaml
+++ b/Xenia Manager/Windows/EditGameInfo.xaml
@@ -5,6 +5,8 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:Xenia_Manager.Windows"
         mc:Ignorable="d"
+        AutomationProperties.Name="Edit Game Info"
+        AutomationProperties.HelpText="Used for editing game titles, changing their location (if you moved the game) and switching the game to use different version of Xenia"
         Title="Xenia Manager - Edit Game Info"
         Height="600" Width="500"
         WindowStyle="None" ResizeMode="NoResize"
@@ -42,6 +44,8 @@
                 <!-- Close Button -->
                 <Button x:Name="Exit"
                         Grid.Column="1"
+                        AutomationProperties.Name="Close Button"
+                        AutomationProperties.HelpText="Closes Game Info Window and saves changes"
                         Content="&#xE711;"
                         HorizontalAlignment="Right"
                         Style="{StaticResource TitleBarButton}"
@@ -60,6 +64,8 @@
                     <!-- Game Icon -->
                     <Grid>
                         <Button x:Name="GameIcon" 
+                                AutomationProperties.Name="Game Icon"
+                                AutomationProperties.HelpText="Clicking on it allows you to select another game icon you want to use"
                                 Cursor="Hand"
                                 Height="207"
                                 Margin="0,10"
@@ -125,6 +131,8 @@
                             </TextBlock>
                             <TextBox x:Name="GameTitle" 
                                      Grid.Column="1"
+                                     AutomationProperties.Name="Game Title"
+                                     AutomationProperties.HelpText="Typing here changes the game title"
                                      FontSize="18"
                                      HorizontalContentAlignment="Left"
                                      Margin="10"

--- a/Xenia Manager/Windows/EditGameInfo.xaml
+++ b/Xenia Manager/Windows/EditGameInfo.xaml
@@ -255,6 +255,37 @@
                             </Button>
                         </Grid>
                     </Border>
+
+                    <!-- Switch to Custom Xenia -->
+                    <Border x:Name="SwitchToXeniaCustomOption" 
+                            Background="{DynamicResource SettingBackgroundColor}"
+                            BorderBrush="{DynamicResource SettingBorderBrush}" 
+                            BorderThickness="2" 
+                            CornerRadius="10"
+                            Margin="5,2">
+                        <Grid Height="50">
+                            <Button x:Name="SwitchXeniaCustom" 
+                                    Grid.Column="2"
+                                    HorizontalAlignment="Center"
+                                    Margin="0"
+                                    Style="{StaticResource ButtonStyle}"
+                                    VerticalAlignment="Center"
+                                    Click="SwitchXeniaCustom_Click">
+                                <Button.Content>
+                                    <TextBlock FontSize="24"
+                                               Style="{StaticResource AddGameText}"
+                                               Text="Switch to Custom Xenia"/>
+                                </Button.Content>
+                                <Button.ToolTip>
+                                    <ToolTip>
+                                        <TextBlock TextAlignment="Left">
+                                            The game will use custom Xenia defined by the user
+                                        </TextBlock>
+                                    </ToolTip>
+                                </Button.ToolTip>
+                            </Button>
+                        </Grid>
+                    </Border>
                 </StackPanel>
             </ScrollViewer>
         </Grid>

--- a/Xenia Manager/Windows/EditGameInfo.xaml.cs
+++ b/Xenia Manager/Windows/EditGameInfo.xaml.cs
@@ -444,6 +444,10 @@ namespace Xenia_Manager.Windows
         /// <param name="defaultConfigFileLocation">Location to the default configuration file of the new Xenia version</param>
         private async Task TransferGame(InstalledGame game, string SourceVersion, string TargetVersion, string sourceEmulatorLocation, string targetEmulatorLocation, string defaultConfigFileLocation)
         {
+            if (SourceVersion == "Custom")
+            {
+                game.EmulatorExecutableLocation = null;
+            }
             Log.Information($"Moving the game to Xenia {TargetVersion}");
             game.EmulatorVersion = TargetVersion; // Set the emulator version
 
@@ -554,6 +558,7 @@ namespace Xenia_Manager.Windows
                 {
                     "Stable" => App.appConfiguration.XeniaStable.EmulatorLocation,
                     "Netplay" => App.appConfiguration.XeniaNetplay.EmulatorLocation,
+                    "Custom" => "",
                     _ => throw new InvalidOperationException("Unexpected build type")
                 };
                 await TransferGame(game, game.EmulatorVersion, "Canary", sourceEmulatorLocation, App.appConfiguration.XeniaCanary.EmulatorLocation, App.appConfiguration.XeniaCanary.ConfigurationFileLocation);
@@ -583,6 +588,7 @@ namespace Xenia_Manager.Windows
                 {
                     "Canary" => App.appConfiguration.XeniaCanary.EmulatorLocation,
                     "Netplay" => App.appConfiguration.XeniaNetplay.EmulatorLocation,
+                    "Custom" => "",
                     _ => throw new InvalidOperationException("Unexpected build type")
                 };
                 await TransferGame(game, game.EmulatorVersion, "Stable", sourceEmulatorLocation, App.appConfiguration.XeniaStable.EmulatorLocation, App.appConfiguration.XeniaStable.ConfigurationFileLocation);
@@ -612,9 +618,71 @@ namespace Xenia_Manager.Windows
                 {
                     "Canary" => App.appConfiguration.XeniaCanary.EmulatorLocation,
                     "Stable" => App.appConfiguration.XeniaStable.EmulatorLocation,
+                    "Custom" => "",
                     _ => throw new InvalidOperationException("Unexpected build type")
                 };
                 await TransferGame(game, game.EmulatorVersion, "Netplay", sourceEmulatorLocation, App.appConfiguration.XeniaNetplay.EmulatorLocation, App.appConfiguration.XeniaNetplay.ConfigurationFileLocation);
+                await CheckXeniaVersion();
+                MessageBox.Show($"{game.Title} transfer is complete. Now the game will use Xenia {game.EmulatorVersion}.");
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex.Message + "\nFull Error:\n" + ex);
+                MessageBox.Show(ex.Message);
+            }
+        }
+
+        /// <summary>
+        /// Makes the game use custom version of Xenia
+        /// </summary>
+        private async void SwitchXeniaCustom_Click(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                if (game.Title != GameTitle.Text)
+                {
+                    Log.Information("There is a change in game title");
+                    AdjustGameTitle();
+                }
+
+                // OpenFileDialog to select custom Xenia executable
+                OpenFileDialog CustomXeniaExecutableSelector = new OpenFileDialog();
+                CustomXeniaExecutableSelector.Title = "Select Xenia executable";
+                CustomXeniaExecutableSelector.Filter = "Supported Files|*.exe";
+                bool? CustomXeniaExecutableSelectorResult = CustomXeniaExecutableSelector.ShowDialog();
+                if (CustomXeniaExecutableSelectorResult == true)
+                {
+                    Log.Information($"Selected Xenia executable: {CustomXeniaExecutableSelector.FileName}");
+                    game.EmulatorVersion = "Custom";
+                    game.EmulatorExecutableLocation = CustomXeniaExecutableSelector.FileName;
+
+                    // Trying to find the appropriate configuration file next to the emulator executable
+                    Log.Information("Trying to find the configuration file");
+                    if (File.Exists(Path.Combine(Path.GetDirectoryName(CustomXeniaExecutableSelector.FileName), $"{Path.GetFileNameWithoutExtension(CustomXeniaExecutableSelector.FileName).Replace('_','-')}.config.toml")))
+                    {
+                        Log.Information($"Found configuration file: {Path.Combine(Path.GetDirectoryName(CustomXeniaExecutableSelector.FileName), $"{Path.GetFileNameWithoutExtension(CustomXeniaExecutableSelector.FileName).Replace('_', '-')}.config.toml")}");
+                        game.ConfigFilePath = Path.Combine(Path.GetDirectoryName(CustomXeniaExecutableSelector.FileName), $"{Path.GetFileNameWithoutExtension(CustomXeniaExecutableSelector.FileName).Replace('_', '-')}.config.toml");
+                    }
+                    else
+                    {
+                        // Incase it can't find it, ask user to find it himself
+                        Log.Information($"Not able to find a configuration file");
+                        OpenFileDialog CustomXeniaConfigurationSelector = new OpenFileDialog();
+                        CustomXeniaConfigurationSelector.Title = "Select Xenia configuration file";
+                        CustomXeniaConfigurationSelector.Filter = "Supported Files|*.toml";
+                        bool? CustomXeniaConfigurationSelectorResult = CustomXeniaConfigurationSelector.ShowDialog();
+                        if (CustomXeniaConfigurationSelectorResult == true)
+                        {
+                            Log.Information($"Selected configuration file: {CustomXeniaConfigurationSelector.FileName}");
+                            game.ConfigFilePath = CustomXeniaConfigurationSelector.FileName;
+                        }
+                        else
+                        {
+                            game.ConfigFilePath = null;
+                        }
+                    }
+                }
+                //await TransferGame(game, game.EmulatorVersion, "Custom", sourceEmulatorLocation, App.appConfiguration.XeniaNetplay.EmulatorLocation, App.appConfiguration.XeniaNetplay.ConfigurationFileLocation);
                 await CheckXeniaVersion();
                 MessageBox.Show($"{game.Title} transfer is complete. Now the game will use Xenia {game.EmulatorVersion}.");
             }

--- a/Xenia Manager/Windows/EditGamePatch.xaml
+++ b/Xenia Manager/Windows/EditGamePatch.xaml
@@ -5,6 +5,8 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:Xenia_Manager.Windows"
         mc:Ignorable="d"
+        AutomationProperties.Name="Edit Game Patch"
+        AutomationProperties.HelpText="Used for enabling or disabling game patches"
         Title="Xenia Manager - Edit Game Patch"
         Height="440" Width="418" MinWidth="500" MinHeight="500"
         WindowStyle="None" ResizeMode="NoResize"
@@ -38,6 +40,8 @@
                 <!-- Close button -->
                 <Button Grid.Column="1" 
                         x:Name="Exit"
+                        AutomationProperties.Name="Close Button"
+                        AutomationProperties.HelpText="Closes Edit Game Patch window and saves changes"
                         Content="&#xE711;"
                         HorizontalAlignment="Right"
                         Style="{StaticResource TitleBarButton}"
@@ -75,6 +79,8 @@
                                                 </TextBlock.ToolTip>
                                         </TextBlock>
                                             <CheckBox Grid.Column="1"
+                                                      AutomationProperties.Name="{Binding Name}"
+                                                      AutomationProperties.HelpText="{Binding Description}"
                                                       IsChecked="{Binding IsEnabled}"
                                                       Margin="10,10,10,10"
                                                       Style="{StaticResource CheckboxStyle}"/>

--- a/Xenia Manager/Windows/InstallContent.xaml
+++ b/Xenia Manager/Windows/InstallContent.xaml
@@ -5,6 +5,8 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:Xenia_Manager.Windows"
         mc:Ignorable="d"
+        AutomationProperties.Name="Install Content"
+        AutomationProperties.HelpText="Displays all of the content selected for installation"
         Title="Xenia Manager - Install Content" 
         Height="550" Width="800"
         WindowStyle="None" ResizeMode="NoResize"
@@ -44,6 +46,8 @@
                 <!-- Close button -->
                 <Button x:Name="Exit" 
                         Grid.Column="1" 
+                        AutomationProperties.Name="Close Button"
+                        AutomationProperties.HelpText="Closes Install Content window"
                         Content="&#xE711;"
                         HorizontalAlignment="Right"
                         Style="{StaticResource TitleBarButton}"
@@ -77,6 +81,8 @@
                 <!-- Confirm button -->
                 <Button x:Name="Confirm" 
                         Grid.Column="0"
+                        AutomationProperties.Name="Confirm Button"
+                        AutomationProperties.HelpText="Clicking this installs the selected content"
                         HorizontalAlignment="Center"
                         Margin="0,5"
                         Style="{StaticResource ButtonStyle}" 
@@ -91,6 +97,8 @@
                 <!-- Remove button -->
                 <Button x:Name="Remove" 
                         Grid.Column="1"
+                        AutomationProperties.Name="Remove Button"
+                        AutomationProperties.HelpText="Used to remove items you accidentally added for installation. Select the content from the ListBox (You can multiselect) and press Remove button to remove the items"
                         HorizontalAlignment="Center"
                         Margin="0,5"
                         Style="{StaticResource ButtonStyle}"

--- a/Xenia Manager/Windows/MainWindow.xaml
+++ b/Xenia Manager/Windows/MainWindow.xaml
@@ -26,6 +26,21 @@
             <Border Grid.Row="0" 
                     CornerRadius="10,10,0,0">
                 <Grid>
+                    <!-- Open Repository Button -->
+                    <Button x:Name="OpenRepository"
+                            Grid.Column="0"
+                            Content="&#xED15;"
+                            HorizontalAlignment="Left"
+                            Margin="21,0,0,0"
+                            Style="{StaticResource TitleBarButton}"
+                            Click="OpenRepository_Click">
+                        <Button.ToolTip>
+                            <TextBlock TextAlignment="Left">
+                                Opens the repository page in the default web browser
+                            </TextBlock>
+                        </Button.ToolTip>
+                    </Button>
+
                     <!-- Title text -->
                     <TextBlock FontFamily="{StaticResource SegoeFluent}"
                                FontSize="36"

--- a/Xenia Manager/Windows/MainWindow.xaml
+++ b/Xenia Manager/Windows/MainWindow.xaml
@@ -5,6 +5,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:Xenia_Manager"
         mc:Ignorable="d"
+        AutomationProperties.Name="Main Xenia Manager"
         Title="Xenia Manager"
         Width="885" Height="720" WindowStyle="None"
         ResizeMode="NoResize" WindowStartupLocation="CenterScreen"
@@ -29,6 +30,7 @@
                     <!-- Open Repository Button -->
                     <Button x:Name="OpenRepository"
                             Grid.Column="0"
+                            AutomationProperties.Name="Open Repository Button"
                             Content="&#xED15;"
                             HorizontalAlignment="Left"
                             Margin="21,0,0,0"
@@ -58,6 +60,8 @@
                         <!-- Maximize Button -->
                         <Button x:Name="Maximize"
                                 Grid.Column="0"
+                                AutomationProperties.Name="Maximize Button"
+                                AutomationProperties.HelpText="Maximizes the application window"
                                 Content="&#xE923;"
                                 Style="{StaticResource TitleBarButton}"
                                 Click="Maximize_Click"/>
@@ -65,6 +69,8 @@
                         <!-- Exit Button -->
                         <Button x:Name="Exit"
                                 Grid.Column="1"
+                                AutomationProperties.Name="Exit Button"
+                                AutomationProperties.HelpText="Closes the application"
                                 Content="&#xE711;"
                                 Style="{StaticResource TitleBarButton}"
                                 Click="Exit_Click"/>
@@ -95,6 +101,8 @@
                                         VerticalAlignment="Stretch">
                                 <!-- Home button -->
                                 <Button x:Name="Home"
+                                        AutomationProperties.Name="Home Button"
+                                        AutomationProperties.HelpText="Opens the main library page containing all of the available games"
                                         Margin="0,10"
                                         Style="{StaticResource NavigationButton}"
                                         Click="Home_Click">
@@ -120,6 +128,8 @@
 
                                 <!-- Xenia Settings button -->
                                 <Button x:Name="XeniaSettings"
+                                        AutomationProperties.Name="Xenia Settings Button"
+                                        AutomationProperties.HelpText="Opens the Xenia Settings page containing most of the general settings"
                                         Style="{StaticResource NavigationButton}"
                                         Click="XeniaSettings_Click">
                                     <Button.Content>
@@ -144,6 +154,8 @@
 
                                 <!-- Settings button -->
                                 <Button x:Name="Settings"
+                                        AutomationProperties.Name="Settings Button"
+                                        AutomationProperties.HelpText="Opens the settings page containing all of the settings for Xenia Manager"
                                         Style="{StaticResource NavigationButton}"
                                         Click="Settings_Click">
                                     <Button.Content>
@@ -170,6 +182,8 @@
                             <!-- Update button -->
                             <Button x:Name="Update"
                                     Grid.Row="1"
+                                    AutomationProperties.Name="Update Button"
+                                    AutomationProperties.HelpText="Updates Xenia Manager to the latest version"
                                     Margin="0,0,0,5"
                                     Style="{StaticResource NavigationButton}"
                                     VerticalAlignment="Bottom"

--- a/Xenia Manager/Windows/MainWindow.xaml.cs
+++ b/Xenia Manager/Windows/MainWindow.xaml.cs
@@ -283,6 +283,18 @@ namespace Xenia_Manager
         }
 
         /// <summary>
+        /// Opens the repository page in the primary browser
+        /// </summary>
+        private void OpenRepository_Click(object sender, RoutedEventArgs e)
+        {
+            Process.Start(new ProcessStartInfo
+            {
+                FileName = "https://www.github.com/xenia-manager/xenia-manager/",
+                UseShellExecute = true,
+            });
+        }
+
+        /// <summary>
         /// Maximizes the Xenia Manager window
         /// </summary>
         private async void Maximize_Click(object sender, RoutedEventArgs e)

--- a/Xenia Manager/Windows/SelectGame.xaml
+++ b/Xenia Manager/Windows/SelectGame.xaml
@@ -5,6 +5,8 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:Xenia_Manager.Windows"
         mc:Ignorable="d"
+        AutomationProperties.Name="Select Game"
+        AutomationProperties.HelpText="Here, the user selects the game they want to add"
         Title="Xenia Manager - Select Game"
         Height="640" Width="418" MinWidth="500" MinHeight="500"
         WindowStyle="None" ResizeMode="NoResize"
@@ -33,6 +35,8 @@
                 
                 <!-- SearchBox -->
                 <TextBox x:Name="SearchBox"
+                         AutomationProperties.Name="Game Title SearchBox"
+                         AutomationProperties.HelpText="If Xenia Manager can't find the game you are looking for, type the game title in this searchbox to search for it manually"
                          Style="{StaticResource SearchBox}"
                          TextChanged="SearchBox_TextChanged">
                     <TextBox.Resources>
@@ -45,6 +49,8 @@
                 <!-- Exit button -->
                 <Button Grid.Column="1" 
                         x:Name="Exit"
+                        AutomationProperties.Name="Close Button"
+                        AutomationProperties.HelpText="Closes Select Game window. It will prompt the user if he wants to use the default disc icon (Press Yes) or to cancel the adding of the game process (Press No)."
                         Content="&#xE711;"
                         Style="{StaticResource TitleBarButton}"
                         Click="Exit_Click"/>
@@ -58,6 +64,8 @@
                         Orientation="Vertical">
                 <!-- Lists Selector -->
                 <ComboBox x:Name="SourceSelector"
+                          AutomationProperties.Name="Game Sources"
+                          AutomationProperties.HelpText="Different sources for trying to find your game (Xbox Marketplace is the biggest and best out of all of them)"
                           FontSize="18"
                           HorizontalContentAlignment="Center"
                           Margin="100,10,100,10"               

--- a/Xenia Manager/Windows/SelectGamePatch.xaml
+++ b/Xenia Manager/Windows/SelectGamePatch.xaml
@@ -5,6 +5,8 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:Xenia_Manager.Windows"
         mc:Ignorable="d"
+        AutomationProperties.Name="Select Game Patch"
+        AutomationProperties.HelpText="This window is used for installing game patches"
         Title="Xenia Manager - Select Game Patch"
         Height="440" Width="418" MinWidth="500" MinHeight="500"
         WindowStyle="None" ResizeMode="NoResize"
@@ -32,12 +34,16 @@
 
                 <!-- SearchBox -->
                 <TextBox x:Name="SearchBox"
+                         AutomationProperties.Name="Game Title SearchBox"
+                         AutomationProperties.HelpText="If Xenia Manager can't find the game patch you are looking for, you can try typing the game title yourself"
                          Style="{StaticResource SearchBox}"
                          TextChanged="SearchBox_TextChanged"/>
 
                 <!-- Exit button -->
                 <Button x:Name="Exit"
                         Grid.Column="1" 
+                        AutomationProperties.Name="Close Button"
+                        AutomationProperties.HelpText="Closes Select Game Patch window"
                         Content="&#xE711;"
                         Margin="0,0,10,0"
                         Style="{StaticResource TitleBarButton}"

--- a/Xenia Manager/Windows/ShowInstalledContent.xaml
+++ b/Xenia Manager/Windows/ShowInstalledContent.xaml
@@ -5,6 +5,8 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:Xenia_Manager.Windows"
         mc:Ignorable="d"
+        AutomationProperties.Name="Installed Content"
+        AutomationProperties.HelpText="Displays all of the content the selected game has"
         Title="ShowInstalledContent" 
         Height="600" Width="500"
         WindowStyle="None" ResizeMode="NoResize"
@@ -46,6 +48,8 @@
                 <!-- Close button -->
                 <Button Grid.Column="1" 
                         x:Name="Exit"
+                        AutomationProperties.Name="Close Button"
+                        AutomationProperties.HelpText="Closes Installed Content window"
                         Content="&#xE711;"
                         HorizontalAlignment="Right"
                         Style="{StaticResource TitleBarButton}"
@@ -65,6 +69,8 @@
                 
                 <!-- List of content types -->
                 <ComboBox x:Name="ContentTypeList"
+                          AutomationProperties.Name="Content Types"
+                          AutomationProperties.HelpText="This is used to display different content types (Saved Games, DLC's...)"
                           FontSize="20"
                           Margin="10,10,10,10"
                           Style="{StaticResource ComboBoxStyle}"
@@ -73,6 +79,7 @@
                 <!-- Open Folder button -->
                 <Button x:Name="OpenDirectory" 
                         Grid.Column="1"
+                        AutomationProperties.HelpText="Opens the selected Content Type folder in the Windows Explorer"
                         HorizontalAlignment="Center"
                         Margin="0,5"
                         Style="{StaticResource ButtonStyle}"
@@ -92,6 +99,8 @@
             
             <!-- List of installed content -->
             <ListBox x:Name="InstalledContentList"
+                     AutomationProperties.Name="Content List"
+                     AutomationProperties.HelpText="Displays all of the content in the selected Content Type folder"
                      Grid.Row="4" 
                      Margin="17,0,0,0"
                      ScrollViewer.VerticalScrollBarVisibility="Visible"
@@ -113,6 +122,7 @@
                   Grid.Row="6">
                 <!-- Delete button -->
                 <Button x:Name="Delete"
+                        AutomationProperties.HelpText="Delete's the selected folders from the content folder"
                         HorizontalAlignment="Center"
                         Margin="0,5"
                         Style="{StaticResource ButtonStyle}"
@@ -136,6 +146,7 @@
                 <!-- Import button -->
                 <Button x:Name="Import" 
                         Grid.Column="0"
+                        AutomationProperties.HelpText="Imports the save game (Has to have specific folder structure, similar to game saves found on xenia's game-saves repository)"
                         HorizontalAlignment="Center"
                         Margin="0,5"
                         Style="{StaticResource ButtonStyle}"
@@ -150,6 +161,7 @@
                 <!-- Export button -->
                 <Button x:Name="Export" 
                         Grid.Column="1"
+                        AutomationProperties.HelpText="Exports the save files into a zip folder (Follows the folder structure found in Xenia's game saves folder"
                         HorizontalAlignment="Center"
                         Margin="0,5"
                         Style="{StaticResource ButtonStyle}"

--- a/Xenia Manager/Windows/WelcomeDialog.xaml
+++ b/Xenia Manager/Windows/WelcomeDialog.xaml
@@ -5,6 +5,8 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:Xenia_Manager.Windows"
         mc:Ignorable="d"
+        AutomationProperties.Name="Install Xenia"
+        AutomationProperties.HelpText="Used for Installing and uninstalling different Xenia Versions"
         Title="Xenia Manager - Welcome Dialog"
         Height="440" Width="418" MinWidth="500" MinHeight="500"
         WindowStyle="None" ResizeMode="NoResize" Topmost="True"
@@ -33,6 +35,8 @@
             <!-- Close button -->
             <Button Grid.Row="0"
                     x:Name="Exit"
+                    AutomationProperties.Name="Close Button"
+                    AutomationProperties.HelpText="Closes Xenia Installer window"
                     Content="&#xE711;"
                     HorizontalAlignment="Right"
                     Margin="0,0,10,0"
@@ -49,6 +53,8 @@
                       Margin="80,100,80,10">
                     <!-- Install Xenia Stable Button -->
                     <Button x:Name="InstallXeniaStable"
+                            AutomationProperties.Name="Install Xenia Stable Button"
+                            AutomationProperties.HelpText="Installs Xenia Stable"
                             Content="Install Xenia Stable"
                             FontSize="20"
                             Style="{StaticResource WD_Install_Button}"
@@ -56,6 +62,8 @@
 
                     <!-- Uninstall Xenia Stable Button -->
                     <Button x:Name="UninstallXeniaStable"
+                            AutomationProperties.Name="Uninstall Xenia Stable Button"
+                            AutomationProperties.HelpText="Uninstalls Xenia Stable"
                             Content="Uninstall Xenia Stable"
                             FontSize="20"
                             Style="{StaticResource WD_Install_Button}"
@@ -66,6 +74,8 @@
                       Margin="80,10,80,10">
                     <!-- Install Xenia Canary Button -->
                     <Button x:Name="InstallXeniaCanary"
+                            AutomationProperties.Name="Install Xenia Canary Button"
+                            AutomationProperties.HelpText="Installs Xenia Canary"
                             Content="Install Xenia Canary"
                             FontSize="20"
                             Style="{StaticResource WD_Install_Button}"
@@ -73,6 +83,8 @@
 
                     <!-- Uninstall Xenia Canary Button -->
                     <Button x:Name="UninstallXeniaCanary"
+                            AutomationProperties.Name="Uninstall Xenia Canary Button"
+                            AutomationProperties.HelpText="Uninstalls Xenia Canary"
                             Content="Uninstall Xenia Canary"
                             FontSize="20"
                             Style="{StaticResource WD_Install_Button}"
@@ -83,6 +95,8 @@
                       Margin="80,10,80,10">
                     <!-- Install Xenia Netplay Button -->
                     <Button x:Name="InstallXeniaNetplay"
+                            AutomationProperties.Name="Install Xenia Netplay Button"
+                            AutomationProperties.HelpText="Installs Xenia Netplay"
                             Content="Install Xenia Netplay"
                             FontSize="20"
                             Style="{StaticResource WD_Install_Button}"
@@ -90,6 +104,8 @@
 
                     <!-- Uninstall Xenia Netplay Button -->
                     <Button x:Name="UninstallXeniaNetplay"
+                            AutomationProperties.Name="Uninstall Xenia Netplay Button"
+                            AutomationProperties.HelpText="Uninstalls Xenia Netplay"
                             Content="Uninstall Xenia Netplay"
                             FontSize="20"
                             Style="{StaticResource WD_Install_Button}"

--- a/Xenia Manager/Xenia Manager.csproj
+++ b/Xenia Manager/Xenia Manager.csproj
@@ -9,8 +9,8 @@
     <UseWPF>true</UseWPF>
     <PlatformTarget>x64</PlatformTarget>
 	<NoWarn>CS8604, CS8602, CS8600</NoWarn>
-	<AssemblyVersion>1.10.0</AssemblyVersion>
-	<FileVersion>1.10.0</FileVersion>
+	<AssemblyVersion>1.11.0</AssemblyVersion>
+	<FileVersion>1.11.0</FileVersion>
 	<ApplicationIcon>Assets\icon.ico</ApplicationIcon>
   </PropertyGroup>
 


### PR DESCRIPTION
- Added "Copy Settings" button (This will be used to copy all of the current settings from the appropriate default configuration file to the selected game's configuration file)
- Added option to Switch to Custom Xenia build (You lose some features when you do this, might add support for them in the future)
- Added reading of MediaID for games (For future purpose)
- Improvement to checking if image URL's are working (Now it'll check if the url will serve image or something else instead of it just checking if the URL works)
- Xenia Manager won't ignore games that have same game title, it will just act like Windows (add a number at the end of game title)
- When deleting games, Xenia Manager will ask the user if he also wants to delete the content folder of that game (if it exists)
- Added "Open Repository" button to the Main Window 
- Added Text To Speech support to the UI (Tested it with Windows Narrator)