### PR TITLE
Editing Game Improvements

### DIFF
--- a/Xenia Manager/Classes/JSONParse.cs
+++ b/Xenia Manager/Classes/JSONParse.cs
@@ -89,15 +89,11 @@ namespace Xenia_Manager.Classes
         [JsonProperty("Title")]
         public string? Title { get; set; }
 
-        // This is for Andy Declari's JSON file
-        [JsonProperty("Front")]
-        public CoverDetails? Front { get; set; }
-
-        [JsonProperty("Back")]
-        public CoverDetails? Back { get; set; }
+        // This is for Launchbox Database
+        [JsonProperty("Artwork")]
+        public Artwork Artwork { get; set; }
 
         // This is for Wikipedia JSON file
-
         [JsonProperty("Link")]
         public string? Link { get; set; }
 
@@ -113,15 +109,18 @@ namespace Xenia_Manager.Classes
     }
 
     /// <summary>
-    /// This is for CoverDetails (Andy Declari's JSON file)
+    /// This holds different artworks from Launchbox Database
     /// </summary>
-    public class CoverDetails
+    public class Artwork
     {
-        [JsonProperty("Full Size")]
-        public string? FullSize { get; set; }
+        [JsonProperty("Front Image")]
+        public string? Boxart { get; set; }
 
-        [JsonProperty("Thumbnail")]
-        public string? Thumbnail { get; set; }
+        [JsonProperty("Disc")]
+        public string? Disc { get; set; }
+
+        [JsonProperty("Logo")]
+        public string? Logo { get; set; }
     }
 
     /// <summary>

--- a/Xenia Manager/Classes/JSONParse.cs
+++ b/Xenia Manager/Classes/JSONParse.cs
@@ -112,6 +112,9 @@ namespace Xenia_Manager.Classes
 
         [JsonProperty("Box art")]
         public string? BoxArt { get; set; }
+
+        [JsonProperty("Icon")]
+        public string? Icon { get; set; }
     }
 
     /// <summary>

--- a/Xenia Manager/Classes/JSONParse.cs
+++ b/Xenia Manager/Classes/JSONParse.cs
@@ -39,7 +39,7 @@ namespace Xenia_Manager.Classes
         /// The file path to the game's icon
         /// </summary>
         [JsonProperty("icon")]
-        public string? IconFilePath { get; set; }
+        public string? BoxartFilePath { get; set; }
 
         /// <summary>
         /// The file path to the game's icon

--- a/Xenia Manager/Classes/JSONParse.cs
+++ b/Xenia Manager/Classes/JSONParse.cs
@@ -36,16 +36,22 @@ namespace Xenia_Manager.Classes
         public string? GameCompatibilityURL { get; set; }
 
         /// <summary>
-        /// The file path to the game's icon
+        /// The file path to the game's boxart
         /// </summary>
         [JsonProperty("icon")]
         public string? BoxartFilePath { get; set; }
 
         /// <summary>
-        /// The file path to the game's icon
+        /// The file path to the game's cached boxart
         /// </summary>
         [JsonProperty("cached_icon")]
         public string? CachedIconPath { get; set; }
+
+        /// <summary>
+        /// The file path to the game's shortcut icon
+        /// </summary>
+        [JsonProperty("shortcut_icon")]
+        public string? ShortcutIconFilePath { get; set; }
 
         /// <summary>
         /// The file path to the game's ISO file

--- a/Xenia Manager/Pages/Library.xaml.cs
+++ b/Xenia Manager/Pages/Library.xaml.cs
@@ -712,25 +712,34 @@ namespace Xenia_Manager.Pages
             // Add "Add shortcut to desktop" option
             contextMenu.Items.Add(CreateMenuItem("Add shortcut to desktop", null, (sender, e) =>
             {
+                string IconLocation;
+                if (game.ShortcutIconFilePath != null)
+                {
+                    IconLocation = game.ShortcutIconFilePath;
+                }
+                else
+                {
+                    IconLocation = game.BoxartFilePath;
+                }
                 switch (game.EmulatorVersion)
                 {
                     case "Stable":
-                        ShortcutCreator.CreateShortcutOnDesktop(game.Title, Path.Combine(App.baseDirectory, App.appConfiguration.XeniaStable.ExecutableLocation), Path.Combine(App.baseDirectory, App.appConfiguration.XeniaStable.EmulatorLocation), $@"""{game.GameFilePath}"" --config ""{Path.Combine(App.baseDirectory, game.ConfigFilePath)}""", Path.Combine(App.baseDirectory, game.BoxartFilePath));
+                        ShortcutCreator.CreateShortcutOnDesktop(game.Title, Path.Combine(App.baseDirectory, App.appConfiguration.XeniaStable.ExecutableLocation), Path.Combine(App.baseDirectory, App.appConfiguration.XeniaStable.EmulatorLocation), $@"""{game.GameFilePath}"" --config ""{Path.Combine(App.baseDirectory, game.ConfigFilePath)}""", Path.Combine(App.baseDirectory, IconLocation));
                         break;
                     case "Canary":
-                        ShortcutCreator.CreateShortcutOnDesktop(game.Title, Path.Combine(App.baseDirectory, App.appConfiguration.XeniaCanary.ExecutableLocation), Path.Combine(App.baseDirectory, App.appConfiguration.XeniaCanary.EmulatorLocation), $@"""{game.GameFilePath}"" --config ""{Path.Combine(App.baseDirectory, game.ConfigFilePath)}""", Path.Combine(App.baseDirectory, game.BoxartFilePath));
+                        ShortcutCreator.CreateShortcutOnDesktop(game.Title, Path.Combine(App.baseDirectory, App.appConfiguration.XeniaCanary.ExecutableLocation), Path.Combine(App.baseDirectory, App.appConfiguration.XeniaCanary.EmulatorLocation), $@"""{game.GameFilePath}"" --config ""{Path.Combine(App.baseDirectory, game.ConfigFilePath)}""", Path.Combine(App.baseDirectory, IconLocation));
                         break;
                     case "Netplay":
-                        ShortcutCreator.CreateShortcutOnDesktop(game.Title, Path.Combine(App.baseDirectory, App.appConfiguration.XeniaNetplay.ExecutableLocation), Path.Combine(App.baseDirectory, App.appConfiguration.XeniaNetplay.EmulatorLocation), $@"""{game.GameFilePath}"" --config ""{Path.Combine(App.baseDirectory, game.ConfigFilePath)}""", Path.Combine(App.baseDirectory, game.BoxartFilePath));
+                        ShortcutCreator.CreateShortcutOnDesktop(game.Title, Path.Combine(App.baseDirectory, App.appConfiguration.XeniaNetplay.ExecutableLocation), Path.Combine(App.baseDirectory, App.appConfiguration.XeniaNetplay.EmulatorLocation), $@"""{game.GameFilePath}"" --config ""{Path.Combine(App.baseDirectory, game.ConfigFilePath)}""", Path.Combine(App.baseDirectory, IconLocation));
                         break;
                     case "Custom":
                         if (game.GameFilePath != null)
                         {
-                            ShortcutCreator.CreateShortcutOnDesktop(game.Title, game.EmulatorExecutableLocation, Path.GetDirectoryName(game.EmulatorExecutableLocation), $@"""{game.GameFilePath}"" --config ""{game.ConfigFilePath}""", Path.Combine(App.baseDirectory, game.BoxartFilePath));
+                            ShortcutCreator.CreateShortcutOnDesktop(game.Title, game.EmulatorExecutableLocation, Path.GetDirectoryName(game.EmulatorExecutableLocation), $@"""{game.GameFilePath}"" --config ""{game.ConfigFilePath}""", Path.Combine(App.baseDirectory, IconLocation));
                         }
                         else
                         {
-                            ShortcutCreator.CreateShortcutOnDesktop(game.Title, game.EmulatorExecutableLocation, Path.GetDirectoryName(game.EmulatorExecutableLocation), $@"""{game.GameFilePath}""", Path.Combine(App.baseDirectory, game.BoxartFilePath));
+                            ShortcutCreator.CreateShortcutOnDesktop(game.Title, game.EmulatorExecutableLocation, Path.GetDirectoryName(game.EmulatorExecutableLocation), $@"""{game.GameFilePath}""", Path.Combine(App.baseDirectory, IconLocation));
                         };
                         break;
                     default:

--- a/Xenia Manager/Pages/Library.xaml.cs
+++ b/Xenia Manager/Pages/Library.xaml.cs
@@ -152,7 +152,7 @@ namespace Xenia_Manager.Pages
         private async Task<BitmapImage> LoadOrCacheIcon(InstalledGame game)
         {
             await Task.Delay(1);
-            string iconFilePath = Path.Combine(App.baseDirectory, game.IconFilePath); // Path to the game icon
+            string iconFilePath = Path.Combine(App.baseDirectory, game.BoxartFilePath); // Path to the game icon
             string cacheDirectory = Path.Combine(App.baseDirectory, @"Icons\Cache\"); // Path to the cached directory
 
             // Tries to find cached icon
@@ -311,10 +311,10 @@ namespace Xenia_Manager.Pages
                 };
 
                 // Remove game icon
-                if (game.IconFilePath != null && File.Exists(Path.Combine(App.baseDirectory, game.IconFilePath)))
+                if (game.BoxartFilePath != null && File.Exists(Path.Combine(App.baseDirectory, game.BoxartFilePath)))
                 {
-                    File.Delete(Path.Combine(App.baseDirectory, game.IconFilePath));
-                    Log.Information($"Deleted icon: {Path.Combine(App.baseDirectory, game.IconFilePath)}");
+                    File.Delete(Path.Combine(App.baseDirectory, game.BoxartFilePath));
+                    Log.Information($"Deleted icon: {Path.Combine(App.baseDirectory, game.BoxartFilePath)}");
                 };
 
                 // Check if there is any content
@@ -715,22 +715,22 @@ namespace Xenia_Manager.Pages
                 switch (game.EmulatorVersion)
                 {
                     case "Stable":
-                        ShortcutCreator.CreateShortcutOnDesktop(game.Title, Path.Combine(App.baseDirectory, App.appConfiguration.XeniaStable.ExecutableLocation), Path.Combine(App.baseDirectory, App.appConfiguration.XeniaStable.EmulatorLocation), $@"""{game.GameFilePath}"" --config ""{Path.Combine(App.baseDirectory, game.ConfigFilePath)}""", Path.Combine(App.baseDirectory, game.IconFilePath));
+                        ShortcutCreator.CreateShortcutOnDesktop(game.Title, Path.Combine(App.baseDirectory, App.appConfiguration.XeniaStable.ExecutableLocation), Path.Combine(App.baseDirectory, App.appConfiguration.XeniaStable.EmulatorLocation), $@"""{game.GameFilePath}"" --config ""{Path.Combine(App.baseDirectory, game.ConfigFilePath)}""", Path.Combine(App.baseDirectory, game.BoxartFilePath));
                         break;
                     case "Canary":
-                        ShortcutCreator.CreateShortcutOnDesktop(game.Title, Path.Combine(App.baseDirectory, App.appConfiguration.XeniaCanary.ExecutableLocation), Path.Combine(App.baseDirectory, App.appConfiguration.XeniaCanary.EmulatorLocation), $@"""{game.GameFilePath}"" --config ""{Path.Combine(App.baseDirectory, game.ConfigFilePath)}""", Path.Combine(App.baseDirectory, game.IconFilePath));
+                        ShortcutCreator.CreateShortcutOnDesktop(game.Title, Path.Combine(App.baseDirectory, App.appConfiguration.XeniaCanary.ExecutableLocation), Path.Combine(App.baseDirectory, App.appConfiguration.XeniaCanary.EmulatorLocation), $@"""{game.GameFilePath}"" --config ""{Path.Combine(App.baseDirectory, game.ConfigFilePath)}""", Path.Combine(App.baseDirectory, game.BoxartFilePath));
                         break;
                     case "Netplay":
-                        ShortcutCreator.CreateShortcutOnDesktop(game.Title, Path.Combine(App.baseDirectory, App.appConfiguration.XeniaNetplay.ExecutableLocation), Path.Combine(App.baseDirectory, App.appConfiguration.XeniaNetplay.EmulatorLocation), $@"""{game.GameFilePath}"" --config ""{Path.Combine(App.baseDirectory, game.ConfigFilePath)}""", Path.Combine(App.baseDirectory, game.IconFilePath));
+                        ShortcutCreator.CreateShortcutOnDesktop(game.Title, Path.Combine(App.baseDirectory, App.appConfiguration.XeniaNetplay.ExecutableLocation), Path.Combine(App.baseDirectory, App.appConfiguration.XeniaNetplay.EmulatorLocation), $@"""{game.GameFilePath}"" --config ""{Path.Combine(App.baseDirectory, game.ConfigFilePath)}""", Path.Combine(App.baseDirectory, game.BoxartFilePath));
                         break;
                     case "Custom":
                         if (game.GameFilePath != null)
                         {
-                            ShortcutCreator.CreateShortcutOnDesktop(game.Title, game.EmulatorExecutableLocation, Path.GetDirectoryName(game.EmulatorExecutableLocation), $@"""{game.GameFilePath}"" --config ""{game.ConfigFilePath}""", Path.Combine(App.baseDirectory, game.IconFilePath));
+                            ShortcutCreator.CreateShortcutOnDesktop(game.Title, game.EmulatorExecutableLocation, Path.GetDirectoryName(game.EmulatorExecutableLocation), $@"""{game.GameFilePath}"" --config ""{game.ConfigFilePath}""", Path.Combine(App.baseDirectory, game.BoxartFilePath));
                         }
                         else
                         {
-                            ShortcutCreator.CreateShortcutOnDesktop(game.Title, game.EmulatorExecutableLocation, Path.GetDirectoryName(game.EmulatorExecutableLocation), $@"""{game.GameFilePath}""", Path.Combine(App.baseDirectory, game.IconFilePath));
+                            ShortcutCreator.CreateShortcutOnDesktop(game.Title, game.EmulatorExecutableLocation, Path.GetDirectoryName(game.EmulatorExecutableLocation), $@"""{game.GameFilePath}""", Path.Combine(App.baseDirectory, game.BoxartFilePath));
                         };
                         break;
                     default:

--- a/Xenia Manager/Pages/Library.xaml.cs
+++ b/Xenia Manager/Pages/Library.xaml.cs
@@ -310,12 +310,19 @@ namespace Xenia_Manager.Pages
                     Log.Information($"Deleted configuration file: {Path.Combine(App.baseDirectory, game.ConfigFilePath)}");
                 };
 
-                // Remove game icon
+                // Remove game boxart
                 if (game.BoxartFilePath != null && File.Exists(Path.Combine(App.baseDirectory, game.BoxartFilePath)))
                 {
                     File.Delete(Path.Combine(App.baseDirectory, game.BoxartFilePath));
-                    Log.Information($"Deleted icon: {Path.Combine(App.baseDirectory, game.BoxartFilePath)}");
+                    Log.Information($"Deleted boxart: {Path.GetFileName(Path.Combine(App.baseDirectory, game.BoxartFilePath))}");
                 };
+
+                // Remove game icon
+                if (game.ShortcutIconFilePath != null && File.Exists(Path.Combine(App.baseDirectory, game.ShortcutIconFilePath)))
+                {
+                    File.Delete(Path.Combine(App.baseDirectory, game.ShortcutIconFilePath));
+                    Log.Information($"Deleted icon: {Path.GetFileName(Path.Combine(App.baseDirectory, game.ShortcutIconFilePath))}");
+                }
 
                 // Check if there is any content
                 string GameContentFolder = game.EmulatorVersion switch

--- a/Xenia Manager/Windows/EditGameInfo.xaml
+++ b/Xenia Manager/Windows/EditGameInfo.xaml
@@ -61,16 +61,61 @@
                           HorizontalScrollBarVisibility="Disabled"
                           VerticalScrollBarVisibility="Visible">
                 <StackPanel Margin="17,0,0,0">
-                    <!-- Game Icon -->
-                    <Grid>
-                        <Button x:Name="GameIcon" 
-                                AutomationProperties.Name="Game Icon"
-                                AutomationProperties.HelpText="Clicking on it allows you to select another game icon you want to use"
+                    <Grid Margin="0,0,0,10">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition/>
+                            <ColumnDefinition/>
+                        </Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition/>
+                            <RowDefinition/>
+                        </Grid.RowDefinitions>
+                        <!-- Game Boxart -->
+                        <Button x:Name="GameBoxart" 
+                                Grid.Column="0"
+                                Grid.Row="0"
+                                AutomationProperties.Name="Game Boxart"
+                                AutomationProperties.HelpText="Clicking on it allows you to select another game boxart you want to use"
                                 Cursor="Hand"
                                 Height="207"
                                 Margin="0,10"
                                 Style="{StaticResource GameCoverButtons}"
                                 Width="150"
+                                Click="GameBoxart_Click">
+                            <Button.ToolTip>
+                                <ToolTip>
+                                    <TextBlock TextAlignment="Left">
+                                        Click on the boxart to change it
+                                        <LineBreak/>
+                                        <TextBlock Text="NOTE:" 
+                                                   FontWeight="Bold"/>
+                                        Xenia Manager uses 150x207 boxart. 
+                                        <LineBreak/>
+                                        When adding a new boxart it will auto scale it so it fits the button and fill the unused space.
+                                    </TextBlock>
+                                </ToolTip>
+                            </Button.ToolTip>
+                        </Button>
+
+                        <!-- Text under Boxart -->
+                        <TextBlock Grid.Column="0" 
+                                   Grid.Row="1"
+                                   FontSize="24" 
+                                   Style="{StaticResource SettingText}">
+                            Boxart
+                        </TextBlock>
+
+                        <!-- Game Boxart -->
+                        <Button x:Name="GameIcon" 
+                                Grid.Column="1"
+                                Grid.Row="0"
+                                AutomationProperties.Name="Game Icon"
+                                AutomationProperties.HelpText="Clicking on it allows you to select another game icon you want to use"
+                                Cursor="Hand"
+                                Height="64"
+                                Margin="0,10"
+                                Style="{StaticResource GameCoverButtons}"
+                                Width="64"
                                 Click="GameIcon_Click">
                             <Button.ToolTip>
                                 <ToolTip>
@@ -79,13 +124,19 @@
                                         <LineBreak/>
                                         <TextBlock Text="NOTE:" 
                                                    FontWeight="Bold"/>
-                                        Xenia Manager uses 150x207 icons. 
-                                        <LineBreak/>
-                                        When adding a new icon it will auto scale it so it fits the button and fill the unused space.
+                                        By default, Xenia Manager creates 64x64 icons
                                     </TextBlock>
                                 </ToolTip>
                             </Button.ToolTip>
                         </Button>
+
+                        <!-- Text under Icon -->
+                        <TextBlock Grid.Column="1"
+                                   Grid.Row="1"
+                                   FontSize="24" 
+                                   Style="{StaticResource SettingText}">
+                            Icon
+                        </TextBlock>
                     </Grid>
 
                     <!-- Game ID -->

--- a/Xenia Manager/Windows/EditGameInfo.xaml.cs
+++ b/Xenia Manager/Windows/EditGameInfo.xaml.cs
@@ -285,7 +285,7 @@ namespace Xenia_Manager.Windows
         public async Task CacheIcon()
         {
             await Task.Delay(1);
-            string iconFilePath = Path.Combine(App.baseDirectory, game.IconFilePath); // Path to the game icon
+            string iconFilePath = Path.Combine(App.baseDirectory, game.BoxartFilePath); // Path to the game icon
             string cacheDirectory = Path.Combine(App.baseDirectory, @"Icons\Cache\"); // Path to the cached directory
 
             Log.Information("Creating new cached icon for the game");
@@ -384,8 +384,8 @@ namespace Xenia_Manager.Windows
                 game.Title = RemoveUnsupportedCharacters(GameTitle.Text);
 
                 Log.Information("Changing the name of icon");
-                File.Move(Path.Combine(App.baseDirectory, game.IconFilePath), Path.Combine(App.baseDirectory, $"Icons\\{game.Title}.ico"), true);
-                game.IconFilePath = $"Icons\\{game.Title}.ico";
+                File.Move(Path.Combine(App.baseDirectory, game.BoxartFilePath), Path.Combine(App.baseDirectory, $"Icons\\{game.Title}.ico"), true);
+                game.BoxartFilePath = $"Icons\\{game.Title}.ico";
             }
             catch (Exception ex)
             {

--- a/Xenia Manager/Windows/EditGameInfo.xaml.cs
+++ b/Xenia Manager/Windows/EditGameInfo.xaml.cs
@@ -23,7 +23,7 @@ namespace Xenia_Manager.Windows
     {
         // Selected game
         private InstalledGame game = new InstalledGame();
-
+        private string cachedShortcutIconPath;
         // Used to send a signal that this window has been closed
         private TaskCompletionSource<bool> _closeTaskCompletionSource = new TaskCompletionSource<bool>();
 
@@ -49,13 +49,13 @@ namespace Xenia_Manager.Windows
         /// <summary>
         /// Creates image for the button
         /// </summary>
-        /// <param name="game">Game itself</param>
+        /// <param name="imagePath">Path to the image that will be shown</param>
         /// <returns>Border - Content of the button</returns>
-        private async Task<Border> CreateButtonContent()
+        private async Task<Border> CreateButtonContent(string imagePath)
         {
             await Task.Delay(1);
             // Cached game icon
-            BitmapImage iconImage = new BitmapImage(new Uri(game.CachedIconPath));
+            BitmapImage iconImage = new BitmapImage(new Uri(imagePath));
             Image image = new Image
             {
                 Source = iconImage,
@@ -89,7 +89,16 @@ namespace Xenia_Manager.Windows
             {
                 GameID.Text = game.GameId;
                 GameTitle.Text = game.Title;
-                GameIcon.Content = await CreateButtonContent();
+                GameBoxart.Content = await CreateButtonContent(game.CachedIconPath);
+                if (game.ShortcutIconFilePath != null)
+                {
+                    await CacheImage(game.ShortcutIconFilePath, true);
+                    GameIcon.Content = await CreateButtonContent(cachedShortcutIconPath);
+                }
+                else
+                {
+                    GameIcon.Content = await CreateButtonContent(game.CachedIconPath);
+                }
                 await Task.Delay(1);
             }
             catch (Exception ex)
@@ -241,7 +250,7 @@ namespace Xenia_Manager.Windows
         /// <param name="width">Width of the box art. Default is 150</param>
         /// <param name="height">Height of the box art. Default is 207</param>
         /// <returns></returns>
-        private async Task GetGameBoxArtFromFile(string filePath, string outputPath, int width = 150, int height = 207)
+        private void GetIconFromFile(string filePath, string outputPath, int width = 150, int height = 207)
         {
             try
             {
@@ -280,29 +289,34 @@ namespace Xenia_Manager.Windows
         /// Checks if the game icon is cached
         /// <para>If the game icon is not cached, it'll cache it</para>
         /// </summary>
-        /// <param name="game">Game</param>
+        /// <param name="imagePath">Path to the image that needs caching</param>
         /// <returns >BitmapImage - cached game icon</returns>
-        public async Task CacheIcon()
+        public async Task CacheImage(string imagePath, bool shortcutIcon = false)
         {
             await Task.Delay(1);
-            string iconFilePath = Path.Combine(App.baseDirectory, game.BoxartFilePath); // Path to the game icon
+            string iconFilePath = Path.Combine(App.baseDirectory, imagePath); // Path to the game icon
             string cacheDirectory = Path.Combine(App.baseDirectory, @"Icons\Cache\"); // Path to the cached directory
 
             Log.Information("Creating new cached icon for the game");
             string randomIconName = Path.GetRandomFileName().Replace(".", "").Substring(0, 8) + ".ico";
-            game.CachedIconPath = Path.Combine(cacheDirectory, randomIconName);
-
-            File.Copy(iconFilePath, game.CachedIconPath, true);
+            if (!shortcutIcon)
+            {
+                game.CachedIconPath = Path.Combine(cacheDirectory, randomIconName);
+                File.Copy(iconFilePath, game.CachedIconPath, true);
+            }
+            else
+            {
+                cachedShortcutIconPath = Path.Combine(cacheDirectory, randomIconName);
+                File.Copy(iconFilePath, cachedShortcutIconPath, true);
+            }
             Log.Information($"Cached icon name: {randomIconName}");
         }
 
         /// <summary>
-        /// Opens the file dialog and waits for user to select a new icon for the game
-        /// <para>Afterwards it'll apply the new icon to the game</para>
+        /// Opens the file dialog and waits for user to select a new boxart for the game
+        /// <para>Afterwards it'll apply the new boxart to the game</para>
         /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
-        private async void GameIcon_Click(object sender, RoutedEventArgs e)
+        private async void GameBoxart_Click(object sender, RoutedEventArgs e)
         {
             try
             {
@@ -311,7 +325,7 @@ namespace Xenia_Manager.Windows
 
                 // Set filter for image files
                 openFileDialog.Filter = "Image Files|*.jpg;*.jpeg;*.png;*.ico|All Files|*.*";
-                openFileDialog.Title = $"Select a new icon for {game.Title}";
+                openFileDialog.Title = $"Select new boxart for {game.Title}";
 
                 // Allow the user to only select 1 file
                 openFileDialog.Multiselect = false;
@@ -325,18 +339,18 @@ namespace Xenia_Manager.Windows
                     Log.Information($"Selected file: {Path.GetFileName(openFileDialog.FileName)}");
                     if (game.Title == GameTitle.Text)
                     {
-                        await GetGameBoxArtFromFile(openFileDialog.FileName, Path.Combine(App.baseDirectory, @$"Icons\{game.Title}.ico"));
+                        GetIconFromFile(openFileDialog.FileName, Path.Combine(App.baseDirectory, @$"Icons\{game.Title}.ico"));
                     }
                     else
                     {
-                        await GetGameBoxArtFromFile(openFileDialog.FileName, Path.Combine(App.baseDirectory, @$"Icons\{game.Title}.ico"));
+                        GetIconFromFile(openFileDialog.FileName, Path.Combine(App.baseDirectory, @$"Icons\{game.Title}.ico"));
                         AdjustGameTitle();
                     }
-                    Log.Information("New icon is added to Icons folder");
+                    Log.Information("New boxart is added to the Icons folder");
 
-                    Log.Information("Changing icon showed on the button to the new one");
-                    await CacheIcon();
-                    GameIcon.Content = await CreateButtonContent();
+                    Log.Information("Changing boxart showed on the button to the new one");
+                    await CacheImage(game.BoxartFilePath);
+                    GameBoxart.Content = await CreateButtonContent(game.CachedIconPath);
                 }
                 await Task.Delay(1);
             }
@@ -344,6 +358,61 @@ namespace Xenia_Manager.Windows
             {
                 Log.Error(ex.Message + "\nFull Error:\n" + ex);
                 MessageBox.Show(ex.Message);
+                return;
+            }
+        }
+
+        /// <summary>
+        /// Opens the file dialog and waits for user to select a new icon for the game
+        /// <para>Afterwards it'll apply the new icon to the game</para>
+        /// </summary>
+        private async void GameIcon_Click(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                // Create OpenFileDialog
+                OpenFileDialog openFileDialog = new OpenFileDialog();
+
+                // Set filter for image files
+                openFileDialog.Filter = "Image Files|*.jpg;*.jpeg;*.png;*.ico|All Files|*.*";
+                openFileDialog.Title = $"Select new icon for {game.Title}";
+
+                // Allow the user to only select 1 file
+                openFileDialog.Multiselect = false;
+
+                // Show the dialog and get result
+                bool? result = openFileDialog.ShowDialog();
+
+                // Process open file dialog results
+                if (result == true)
+                {
+                    Log.Information($"Selected file: {Path.GetFileName(openFileDialog.FileName)}");
+                    if (game.Title == GameTitle.Text)
+                    {
+                        GetIconFromFile(openFileDialog.FileName, Path.Combine(App.baseDirectory, @$"Icons\{game.Title} Icon.ico"));
+                    }
+                    else
+                    {
+                        GetIconFromFile(openFileDialog.FileName, Path.Combine(App.baseDirectory, @$"Icons\{game.Title} Icon.ico"));
+                        AdjustGameTitle();
+                    }
+                    if (game.ShortcutIconFilePath == null)
+                    {
+                        game.ShortcutIconFilePath = @$"Icons\{game.Title} Icon.ico";
+                    }
+                    Log.Information("New icon is added to the Icons folder");
+
+                    Log.Information("Changing icon showed on the button to the new one");
+                    await CacheImage(game.ShortcutIconFilePath, true);
+                    GameIcon.Content = await CreateButtonContent(cachedShortcutIconPath);
+                }
+                await Task.Delay(1);
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex.Message + "\nFull Error:\n" + ex);
+                MessageBox.Show(ex.Message);
+                return;
             }
         }
 

--- a/Xenia Manager/Windows/EditGameInfo.xaml.cs
+++ b/Xenia Manager/Windows/EditGameInfo.xaml.cs
@@ -260,37 +260,12 @@ namespace Xenia_Manager.Windows
                 {
                     using (MagickImage magickImage = new MagickImage(fileStream, format))
                     {
-                        double aspectRatio = (double)width / height;
+                        // Resize the image to the specified dimensions (this will stretch the image)
                         magickImage.Resize(width, height);
 
-                        double imageRatio = (double)magickImage.Width / magickImage.Height;
-                        int newWidth, newHeight, offsetX, offsetY;
-
-                        if (imageRatio > aspectRatio)
-                        {
-                            newWidth = width;
-                            newHeight = (int)Math.Round(width / imageRatio);
-                            offsetX = 0;
-                            offsetY = (height - newHeight) / 2;
-                        }
-                        else
-                        {
-                            newWidth = (int)Math.Round(height * imageRatio);
-                            newHeight = height;
-                            offsetX = (width - newWidth) / 2;
-                            offsetY = 0;
-                        }
-
-                        // Create a canvas with black background
-                        using (var canvas = new MagickImage(MagickColors.Black, width, height))
-                        {
-                            // Composite the resized image onto the canvas
-                            canvas.Composite(magickImage, offsetX, offsetY, CompositeOperator.SrcOver);
-
-                            // Convert to ICO format
-                            canvas.Format = MagickFormat.Ico;
-                            canvas.Write(outputPath);
-                        }
+                        // Convert to ICO format
+                        magickImage.Format = MagickFormat.Ico;
+                        magickImage.Write(outputPath);
                     }
                 }
             }

--- a/Xenia Manager/Windows/SelectGame.xaml
+++ b/Xenia Manager/Windows/SelectGame.xaml
@@ -75,10 +75,8 @@
                     <ComboBox.Items>
                         <ComboBoxItem Content="Xbox Marketplace" />
                         <ComboBoxItem Content="Wikipedia" />
-                        <ComboBoxItem Content="Andy Decarli's List" />
                     </ComboBox.Items>
                 </ComboBox>
-
 
                 <!-- Lists of games-->
                 <Grid>
@@ -106,19 +104,6 @@
                              Grid.Row="1"
                              Visibility="Collapsed"
                              SelectionChanged="WikipediaGames_SelectionChanged">
-                        <ListBox.Resources>
-                            <Style TargetType="Border">
-                                <Setter Property="CornerRadius" 
-                                        Value="0,0,10,10"/>
-                            </Style>
-                        </ListBox.Resources>
-                    </ListBox>
-
-                    <!-- Andy Decarli's list of games -->
-                    <ListBox x:Name="AndyDecarliGames" 
-                             Grid.Row="2"
-                             Visibility="Collapsed"
-                             SelectionChanged="AndyDecarliGames_SelectionChanged">
                         <ListBox.Resources>
                             <Style TargetType="Border">
                                 <Setter Property="CornerRadius" 

--- a/Xenia Manager/Windows/SelectGame.xaml
+++ b/Xenia Manager/Windows/SelectGame.xaml
@@ -74,6 +74,7 @@
                           SelectionChanged="SourceSelector_SelectionChanged">
                     <ComboBox.Items>
                         <ComboBoxItem Content="Xbox Marketplace" />
+                        <ComboBoxItem Content="Launchbox Database" />
                         <ComboBoxItem Content="Wikipedia" />
                     </ComboBox.Items>
                 </ComboBox>
@@ -91,6 +92,19 @@
                              Grid.Row="0"
                              Visibility="Collapsed"
                              SelectionChanged="XboxMarketplaceGames_SelectionChanged">
+                        <ListBox.Resources>
+                            <Style TargetType="Border">
+                                <Setter Property="CornerRadius" 
+                                        Value="0,0,10,10"/>
+                            </Style>
+                        </ListBox.Resources>
+                    </ListBox>
+
+                    <!-- Launchbox Database -->
+                    <ListBox x:Name="LaunchboxDatabaseGames" 
+                             Grid.Row="1"
+                             Visibility="Collapsed"
+                             SelectionChanged="LaunchboxDatabaseGames_SelectionChanged">
                         <ListBox.Resources>
                             <Style TargetType="Border">
                                 <Setter Property="CornerRadius" 

--- a/Xenia Manager/Windows/SelectGame.xaml.cs
+++ b/Xenia Manager/Windows/SelectGame.xaml.cs
@@ -233,7 +233,7 @@ namespace Xenia_Manager.Windows
                 if (!library.Games.Any(game => game.Title == newGame.Title))
                 {
                     await GetGameIcon($@"https://raw.githubusercontent.com/xenia-manager/xenia-manager-database/main/Assets/disc.png", Path.Combine(App.baseDirectory, @$"Icons\{newGame.Title}.ico"));
-                    newGame.IconFilePath = @$"Icons\{newGame.Title}.ico";
+                    newGame.BoxartFilePath = @$"Icons\{newGame.Title}.ico";
                     Log.Information("Adding the game to the Xenia Manager");
                     library.Games.Add(newGame);
                 }
@@ -694,7 +694,7 @@ namespace Xenia_Manager.Windows
                                     await GetGameIcon($@"https://raw.githubusercontent.com/xenia-manager/xenia-manager-database/main/Assets/disc.png", Path.Combine(App.baseDirectory, @$"Icons\{newGame.Title}.ico"));
                                 }
                             }
-                            newGame.IconFilePath = @$"Icons\{newGame.Title}.ico";
+                            newGame.BoxartFilePath = @$"Icons\{newGame.Title}.ico";
                             Log.Information("Adding the game to the Xenia Manager");
                             library.Games.Add(newGame);
                         }
@@ -728,7 +728,7 @@ namespace Xenia_Manager.Windows
                                     await GetGameIcon($@"https://raw.githubusercontent.com/xenia-manager/xenia-manager-database/main/Assets/disc.png", Path.Combine(App.baseDirectory, @$"Icons\{newGame.Title}.ico"));
                                 }
                             }
-                            newGame.IconFilePath = @$"Icons\{newGame.Title}.ico";
+                            newGame.BoxartFilePath = @$"Icons\{newGame.Title}.ico";
                             Log.Information("Adding the game to the Xenia Manager");
                             library.Games.Add(newGame);
                         }
@@ -796,7 +796,7 @@ namespace Xenia_Manager.Windows
                                     await GetGameIcon($@"https://raw.githubusercontent.com/xenia-manager/xenia-manager-database/main/Assets/disc.png", Path.Combine(App.baseDirectory, @$"Icons\{newGame.Title}.ico"));
                                 }
                             }
-                            newGame.IconFilePath = @$"Icons\{newGame.Title}.ico";
+                            newGame.BoxartFilePath = @$"Icons\{newGame.Title}.ico";
                             Log.Information("Adding the game to the Xenia Manager");
                             library.Games.Add(newGame);
                         }
@@ -832,7 +832,7 @@ namespace Xenia_Manager.Windows
                                     await GetGameIcon($@"https://raw.githubusercontent.com/xenia-manager/xenia-manager-database/main/Assets/disc.png", Path.Combine(App.baseDirectory, @$"Icons\{newGame.Title}.ico"));
                                 }
                             }
-                            newGame.IconFilePath = @$"Icons\{newGame.Title}.ico";
+                            newGame.BoxartFilePath = @$"Icons\{newGame.Title}.ico";
                             Log.Information("Adding the game to the Xenia Manager");
                             library.Games.Add(newGame);
                         }
@@ -900,7 +900,7 @@ namespace Xenia_Manager.Windows
                                     await GetGameIcon($@"https://raw.githubusercontent.com/xenia-manager/xenia-manager-database/main/Assets/disc.png", Path.Combine(App.baseDirectory, @$"Icons\{newGame.Title}.ico"));
                                 }
                             }
-                            newGame.IconFilePath = @$"Icons\{newGame.Title}.ico";
+                            newGame.BoxartFilePath = @$"Icons\{newGame.Title}.ico";
                             Log.Information("Adding the game to the Xenia Manager");
                             library.Games.Add(newGame);
                         }
@@ -936,7 +936,7 @@ namespace Xenia_Manager.Windows
                                     await GetGameIcon($@"https://raw.githubusercontent.com/xenia-manager/xenia-manager-database/main/Assets/disc.png", Path.Combine(App.baseDirectory, @$"Icons\{newGame.Title}.ico"));
                                 }
                             }
-                            newGame.IconFilePath = @$"Icons\{newGame.Title}.ico";
+                            newGame.BoxartFilePath = @$"Icons\{newGame.Title}.ico";
                             Log.Information("Adding the game to the Xenia Manager");
                             library.Games.Add(newGame);
                         }

--- a/Xenia Manager/Windows/SelectGame.xaml.cs
+++ b/Xenia Manager/Windows/SelectGame.xaml.cs
@@ -22,17 +22,15 @@ namespace Xenia_Manager.Windows
     /// </summary>
     public partial class SelectGame : Window
     {
-        // These 2 lists hold unfiltered and filtered list of games in Xbox Marketplace's list of games
-        List<GameInfo> XboxMarketplaceListOfGames = new List<GameInfo>();
-        private List<string> XboxMarketplaceFilteredGames = new List<string>();
-
         /// <summary>
         /// Used to track if it's the initial search and if it is, search based on GameID for Xbox Marketplace and every other based on game title
         /// </summary>
         private bool isFirstSearch = true;
 
-        // Signal that is used when first search is completed
-        private TaskCompletionSource<bool> _searchCompletionSource;
+        // Game lists
+        // These 2 lists hold unfiltered and filtered list of games in Xbox Marketplace's list of games
+        List<GameInfo> XboxMarketplaceListOfGames = new List<GameInfo>();
+        private List<string> XboxMarketplaceFilteredGames = new List<string>();
 
         // These 2 lists hold unfiltered and filtered list of games in Wikipedia's list of games
         List<GameInfo> wikipediaListOfGames = new List<GameInfo>();
@@ -49,6 +47,10 @@ namespace Xenia_Manager.Windows
 
         // Holds game that user wants to add to the Manager
         public InstalledGame newGame = new InstalledGame();
+
+        // Signals
+        // Signal that is used when first search is completed
+        private TaskCompletionSource<bool> _searchCompletionSource;
 
         // Used to send a signal that this window has been closed
         private TaskCompletionSource<bool> _closeTaskCompletionSource = new TaskCompletionSource<bool>();

--- a/Xenia Manager/Windows/SelectGame.xaml.cs
+++ b/Xenia Manager/Windows/SelectGame.xaml.cs
@@ -774,35 +774,13 @@ namespace Xenia_Manager.Windows
 
                 // Finding matching selected game in the list of games
                 string selectedTitle = listBox.SelectedItem.ToString();
-                GameInfo selectedGame = null;
-                List<GameInfo> matchingGames = launchboxListOfGames.Where(game => game.Title == selectedTitle).ToList();
-                if (matchingGames.Count > 1)
-                {
-                    if (gameid != "Not found")
-                    {
-                        foreach (GameInfo game in matchingGames)
-                        {
-                            if (game.GameID == gameid)
-                            {
-                                selectedGame = game;
-                                break;
-                            }
-                        }
-                    }
-                    else
-                    {
-                        selectedGame = matchingGames[0];
-                    }
-                }
-                else if (matchingGames.Count == 1)
-                {
-                    selectedGame = matchingGames[0];
-                }
+                GameInfo selectedGame = launchboxListOfGames.FirstOrDefault(game => game.Title == selectedTitle);
 
                 if (selectedGame == null)
                 {
                     return;
                 }
+
                 Mouse.OverrideCursor = Cursors.Wait;
 
                 // Adding the game to the library
@@ -822,7 +800,7 @@ namespace Xenia_Manager.Windows
                         counter++;
                     }
                 }
-                newGame.GameId = selectedGame.GameID;
+                newGame.GameId = gameid;
                 newGame.MediaId = mediaid;
                 await GetGameCompatibilityPageURL();
                 newGame.GameFilePath = GameFilePath;

--- a/Xenia Manager/Windows/SelectGame.xaml.cs
+++ b/Xenia Manager/Windows/SelectGame.xaml.cs
@@ -734,7 +734,7 @@ namespace Xenia_Manager.Windows
                 {
                     if (await CheckIfURLWorks(selectedGame.Icon))
                     {
-                        Log.Information("Using default disc image since the game doesn't have icon");
+                        Log.Information("Using game icon for shortcut icons");
                         await GetGameIcon(selectedGame.Icon, Path.Combine(App.baseDirectory, @$"Icons\{newGame.Title} Icon.ico"), 64, 64);
                     }
                     else
@@ -824,7 +824,7 @@ namespace Xenia_Manager.Windows
                 {
                     if (await CheckIfURLWorks(selectedGame.Artwork.Boxart))
                     {
-                        Log.Information("Using the image from Xbox Marketplace");
+                        Log.Information("Using the image from Launchbox Database");
                         await GetGameIcon(selectedGame.Artwork.Boxart, Path.Combine(App.baseDirectory, @$"Icons\{newGame.Title}.ico"));
                     }
                     else
@@ -847,7 +847,7 @@ namespace Xenia_Manager.Windows
                 {
                     if (await CheckIfURLWorks(selectedGame.Artwork.Disc))
                     {
-                        Log.Information("Using default disc image since the game doesn't have icon");
+                        Log.Information("Using game disc as shortcut icon");
                         await GetGameIcon(selectedGame.Artwork.Disc, Path.Combine(App.baseDirectory, @$"Icons\{newGame.Title} Icon.ico"), 64, 64);
                     }
                     else

--- a/Xenia Manager/Windows/SelectGame.xaml.cs
+++ b/Xenia Manager/Windows/SelectGame.xaml.cs
@@ -32,6 +32,10 @@ namespace Xenia_Manager.Windows
         List<GameInfo> XboxMarketplaceListOfGames = new List<GameInfo>();
         private List<string> XboxMarketplaceFilteredGames = new List<string>();
 
+        // These 2 lists hold unfiltered and filtered list of games in Launchbox Database
+        List<GameInfo> launchboxListOfGames = new List<GameInfo>();
+        private List<string> launchboxfilteredGames = new List<string>();
+
         // These 2 lists hold unfiltered and filtered list of games in Wikipedia's list of games
         List<GameInfo> wikipediaListOfGames = new List<GameInfo>();
         private List<string> wikipediafilteredGames = new List<string>();
@@ -126,6 +130,37 @@ namespace Xenia_Manager.Windows
 
                             XboxMarketplaceGames.Items.Clear();
                             XboxMarketplaceGames.ItemsSource = displayItems;
+                        }
+                        else
+                        {
+                            Log.Error($"Failed to load data. Status code: {response.StatusCode}");
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.Error(ex.Message, "");
+                        MessageBox.Show(ex.Message + "\nFull Error:\n" + ex);
+                    }
+                }
+
+                // Launchbox Database
+                Log.Information("Loading Launchbox Database");
+                url = "https://gist.githubusercontent.com/shazzaam7/7816ce5d456fb5db9bac8020da5d3600/raw/2bec316fbcd85de34358e1eb8918aa506018c6aa/launchbox_games.json";
+                using (HttpClient client = new HttpClient())
+                {
+                    try
+                    {
+                        client.DefaultRequestHeaders.Add("User-Agent", "Xenia Manager (https://github.com/xenia-manager/xenia-manager)");
+                        HttpResponseMessage response = await client.GetAsync(url);
+                        if (response.IsSuccessStatusCode)
+                        {
+                            string json = await response.Content.ReadAsStringAsync();
+
+                            launchboxListOfGames = JsonConvert.DeserializeObject<List<GameInfo>>(json);
+                            displayItems = launchboxListOfGames.Select(game => game.Title).ToList();
+
+                            LaunchboxDatabaseGames.Items.Clear();
+                            LaunchboxDatabaseGames.ItemsSource = displayItems;
                         }
                         else
                         {
@@ -254,10 +289,15 @@ namespace Xenia_Manager.Windows
                         Log.Information("There are some results in Xbox Marketplace list");
                         SourceSelector.SelectedIndex = 0;
                     }
+                    else if (launchboxfilteredGames.Count > 0)
+                    {
+                        Log.Information("There are some results in Launchbox Database");
+                        SourceSelector.SelectedIndex = 1;
+                    }
                     else if (wikipediafilteredGames.Count > 0)
                     {
                         Log.Information("There are some results in Wikipedia's list");
-                        SourceSelector.SelectedIndex = 1;
+                        SourceSelector.SelectedIndex = 2;
                     }
                     else
                     {
@@ -312,6 +352,9 @@ namespace Xenia_Manager.Windows
             // Xbox Marketplace filtering
             XboxMarketplaceGames.ItemsSource = XboxMarketplaceFilteredGames;
 
+            // Launchbox filtering
+            LaunchboxDatabaseGames.ItemsSource = launchboxfilteredGames;
+
             // Wikipedia filtering
             WikipediaGames.ItemsSource = wikipediafilteredGames;
 
@@ -319,9 +362,13 @@ namespace Xenia_Manager.Windows
             {
                 SourceSelector.SelectedIndex = 0;
             }
-            else if (WikipediaGames.Items.Count > 0)
+            else if (LaunchboxDatabaseGames.Items.Count > 0)
             {
                 SourceSelector.SelectedIndex = 1;
+            }
+            else if (WikipediaGames.Items.Count > 0)
+            {
+                SourceSelector.SelectedIndex = 2;
             }
         }
 
@@ -358,6 +405,11 @@ namespace Xenia_Manager.Windows
             });
             await Task.Run(() =>
             {
+                launchboxfilteredGames = launchboxListOfGames.Where(game => game.Title.ToLower().Contains(searchQuery)).Select(game => game.Title).ToList();
+                GC.Collect();
+            });
+            await Task.Run(() =>
+            {
                 wikipediafilteredGames = wikipediaListOfGames.Where(game => game.Title.ToLower().Contains(searchQuery)).Select(game => game.Title).ToList();
                 GC.Collect();
             });
@@ -388,13 +440,21 @@ namespace Xenia_Manager.Windows
             switch (SourceSelector.SelectedIndex)
             {
                 case 1:
+                    // Launchbox Database list of games
+                    XboxMarketplaceGames.Visibility = Visibility.Collapsed;
+                    LaunchboxDatabaseGames.Visibility = Visibility.Visible;
+                    WikipediaGames.Visibility = Visibility.Collapsed;
+                    break;
+                case 2:
                     // Wikipedia list of games
                     XboxMarketplaceGames.Visibility = Visibility.Collapsed;
+                    LaunchboxDatabaseGames.Visibility = Visibility.Collapsed;
                     WikipediaGames.Visibility = Visibility.Visible;
                     break;
                 default:
                     // Xbox Marketplace list of games
                     XboxMarketplaceGames.Visibility = Visibility.Visible;
+                    LaunchboxDatabaseGames.Visibility = Visibility.Collapsed;
                     WikipediaGames.Visibility = Visibility.Collapsed;
                     break;
             }
@@ -689,6 +749,110 @@ namespace Xenia_Manager.Windows
                                 }
                                 else
                                 {
+                                    Log.Information("Using default disc image as the last option");
+                                    await GetGameIcon($@"https://raw.githubusercontent.com/xenia-manager/xenia-manager-database/main/Assets/disc.png", Path.Combine(App.baseDirectory, @$"Icons\{newGame.Title}.ico"));
+                                }
+                            }
+                            newGame.IconFilePath = @$"Icons\{newGame.Title}.ico";
+                            Log.Information("Adding the game to the Xenia Manager");
+                            library.Games.Add(newGame);
+                        }
+                        Mouse.OverrideCursor = null;
+                        await ClosingAnimation();
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex.Message + "\nFull Error:\n" + ex);
+                MessageBox.Show(ex.Message);
+                Mouse.OverrideCursor = null;
+            }
+        }
+
+        /// <summary>
+        /// When the user selects a game from Launchbox Database
+        /// </summary>
+        private async void LaunchboxDatabaseGames_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            try
+            {
+                ListBox listBox = sender as ListBox;
+                if (listBox != null && listBox.SelectedItem != null)
+                {
+                    string selectedItem = listBox.SelectedItem.ToString();
+                    GameInfo selectedGame = launchboxListOfGames.FirstOrDefault(game => game.Title == selectedItem);
+                    if (selectedItem != null)
+                    {
+                        Mouse.OverrideCursor = Cursors.Wait;
+                        Log.Information($"Selected Game: {selectedGame.Title}");
+                        newGame.Title = selectedGame.Title.Replace(":", " -").Replace('\\', ' ').Replace('/', ' ');
+                        newGame.GameId = gameid;
+                        newGame.MediaId = mediaid;
+                        await GetGameCompatibilityPageURL();
+                        newGame.GameFilePath = GameFilePath;
+                        Log.Information($"Creating a new configuration file for {newGame.Title}");
+                        if (File.Exists(Path.Combine(App.baseDirectory, EmulatorInfo.ConfigurationFileLocation)))
+                        {
+                            File.Copy(Path.Combine(App.baseDirectory, EmulatorInfo.ConfigurationFileLocation), Path.Combine(App.baseDirectory, EmulatorInfo.EmulatorLocation, $@"config\{newGame.Title}.config.toml"), true);
+                        }
+                        newGame.ConfigFilePath = Path.Combine(EmulatorInfo.EmulatorLocation, $@"config\{newGame.Title}.config.toml");
+                        newGame.EmulatorVersion = XeniaVersion;
+                        if (!library.Games.Any(game => game.Title == newGame.Title))
+                        {
+                            // Checking if the URL Works
+                            if (selectedGame.Artwork.Boxart == null)
+                            {
+                                selectedGame.Artwork.Boxart = @"https://raw.githubusercontent.com/xenia-manager/xenia-manager-database/main/Assets/disc.png";
+                                Log.Information("Using default disc image since the game doesn't have boxart in Launchbox Database");
+                                await GetGameIcon(selectedGame.Artwork.Boxart, Path.Combine(App.baseDirectory, @$"Icons\{newGame.Title}.ico"));
+                            }
+                            else
+                            {
+                                if (await CheckIfURLWorks(selectedGame.Artwork.Boxart))
+                                {
+                                    Log.Information("Using the image from Launchbox");
+                                    await GetGameIcon(selectedGame.Artwork.Boxart, Path.Combine(App.baseDirectory, @$"Icons\{newGame.Title}.ico"));
+                                }
+                                else
+                                {
+                                    // Using the default disc box art
+                                    Log.Information("Using default disc image as the last option");
+                                    await GetGameIcon($@"https://raw.githubusercontent.com/xenia-manager/xenia-manager-database/main/Assets/disc.png", Path.Combine(App.baseDirectory, @$"Icons\{newGame.Title}.ico"));
+                                }
+                            }
+                            newGame.IconFilePath = @$"Icons\{newGame.Title}.ico";
+                            Log.Information("Adding the game to the Xenia Manager");
+                            library.Games.Add(newGame);
+                        }
+                        else
+                        {
+                            Log.Information("This game title is already in use");
+                            Log.Information("Adding it as a duplicate");
+                            int counter = 1;
+                            string OriginalGameTitle = newGame.Title;
+                            while (library.Games.Any(game => game.Title == newGame.Title))
+                            {
+                                newGame.Title = $"{OriginalGameTitle} ({counter})";
+                                counter++;
+                            }
+                            // Checking if the URL Works
+                            if (selectedGame.Artwork.Boxart == null)
+                            {
+                                selectedGame.Artwork.Boxart = @"https://raw.githubusercontent.com/xenia-manager/xenia-manager-database/main/Assets/disc.png";
+                                Log.Information("Using default disc image since the game doesn't have boxart in Launchbox Database");
+                                await GetGameIcon(selectedGame.Artwork.Boxart, Path.Combine(App.baseDirectory, @$"Icons\{newGame.Title}.ico"));
+                            }
+                            else
+                            {
+                                if (await CheckIfURLWorks(selectedGame.Artwork.Boxart))
+                                {
+                                    Log.Information("Using the image from Launchbox");
+                                    await GetGameIcon(selectedGame.Artwork.Boxart, Path.Combine(App.baseDirectory, @$"Icons\{newGame.Title}.ico"));
+                                }
+                                else
+                                {
+                                    // Using the default disc box art
                                     Log.Information("Using default disc image as the last option");
                                     await GetGameIcon($@"https://raw.githubusercontent.com/xenia-manager/xenia-manager-database/main/Assets/disc.png", Path.Combine(App.baseDirectory, @$"Icons\{newGame.Title}.ico"));
                                 }

--- a/Xenia Manager/Windows/SelectGame.xaml.cs
+++ b/Xenia Manager/Windows/SelectGame.xaml.cs
@@ -766,93 +766,124 @@ namespace Xenia_Manager.Windows
             try
             {
                 ListBox listBox = sender as ListBox;
-                if (listBox != null && listBox.SelectedItem != null)
+                // Checking is listbox has something selected
+                if (listBox == null || listBox.SelectedItem == null)
                 {
-                    string selectedItem = listBox.SelectedItem.ToString();
-                    GameInfo selectedGame = launchboxListOfGames.FirstOrDefault(game => game.Title == selectedItem);
-                    if (selectedItem != null)
+                    return;
+                }
+
+                // Finding matching selected game in the list of games
+                string selectedTitle = listBox.SelectedItem.ToString();
+                GameInfo selectedGame = null;
+                List<GameInfo> matchingGames = launchboxListOfGames.Where(game => game.Title == selectedTitle).ToList();
+                if (matchingGames.Count > 1)
+                {
+                    if (gameid != "Not found")
                     {
-                        Mouse.OverrideCursor = Cursors.Wait;
-                        Log.Information($"Selected Game: {selectedGame.Title}");
-                        newGame.Title = selectedGame.Title.Replace(":", " -").Replace('\\', ' ').Replace('/', ' ');
-                        newGame.GameId = gameid;
-                        newGame.MediaId = mediaid;
-                        await GetGameCompatibilityPageURL();
-                        newGame.GameFilePath = GameFilePath;
-                        Log.Information($"Creating a new configuration file for {newGame.Title}");
-                        if (File.Exists(Path.Combine(App.baseDirectory, EmulatorInfo.ConfigurationFileLocation)))
+                        foreach (GameInfo game in matchingGames)
                         {
-                            File.Copy(Path.Combine(App.baseDirectory, EmulatorInfo.ConfigurationFileLocation), Path.Combine(App.baseDirectory, EmulatorInfo.EmulatorLocation, $@"config\{newGame.Title}.config.toml"), true);
+                            if (game.GameID == gameid)
+                            {
+                                selectedGame = game;
+                                break;
+                            }
                         }
-                        newGame.ConfigFilePath = Path.Combine(EmulatorInfo.EmulatorLocation, $@"config\{newGame.Title}.config.toml");
-                        newGame.EmulatorVersion = XeniaVersion;
-                        if (!library.Games.Any(game => game.Title == newGame.Title))
-                        {
-                            // Checking if the URL Works
-                            if (selectedGame.Artwork.Boxart == null)
-                            {
-                                selectedGame.Artwork.Boxart = @"https://raw.githubusercontent.com/xenia-manager/xenia-manager-database/main/Assets/disc.png";
-                                Log.Information("Using default disc image since the game doesn't have boxart in Launchbox Database");
-                                await GetGameIcon(selectedGame.Artwork.Boxart, Path.Combine(App.baseDirectory, @$"Icons\{newGame.Title}.ico"));
-                            }
-                            else
-                            {
-                                if (await CheckIfURLWorks(selectedGame.Artwork.Boxart))
-                                {
-                                    Log.Information("Using the image from Launchbox");
-                                    await GetGameIcon(selectedGame.Artwork.Boxart, Path.Combine(App.baseDirectory, @$"Icons\{newGame.Title}.ico"));
-                                }
-                                else
-                                {
-                                    // Using the default disc box art
-                                    Log.Information("Using default disc image as the last option");
-                                    await GetGameIcon($@"https://raw.githubusercontent.com/xenia-manager/xenia-manager-database/main/Assets/disc.png", Path.Combine(App.baseDirectory, @$"Icons\{newGame.Title}.ico"));
-                                }
-                            }
-                            newGame.BoxartFilePath = @$"Icons\{newGame.Title}.ico";
-                            Log.Information("Adding the game to the Xenia Manager");
-                            library.Games.Add(newGame);
-                        }
-                        else
-                        {
-                            Log.Information("This game title is already in use");
-                            Log.Information("Adding it as a duplicate");
-                            int counter = 1;
-                            string OriginalGameTitle = newGame.Title;
-                            while (library.Games.Any(game => game.Title == newGame.Title))
-                            {
-                                newGame.Title = $"{OriginalGameTitle} ({counter})";
-                                counter++;
-                            }
-                            // Checking if the URL Works
-                            if (selectedGame.Artwork.Boxart == null)
-                            {
-                                selectedGame.Artwork.Boxart = @"https://raw.githubusercontent.com/xenia-manager/xenia-manager-database/main/Assets/disc.png";
-                                Log.Information("Using default disc image since the game doesn't have boxart in Launchbox Database");
-                                await GetGameIcon(selectedGame.Artwork.Boxart, Path.Combine(App.baseDirectory, @$"Icons\{newGame.Title}.ico"));
-                            }
-                            else
-                            {
-                                if (await CheckIfURLWorks(selectedGame.Artwork.Boxart))
-                                {
-                                    Log.Information("Using the image from Launchbox");
-                                    await GetGameIcon(selectedGame.Artwork.Boxart, Path.Combine(App.baseDirectory, @$"Icons\{newGame.Title}.ico"));
-                                }
-                                else
-                                {
-                                    // Using the default disc box art
-                                    Log.Information("Using default disc image as the last option");
-                                    await GetGameIcon($@"https://raw.githubusercontent.com/xenia-manager/xenia-manager-database/main/Assets/disc.png", Path.Combine(App.baseDirectory, @$"Icons\{newGame.Title}.ico"));
-                                }
-                            }
-                            newGame.BoxartFilePath = @$"Icons\{newGame.Title}.ico";
-                            Log.Information("Adding the game to the Xenia Manager");
-                            library.Games.Add(newGame);
-                        }
-                        Mouse.OverrideCursor = null;
-                        await ClosingAnimation();
+                    }
+                    else
+                    {
+                        selectedGame = matchingGames[0];
                     }
                 }
+                else if (matchingGames.Count == 1)
+                {
+                    selectedGame = matchingGames[0];
+                }
+
+                if (selectedGame == null)
+                {
+                    return;
+                }
+                Mouse.OverrideCursor = Cursors.Wait;
+
+                // Adding the game to the library
+                Log.Information($"Selected Game: {selectedGame.Title}");
+                newGame.Title = selectedGame.Title.Replace(":", " -").Replace('\\', ' ').Replace('/', ' ');
+
+                // Checking if this is a duplicate
+                if (library.Games.Any(game => game.Title == newGame.Title))
+                {
+                    Log.Information("This game title is already in use");
+                    Log.Information("Adding it as a duplicate");
+                    int counter = 1;
+                    string OriginalGameTitle = newGame.Title;
+                    while (library.Games.Any(game => game.Title == newGame.Title))
+                    {
+                        newGame.Title = $"{OriginalGameTitle} ({counter})";
+                        counter++;
+                    }
+                }
+                newGame.GameId = selectedGame.GameID;
+                newGame.MediaId = mediaid;
+                await GetGameCompatibilityPageURL();
+                newGame.GameFilePath = GameFilePath;
+                Log.Information($"Creating a new configuration file for {newGame.Title}");
+                if (File.Exists(Path.Combine(App.baseDirectory, EmulatorInfo.ConfigurationFileLocation)))
+                {
+                    File.Copy(Path.Combine(App.baseDirectory, EmulatorInfo.ConfigurationFileLocation), Path.Combine(App.baseDirectory, EmulatorInfo.EmulatorLocation, $@"config\{newGame.Title}.config.toml"), true);
+                }
+                newGame.ConfigFilePath = Path.Combine(EmulatorInfo.EmulatorLocation, $@"config\{newGame.Title}.config.toml");
+                newGame.EmulatorVersion = XeniaVersion;
+
+                // Download Boxart
+                Log.Information("Downloading boxart");
+                if (selectedGame.Artwork.Boxart == null)
+                {
+                    selectedGame.Artwork.Boxart = @"https://raw.githubusercontent.com/xenia-manager/xenia-manager-database/main/Assets/disc.png";
+                    Log.Information("Using default disc image since the game doesn't have boxart");
+                    await GetGameIcon(selectedGame.Artwork.Boxart, Path.Combine(App.baseDirectory, @$"Icons\{newGame.Title}.ico"));
+                }
+                else
+                {
+                    if (await CheckIfURLWorks(selectedGame.Artwork.Boxart))
+                    {
+                        Log.Information("Using the image from Xbox Marketplace");
+                        await GetGameIcon(selectedGame.Artwork.Boxart, Path.Combine(App.baseDirectory, @$"Icons\{newGame.Title}.ico"));
+                    }
+                    else
+                    {
+                        Log.Information("Using default disc image as the last option");
+                        await GetGameIcon($@"https://raw.githubusercontent.com/xenia-manager/xenia-manager-database/main/Assets/disc.png", Path.Combine(App.baseDirectory, @$"Icons\{newGame.Title}.ico"));
+                    }
+                }
+                newGame.BoxartFilePath = @$"Icons\{newGame.Title}.ico";
+
+                // Download icon for shortcut
+                Log.Information("Downloading icon for shortcuts");
+                if (selectedGame.Artwork.Disc == null)
+                {
+                    selectedGame.Artwork.Disc = @"https://raw.githubusercontent.com/xenia-manager/xenia-manager-database/main/Assets/disc.png";
+                    Log.Information("Using default disc image since the game doesn't have icon");
+                    await GetGameIcon(selectedGame.Artwork.Disc, Path.Combine(App.baseDirectory, @$"Icons\{newGame.Title} Icon.ico"), 64, 64);
+                }
+                else
+                {
+                    if (await CheckIfURLWorks(selectedGame.Artwork.Disc))
+                    {
+                        Log.Information("Using default disc image since the game doesn't have icon");
+                        await GetGameIcon(selectedGame.Artwork.Disc, Path.Combine(App.baseDirectory, @$"Icons\{newGame.Title} Icon.ico"), 64, 64);
+                    }
+                    else
+                    {
+                        Log.Information("Using default disc image as the last option");
+                        await GetGameIcon($@"https://raw.githubusercontent.com/xenia-manager/xenia-manager-database/main/Assets/disc.png", Path.Combine(App.baseDirectory, @$"Icons\{newGame.Title}.ico"), 64, 64);
+                    }
+                }
+                newGame.ShortcutIconFilePath = @$"Icons\{newGame.Title} Icon.ico";
+
+                Log.Information("Adding the game to the Xenia Manager");
+                library.Games.Add(newGame);
+                Mouse.OverrideCursor = null;
+                await ClosingAnimation();
             }
             catch (Exception ex)
             {

--- a/Xenia Manager/Windows/SelectGame.xaml.cs
+++ b/Xenia Manager/Windows/SelectGame.xaml.cs
@@ -545,37 +545,12 @@ namespace Xenia_Manager.Windows
                     {
                         using (MagickImage magickImage = new MagickImage(memoryStream))
                         {
-                            double aspectRatio = (double)width / height;
+                            // Resize the image to the specified dimensions (this will stretch the image)
                             magickImage.Resize(width, height);
 
-                            double imageRatio = (double)magickImage.Width / magickImage.Height;
-                            int newWidth, newHeight, offsetX, offsetY;
-
-                            if (imageRatio > aspectRatio)
-                            {
-                                newWidth = width;
-                                newHeight = (int)Math.Round(width / imageRatio);
-                                offsetX = 0;
-                                offsetY = (height - newHeight) / 2;
-                            }
-                            else
-                            {
-                                newWidth = (int)Math.Round(height * imageRatio);
-                                newHeight = height;
-                                offsetX = (width - newWidth) / 2;
-                                offsetY = 0;
-                            }
-
-                            // Create a canvas with black background
-                            using (var canvas = new MagickImage(MagickColors.Black, width, height))
-                            {
-                                // Composite the resized image onto the canvas
-                                canvas.Composite(magickImage, offsetX, offsetY, CompositeOperator.SrcOver);
-
-                                // Convert to ICO format
-                                canvas.Format = MagickFormat.Ico;
-                                canvas.Write(outputPath);
-                            }
+                            // Convert to ICO format
+                            magickImage.Format = MagickFormat.Ico;
+                            magickImage.Write(outputPath);
                         }
                     }
                 }

--- a/Xenia Manager/Windows/WelcomeDialog.xaml.cs
+++ b/Xenia Manager/Windows/WelcomeDialog.xaml.cs
@@ -295,9 +295,9 @@ namespace Xenia_Manager.Windows
                         Log.Information($"Removing '{game.Title}' because it's using Xenia {XeniaVersion}");
 
                         // Removing game icon
-                        if (File.Exists(game.IconFilePath))
+                        if (File.Exists(game.BoxartFilePath))
                         {
-                            File.Delete(game.IconFilePath);
+                            File.Delete(game.BoxartFilePath);
                         }
 
                         // Removing the game


### PR DESCRIPTION
* Editing game box art now supports .ico files (Also changed the name of the function to fit it better)
* Removed Andy Decarli's list of games since the source died (Currently it's working off backup)
* Now the images will be properly resized to the correct size instead of being filled with black color (I recommend readding games for this to take effect)
* Implemented Launchbox Database (Serves as an replacement to Andy Decarli's source)
* Reworked the functions for adding games. Should be easier to debug and work better
* Added downloading/creating game icons for shortcuts
* Now you can edit the shortcut icon from EditGameInfo window (It probably won't apply right away and might even need a restart of the PC or a reset of icon cache, just windows things)
