### PR TITLE
Version 1.12.0

### DIFF
--- a/Xenia Manager/App.xaml
+++ b/Xenia Manager/App.xaml
@@ -314,8 +314,10 @@
                                     BorderBrush="Transparent"
                                     BorderThickness="1"
                                     CornerRadius="8"
-                                    Margin="2">
-                                <ContentPresenter />
+                                    MaxWidth="{Binding ActualWidth, RelativeSource={RelativeSource TemplatedParent}}"
+                                    Padding="5,2">
+                                <ContentPresenter HorizontalAlignment="Left"
+                                                  ToolTip="{Binding}"/>
                             </Border>
                             <ControlTemplate.Triggers>
                                 <Trigger Property="IsEnabled" Value="False">
@@ -389,21 +391,24 @@
                                                           VerticalAlignment="Center"/>
                                         <TextBox x:Name="PART_EditableTextBox"
                                                  Background="Transparent"
+                                                 BorderBrush="Transparent"
                                                  Focusable="True"
                                                  Foreground="{DynamicResource ForegroundColor}"
                                                  HorizontalAlignment="Center"
                                                  IsReadOnly="{TemplateBinding IsReadOnly}"
-                                                 Margin="3,3,23,3"
+                                                 Margin="5,3,23,3"
                                                  Style="{x:Null}"
                                                  VerticalAlignment="Center"
-                                                 Visibility="Hidden"/>
+                                                 Visibility="Hidden"
+                                                 MaxWidth="{Binding ActualWidth, RelativeSource={RelativeSource TemplatedParent}}"/>
                                         <Popup Name="Popup"
                                                AllowsTransparency="True"
                                                Focusable="False"
                                                IsOpen="{TemplateBinding IsDropDownOpen}"
                                                Placement="Bottom"
                                                PlacementTarget="{Binding RelativeSource={RelativeSource TemplatedParent}}"
-                                               PopupAnimation="Slide">
+                                               PopupAnimation="Slide"
+                                               Width="{Binding ActualWidth, RelativeSource={RelativeSource TemplatedParent}}">
                                             <Grid Name="DropDown"
                                                   MinWidth="{TemplateBinding ActualWidth}"
                                                   MaxHeight="{TemplateBinding MaxDropDownHeight}"
@@ -415,9 +420,9 @@
                                                         CornerRadius="10"/>
                                                 <ScrollViewer CanContentScroll="False" 
                                                               HorizontalScrollBarVisibility="Hidden"
-                                                              Margin="0"
+                                                              Margin="0,2,1,2"
                                                               SnapsToDevicePixels="True"
-                                                              VerticalScrollBarVisibility="Hidden">
+                                                              VerticalScrollBarVisibility="Auto">
                                                     <StackPanel IsItemsHost="True"
                                                                 KeyboardNavigation.DirectionalNavigation="Contained"/>
                                                 </ScrollViewer>
@@ -429,6 +434,10 @@
                             <ControlTemplate.Triggers>
                                 <Trigger Property="HasItems" Value="false">
                                     <Setter TargetName="DropDownBorder" Property="MinHeight" Value="95"/>
+                                </Trigger>
+                                <Trigger Property="IsEditable" Value="True">
+                                    <Setter TargetName="PART_EditableTextBox" Property="Visibility" Value="Visible"/>
+                                    <Setter TargetName="ContentSite" Property="Visibility" Value="Hidden"/>
                                 </Trigger>
                             </ControlTemplate.Triggers>
                         </ControlTemplate>

--- a/Xenia Manager/App.xaml.cs
+++ b/Xenia Manager/App.xaml.cs
@@ -498,6 +498,12 @@ namespace Xenia_Manager
                 Directory.CreateDirectory(Path.Combine(baseDirectory, @"Icons\Cache"));
             }
 
+            // Cleanup of XboxUnity downloads folder
+            if (Directory.Exists(Path.Combine(App.baseDirectory, @"Downloads\")))
+            {
+                Directory.Delete(Path.Combine(App.baseDirectory, @"Downloads\"), true);
+            }
+
             // Clearing icon cache
             foreach (string filePath in Directory.GetFiles(Path.Combine(baseDirectory, @"Icons\Cache"), "*", SearchOption.AllDirectories))
             {

--- a/Xenia Manager/Classes/JSONParse.cs
+++ b/Xenia Manager/Classes/JSONParse.cs
@@ -36,16 +36,22 @@ namespace Xenia_Manager.Classes
         public string? GameCompatibilityURL { get; set; }
 
         /// <summary>
-        /// The file path to the game's icon
+        /// The file path to the game's boxart
         /// </summary>
         [JsonProperty("icon")]
-        public string? IconFilePath { get; set; }
+        public string? BoxartFilePath { get; set; }
 
         /// <summary>
-        /// The file path to the game's icon
+        /// The file path to the game's cached boxart
         /// </summary>
         [JsonProperty("cached_icon")]
         public string? CachedIconPath { get; set; }
+
+        /// <summary>
+        /// The file path to the game's shortcut icon
+        /// </summary>
+        [JsonProperty("shortcut_icon")]
+        public string? ShortcutIconFilePath { get; set; }
 
         /// <summary>
         /// The file path to the game's ISO file
@@ -89,15 +95,11 @@ namespace Xenia_Manager.Classes
         [JsonProperty("Title")]
         public string? Title { get; set; }
 
-        // This is for Andy Declari's JSON file
-        [JsonProperty("Front")]
-        public CoverDetails? Front { get; set; }
-
-        [JsonProperty("Back")]
-        public CoverDetails? Back { get; set; }
+        // This is for Launchbox Database
+        [JsonProperty("Artwork")]
+        public Artwork Artwork { get; set; }
 
         // This is for Wikipedia JSON file
-
         [JsonProperty("Link")]
         public string? Link { get; set; }
 
@@ -110,18 +112,24 @@ namespace Xenia_Manager.Classes
 
         [JsonProperty("Box art")]
         public string? BoxArt { get; set; }
+
+        [JsonProperty("Icon")]
+        public string? Icon { get; set; }
     }
 
     /// <summary>
-    /// This is for CoverDetails (Andy Declari's JSON file)
+    /// This holds different artworks from Launchbox Database
     /// </summary>
-    public class CoverDetails
+    public class Artwork
     {
-        [JsonProperty("Full Size")]
-        public string? FullSize { get; set; }
+        [JsonProperty("Front Image")]
+        public string? Boxart { get; set; }
 
-        [JsonProperty("Thumbnail")]
-        public string? Thumbnail { get; set; }
+        [JsonProperty("Disc")]
+        public string? Disc { get; set; }
+
+        [JsonProperty("Logo")]
+        public string? Logo { get; set; }
     }
 
     /// <summary>

--- a/Xenia Manager/Classes/XboxUnity.cs
+++ b/Xenia Manager/Classes/XboxUnity.cs
@@ -1,0 +1,179 @@
+﻿using System;
+using System.Net.Http;
+using System.Security.Policy;
+using System.Windows;
+
+// Imported
+using Newtonsoft.Json;
+using Serilog;
+
+namespace Xenia_Manager.Classes
+{
+    /// <summary>
+    /// Every MediaID has a list of updates
+    /// </summary>
+    public class XboxUnityMediaID
+    {
+        /// <summary>
+        /// Media ID
+        /// </summary>
+        [JsonProperty("MediaID")]
+        public string? id { get; set; }
+
+        /// <summary>
+        /// List of all of the updates the media id has
+        /// </summary>
+        [JsonProperty("Updates")]
+        public List<XboxUnityTitleUpdate>? updates { get; set; }
+    }
+
+    /// <summary>
+    /// Information about the update
+    /// </summary>
+    public class XboxUnityTitleUpdate
+    {
+        /// <summary>
+        /// Title Update ID that is needed for downloading the TU
+        /// </summary>
+        [JsonProperty("TitleUpdateID")]
+        public string? id { get; set; }
+
+        /// <summary>
+        /// Version of the update
+        /// </summary>
+        [JsonProperty("Version")]
+        public string? Version { get; set; }
+
+        /// <summary>
+        /// Version of the update
+        /// </summary>
+        [JsonProperty("Name")]
+        public string? Name { get; set; }
+
+        /// <summary>
+        /// Returns a string representation of the object, which will be displayed in the ListBox.
+        /// </summary>
+        public override string ToString()
+        {
+            return $"Update {Version} ({id})";
+        }
+    }
+
+    /// <summary>
+    /// Response from XboxUnity
+    /// </summary>
+    public class XboxUnityAPIResponse
+    {
+        /// <summary>
+        /// Type 1 - Has TU's
+        /// Type 2 - No TU's = Skip
+        /// </summary>
+        [JsonProperty("Type")]
+        public int Type { get; set; }
+
+        /// <summary>
+        /// All of the grabbed media ID's
+        /// We need to match this before downloading updates
+        /// </summary>
+        [JsonProperty("MediaIDS")]
+        public List<XboxUnityMediaID>? MediaIds { get; set; }
+    }
+
+    /// <summary>
+    /// Holds everything for grabbing XboxUnity TU's for a certain game
+    /// </summary>
+    public class XboxUnity
+    {
+        /// <summary>
+        /// Game ID
+        /// </summary>
+        public string gameid { get; set; }
+
+        /// <summary>
+        /// Media ID
+        /// </summary>
+        public string mediaid { get; set; }
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="gameid">Game ID</param>
+        /// <param name="mediaid">Media ID</param>
+        public XboxUnity(string gameid, string mediaid)
+        {
+            this.gameid = gameid;
+            this.mediaid = mediaid;
+        }
+
+        /// <summary>
+        /// Returns empty string or JSON as a string from the response
+        /// </summary>
+        /// <param name="url">URL whose response we want</param>
+        private async Task<string> GetResponse(string url)
+        {
+            try
+            {
+                // Create an instance of HttpClient
+                using (HttpClient client = new HttpClient())
+                {
+                    // Send a GET request to the URL
+                    HttpResponseMessage response = await client.GetAsync(url);
+
+                    // Ensure the request was successful
+                    response.EnsureSuccessStatusCode();
+
+                    // Read the HTML content as a string
+                    return await response.Content.ReadAsStringAsync();
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex.Message + "\nFull Error:\n" + ex);
+                return "";
+            }
+        }
+
+        /// <summary>
+        /// Returns the response as a JSON
+        /// </summary>
+        public async Task<List<XboxUnityTitleUpdate>> GetTitleUpdates()
+        {
+            try
+            {
+                // Url to the Title Update Info
+                string url = $"http://xboxunity.net/Resources/Lib/TitleUpdateInfo.php?titleid={gameid}";
+
+                // Checking if response returned something
+                string json = await GetResponse(url);
+                if (json == "")
+                {
+                    return null;
+                }
+
+                // Parsing HTML response
+                XboxUnityAPIResponse responseAsJSON = JsonConvert.DeserializeObject<XboxUnityAPIResponse>(json);
+                if (responseAsJSON.Type != 1)
+                {
+                    Log.Information("Unsupported response type");
+                    return null;
+                }
+
+                // Check for supported Title Update's
+                foreach (XboxUnityMediaID mediaid in responseAsJSON.MediaIds)
+                {
+                    if (mediaid.id == this.mediaid)
+                    {
+                        return mediaid.updates;
+                    }
+                }
+                return null;
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex.Message + "\nFull Error:\n" + ex);
+                MessageBox.Show(ex.Message);
+                return null;
+            }
+        }
+    }
+}

--- a/Xenia Manager/Pages/Library.xaml.cs
+++ b/Xenia Manager/Pages/Library.xaml.cs
@@ -494,60 +494,9 @@ namespace Xenia_Manager.Pages
         /// </summary>
         private async void InstallContent(InstalledGame game)
         {
-            Log.Information("Open file dialog so user can select the content that he wants to install");
-            OpenFileDialog openFileDialog = new OpenFileDialog();
-            openFileDialog.Title = $"Select files for {game.Title}";
-            openFileDialog.Filter = "All Files|*";
-            openFileDialog.Multiselect = true;
-            bool? result = openFileDialog.ShowDialog();
-            if (result == true)
-            {
-                Mouse.OverrideCursor = Cursors.Wait;
-                List<GameContent> gameContent = new List<GameContent>();
-                foreach (string file in openFileDialog.FileNames)
-                {
-                    try
-                    {
-                        Log.Information($"Checking if {Path.GetFileNameWithoutExtension(file)} is supported");
-                        STFS stfs = new STFS(file);
-                        if (stfs.SupportedFile)
-                        {
-                            Log.Information($"{Path.GetFileNameWithoutExtension(file)} is supported");
-                            stfs.ReadTitle();
-                            stfs.ReadDisplayName();
-                            stfs.ReadContentType();
-                            var (contentType, contentTypeValue) = stfs.GetContentType();
-                            GameContent content = new GameContent();
-                            content.GameId = game.GameId;
-                            content.ContentTitle = stfs.Title;
-                            content.ContentDisplayName = stfs.DisplayName;
-                            content.ContentType = contentType.ToString().Replace('_', ' ');
-                            content.ContentTypeValue = $"{contentTypeValue:X8}";
-                            content.ContentPath = file;
-                            if (content.ContentType != null)
-                            {
-                                gameContent.Add(content);
-                            }
-                        }
-                        else
-                        {
-                            Log.Information($"{Path.GetFileNameWithoutExtension(file)} is currently not supported");
-                            MessageBox.Show($"{Path.GetFileNameWithoutExtension(file)} is currently not supported");
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        Log.Information($"Error: {ex.Message}");
-                    }
-                }
-                Mouse.OverrideCursor = null;
-                if (gameContent.Count > 0)
-                {
-                    Log.Information("Opening window for installing content");
-                    InstallContent installContent = new InstallContent(game.EmulatorVersion, gameContent);
-                    await installContent.WaitForCloseAsync();
-                }
-            };
+            Log.Information("Opening window for installing content");
+            InstallContent installContent = new InstallContent(game);
+            await installContent.WaitForCloseAsync();
         }
 
         /// <summary>

--- a/Xenia Manager/Pages/Library.xaml.cs
+++ b/Xenia Manager/Pages/Library.xaml.cs
@@ -828,20 +828,7 @@ namespace Xenia_Manager.Pages
                     button.Style = (Style)FindResource("GameCoverButtons"); // Styling of the game button
 
                     // Tooltip
-                    ToolTip toolTip = new ToolTip();
-                    TextBlock textBlock = new TextBlock();
-                    textBlock.Inlines.Add(new Run("Game Name:") { FontWeight = FontWeights.Bold });
-                    textBlock.Inlines.Add(new Run(" " + game.Title + "\n"));
-                    textBlock.Inlines.Add(new Run("Game ID:") { FontWeight = FontWeights.Bold });
-                    textBlock.Inlines.Add(new Run(" " + game.GameId));
-                    if (game.MediaId != null)
-                    {
-                        textBlock.Inlines.Add(new Run("\n"));
-                        textBlock.Inlines.Add(new Run("Media ID:") { FontWeight = FontWeights.Bold });
-                        textBlock.Inlines.Add(new Run(" " + game.MediaId));
-                    }
-                    toolTip.Content = textBlock;
-                    button.ToolTip = toolTip;
+                    button.ToolTip = game.Title;
 
                     wrapPanel.Children.Add(button); // Add the game to the Warp Panel
 
@@ -984,32 +971,6 @@ namespace Xenia_Manager.Pages
                                         break;
                                     }
                             }
-                            /*
-                            if (line.Contains("Title name"))
-                            {
-                                string[] split = line.Split(':');
-                                Log.Information($"Title: {split[1].TrimStart()}");
-                                if (gameTitle == "Not found")
-                                {
-                                    gameTitle = split[1].TrimStart();
-                                }
-                            }
-                            else if (line.Contains("Title ID"))
-                            {
-                                string[] split = line.Split(':');
-                                Log.Information($"Title ID: {split[1].TrimStart()}");
-                                game_id = split[1].TrimStart();
-                                if (game_id == "Not found")
-                                {
-                                    game_id = split[1].TrimStart();
-                                }
-                            }
-                            else if (line.Contains("Media ID"))
-                            {
-                                string[] split = line.Split(':');
-                                Log.Information($"Media ID: {split[1].TrimStart()}");
-                                game_id = split[1].TrimStart();
-                            }*/
                         }
                     }
                 }

--- a/Xenia Manager/Pages/Library.xaml.cs
+++ b/Xenia Manager/Pages/Library.xaml.cs
@@ -152,7 +152,7 @@ namespace Xenia_Manager.Pages
         private async Task<BitmapImage> LoadOrCacheIcon(InstalledGame game)
         {
             await Task.Delay(1);
-            string iconFilePath = Path.Combine(App.baseDirectory, game.IconFilePath); // Path to the game icon
+            string iconFilePath = Path.Combine(App.baseDirectory, game.BoxartFilePath); // Path to the game icon
             string cacheDirectory = Path.Combine(App.baseDirectory, @"Icons\Cache\"); // Path to the cached directory
 
             // Tries to find cached icon
@@ -310,12 +310,19 @@ namespace Xenia_Manager.Pages
                     Log.Information($"Deleted configuration file: {Path.Combine(App.baseDirectory, game.ConfigFilePath)}");
                 };
 
-                // Remove game icon
-                if (game.IconFilePath != null && File.Exists(Path.Combine(App.baseDirectory, game.IconFilePath)))
+                // Remove game boxart
+                if (game.BoxartFilePath != null && File.Exists(Path.Combine(App.baseDirectory, game.BoxartFilePath)))
                 {
-                    File.Delete(Path.Combine(App.baseDirectory, game.IconFilePath));
-                    Log.Information($"Deleted icon: {Path.Combine(App.baseDirectory, game.IconFilePath)}");
+                    File.Delete(Path.Combine(App.baseDirectory, game.BoxartFilePath));
+                    Log.Information($"Deleted boxart: {Path.GetFileName(Path.Combine(App.baseDirectory, game.BoxartFilePath))}");
                 };
+
+                // Remove game icon
+                if (game.ShortcutIconFilePath != null && File.Exists(Path.Combine(App.baseDirectory, game.ShortcutIconFilePath)))
+                {
+                    File.Delete(Path.Combine(App.baseDirectory, game.ShortcutIconFilePath));
+                    Log.Information($"Deleted icon: {Path.GetFileName(Path.Combine(App.baseDirectory, game.ShortcutIconFilePath))}");
+                }
 
                 // Check if there is any content
                 string GameContentFolder = game.EmulatorVersion switch
@@ -712,25 +719,34 @@ namespace Xenia_Manager.Pages
             // Add "Add shortcut to desktop" option
             contextMenu.Items.Add(CreateMenuItem("Add shortcut to desktop", null, (sender, e) =>
             {
+                string IconLocation;
+                if (game.ShortcutIconFilePath != null)
+                {
+                    IconLocation = game.ShortcutIconFilePath;
+                }
+                else
+                {
+                    IconLocation = game.BoxartFilePath;
+                }
                 switch (game.EmulatorVersion)
                 {
                     case "Stable":
-                        ShortcutCreator.CreateShortcutOnDesktop(game.Title, Path.Combine(App.baseDirectory, App.appConfiguration.XeniaStable.ExecutableLocation), Path.Combine(App.baseDirectory, App.appConfiguration.XeniaStable.EmulatorLocation), $@"""{game.GameFilePath}"" --config ""{Path.Combine(App.baseDirectory, game.ConfigFilePath)}""", Path.Combine(App.baseDirectory, game.IconFilePath));
+                        ShortcutCreator.CreateShortcutOnDesktop(game.Title, Path.Combine(App.baseDirectory, App.appConfiguration.XeniaStable.ExecutableLocation), Path.Combine(App.baseDirectory, App.appConfiguration.XeniaStable.EmulatorLocation), $@"""{game.GameFilePath}"" --config ""{Path.Combine(App.baseDirectory, game.ConfigFilePath)}""", Path.Combine(App.baseDirectory, IconLocation));
                         break;
                     case "Canary":
-                        ShortcutCreator.CreateShortcutOnDesktop(game.Title, Path.Combine(App.baseDirectory, App.appConfiguration.XeniaCanary.ExecutableLocation), Path.Combine(App.baseDirectory, App.appConfiguration.XeniaCanary.EmulatorLocation), $@"""{game.GameFilePath}"" --config ""{Path.Combine(App.baseDirectory, game.ConfigFilePath)}""", Path.Combine(App.baseDirectory, game.IconFilePath));
+                        ShortcutCreator.CreateShortcutOnDesktop(game.Title, Path.Combine(App.baseDirectory, App.appConfiguration.XeniaCanary.ExecutableLocation), Path.Combine(App.baseDirectory, App.appConfiguration.XeniaCanary.EmulatorLocation), $@"""{game.GameFilePath}"" --config ""{Path.Combine(App.baseDirectory, game.ConfigFilePath)}""", Path.Combine(App.baseDirectory, IconLocation));
                         break;
                     case "Netplay":
-                        ShortcutCreator.CreateShortcutOnDesktop(game.Title, Path.Combine(App.baseDirectory, App.appConfiguration.XeniaNetplay.ExecutableLocation), Path.Combine(App.baseDirectory, App.appConfiguration.XeniaNetplay.EmulatorLocation), $@"""{game.GameFilePath}"" --config ""{Path.Combine(App.baseDirectory, game.ConfigFilePath)}""", Path.Combine(App.baseDirectory, game.IconFilePath));
+                        ShortcutCreator.CreateShortcutOnDesktop(game.Title, Path.Combine(App.baseDirectory, App.appConfiguration.XeniaNetplay.ExecutableLocation), Path.Combine(App.baseDirectory, App.appConfiguration.XeniaNetplay.EmulatorLocation), $@"""{game.GameFilePath}"" --config ""{Path.Combine(App.baseDirectory, game.ConfigFilePath)}""", Path.Combine(App.baseDirectory, IconLocation));
                         break;
                     case "Custom":
                         if (game.GameFilePath != null)
                         {
-                            ShortcutCreator.CreateShortcutOnDesktop(game.Title, game.EmulatorExecutableLocation, Path.GetDirectoryName(game.EmulatorExecutableLocation), $@"""{game.GameFilePath}"" --config ""{game.ConfigFilePath}""", Path.Combine(App.baseDirectory, game.IconFilePath));
+                            ShortcutCreator.CreateShortcutOnDesktop(game.Title, game.EmulatorExecutableLocation, Path.GetDirectoryName(game.EmulatorExecutableLocation), $@"""{game.GameFilePath}"" --config ""{game.ConfigFilePath}""", Path.Combine(App.baseDirectory, IconLocation));
                         }
                         else
                         {
-                            ShortcutCreator.CreateShortcutOnDesktop(game.Title, game.EmulatorExecutableLocation, Path.GetDirectoryName(game.EmulatorExecutableLocation), $@"""{game.GameFilePath}""", Path.Combine(App.baseDirectory, game.IconFilePath));
+                            ShortcutCreator.CreateShortcutOnDesktop(game.Title, game.EmulatorExecutableLocation, Path.GetDirectoryName(game.EmulatorExecutableLocation), $@"""{game.GameFilePath}""", Path.Combine(App.baseDirectory, IconLocation));
                         };
                         break;
                     default:

--- a/Xenia Manager/Pages/XeniaSettings.xaml
+++ b/Xenia Manager/Pages/XeniaSettings.xaml
@@ -1755,19 +1755,19 @@
                                                 </TextBlock>
                                             </ToolTip>
                                         </TextBlock.ToolTip>
-                                    API Address
-                                </TextBlock>
-                                    
-                                    <TextBox x:Name="apiAddressTextBox" 
-                                             Grid.Column="1"
-                                             AutomationProperties.Name="API Address"
-                                             AutomationProperties.HelpText="Address that points to the Xenia WebServices which is required for online play"
-                                             FontSize="18" 
-                                             HorizontalContentAlignment="Left"
-                                             Margin="0,10"
-                                             Style="{StaticResource TextBoxStyle}"
-                                             VerticalContentAlignment="Center"
-                                             Width="300"/>
+                                        API Address
+                                    </TextBlock>
+                                    <ComboBox x:Name="ApiAddress" 
+                                              Grid.Column="1" 
+                                              AutomationProperties.Name="API Address"
+                                              AutomationProperties.HelpText="Address that points to the Xenia WebServices which is required for online play"
+                                              FontSize="18"
+                                              HorizontalContentAlignment="Center"
+                                              IsEditable="True"
+                                              Margin="0,10" 
+                                              Style="{StaticResource ComboBoxStyle}"
+                                              VerticalContentAlignment="Center"
+                                              Width="300"/>
                                 </Grid>
                             </Border>
 

--- a/Xenia Manager/Pages/XeniaSettings.xaml
+++ b/Xenia Manager/Pages/XeniaSettings.xaml
@@ -333,52 +333,11 @@
                                 </TextBlock.ToolTip>
                                 Fullscreen
                             </TextBlock>
-                            
+
                             <CheckBox x:Name="Fullscreen" 
                                       Grid.Column="1" 
                                       AutomationProperties.Name="Fullscreen"
                                       AutomationProperties.HelpText="If enabled, it opens the emulator in fullscreen."
-                                      Cursor="Hand"
-                                      Margin="0,10" 
-                                      Style="{StaticResource CheckboxStyle}"
-                                      Width="45"/>
-                        </Grid>
-                    </Border>
-
-                    <!-- Letterboxing/Pillarboxing -->
-                    <Border Style="{StaticResource XeniaSetting}">
-                        <Grid Height="50">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition/>
-                                <ColumnDefinition/>
-                            </Grid.ColumnDefinitions>
-                            <TextBlock Grid.Column="0" 
-                                       FontSize="24" 
-                                       Style="{StaticResource SettingText}">
-                                <TextBlock.ToolTip>
-                                    <ToolTip>
-                                        <TextBlock TextAlignment="Left">
-                                            Black bars (Letterboxing/Pillarboxing)
-                                            <LineBreak/>
-                                            <TextBlock FontWeight="SemiBold" 
-                                                       Text="Options:" 
-                                                       TextDecorations="Underline"/>
-                                            <LineBreak/>
-                                            <TextBlock Padding="10,0,0,0"
-                                                       TextAlignment="Left">
-                                                - On (no stretching, default)
-                                                <LineBreak/>
-                                                - Off (stretching, required for aspect ratio patches)
-                                            </TextBlock>
-                                        </TextBlock>
-                                    </ToolTip>
-                                </TextBlock.ToolTip>
-                                Letterbox
-                            </TextBlock>
-                            
-                            <CheckBox x:Name="Letterbox" 
-                                      Grid.Column="1" 
-                                      AutomationProperties.Name="Letterbox"
                                       Cursor="Hand"
                                       Margin="0,10" 
                                       Style="{StaticResource CheckboxStyle}"
@@ -441,6 +400,83 @@
                                     <ComboBoxItem Content="1920x1080" />
                                 </ComboBox.Items>
                             </ComboBox>
+                        </Grid>
+                    </Border>
+
+                    <!-- Letterboxing/Pillarboxing -->
+                    <Border Style="{StaticResource XeniaSetting}">
+                        <Grid Height="50">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition/>
+                                <ColumnDefinition/>
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Grid.Column="0" 
+                                       FontSize="24" 
+                                       Style="{StaticResource SettingText}">
+                                <TextBlock.ToolTip>
+                                    <ToolTip>
+                                        <TextBlock TextAlignment="Left">
+                                            Black bars (Letterboxing/Pillarboxing)
+                                            <LineBreak/>
+                                            <TextBlock FontWeight="SemiBold" 
+                                                       Text="Options:" 
+                                                       TextDecorations="Underline"/>
+                                            <LineBreak/>
+                                            <TextBlock Padding="10,0,0,0"
+                                                       TextAlignment="Left">
+                                                - On (no stretching, default)
+                                                <LineBreak/>
+                                                - Off (stretching, required for aspect ratio patches)
+                                            </TextBlock>
+                                        </TextBlock>
+                                    </ToolTip>
+                                </TextBlock.ToolTip>
+                                Letterbox
+                            </TextBlock>
+                            
+                            <CheckBox x:Name="Letterbox" 
+                                      Grid.Column="1" 
+                                      AutomationProperties.Name="Letterbox"
+                                      Cursor="Hand"
+                                      Margin="0,10" 
+                                      Style="{StaticResource CheckboxStyle}"
+                                      Width="45"/>
+                        </Grid>
+                    </Border>
+
+                    <!-- Widescreen -->
+                    <Border x:Name="WidescreenSetting" 
+                            Style="{StaticResource XeniaSetting}">
+                        <Grid Height="50">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition/>
+                                <ColumnDefinition/>
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Grid.Column="0" 
+                                       FontSize="24" 
+                                       Style="{StaticResource SettingText}">
+                                <TextBlock.ToolTip>
+                                    <ToolTip>
+                                        <TextBlock TextAlignment="Left">
+                                            Toggles between 16:9 and 4:3 aspect ratio.
+                                            <LineBreak/>
+                                            <TextBlock FontWeight="Bold"
+                                                       Text="NOTE:"/>
+                                            Resolutions below 1280x720 run at 4:3 aspect ratio.
+                                        </TextBlock>
+                                    </ToolTip>
+                                </TextBlock.ToolTip>
+                                Widescreen
+                            </TextBlock>
+
+                            <CheckBox x:Name="Widescreen" 
+                                      Grid.Column="1" 
+                                      AutomationProperties.Name="Widescreen"
+                                      AutomationProperties.HelpText="Toggles between 16:9 and 4:3 aspect ratio."
+                                      Cursor="Hand"
+                                      Margin="0,10" 
+                                      Style="{StaticResource CheckboxStyle}"
+                                      Width="45"/>
                         </Grid>
                     </Border>
 
@@ -1418,6 +1454,40 @@
                         </Grid>
                     </Border>
 
+                    <!-- Allow Invalid Fetch Constants -->
+                    <Border Style="{StaticResource XeniaSetting}">
+                        <Grid Height="50">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition/>
+                                <ColumnDefinition/>
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Grid.Column="0" 
+                                       FontSize="24" 
+                                       Style="{StaticResource SettingText}">
+                                <TextBlock.ToolTip>
+                                    <ToolTip>
+                                        <TextBlock TextAlignment="Left">
+                                            Allow texture and vertex fetch constants with invalid type 
+                                            <LineBreak/>
+                                            Generally unsafe because the constant may contain completely invalid values,
+                                            <LineBreak/>
+                                            but may be used to bypass fetch constant type errors in certain games until the real reason why they're invalid is found
+                                        </TextBlock>
+                                    </ToolTip>
+                                </TextBlock.ToolTip>
+                                Allow Invalid Fetch Constants
+                            </TextBlock>
+
+                            <CheckBox x:Name="AllowInvalidFetchConstants" 
+                                      Grid.Column="1" 
+                                      AutomationProperties.Name="Gamma render target as sRGB"
+                                      Cursor="Hand"
+                                      Margin="0,10" 
+                                      Style="{StaticResource CheckboxStyle}"
+                                      Width="45"/>
+                        </Grid>
+                    </Border>
+
                     <!-- Gamma render target as sRGB -->
                     <Border Style="{StaticResource XeniaSetting}">
                         <Grid Height="50">
@@ -1441,8 +1511,76 @@
                                 </TextBlock.ToolTip>
                                 Gamma Render Target as sRGB
                             </TextBlock>
-                            
+
                             <CheckBox x:Name="gammaRenderTargetAsSRGB" 
+                                      Grid.Column="1" 
+                                      AutomationProperties.Name="Gamma render target as sRGB"
+                                      Cursor="Hand"
+                                      Margin="0,10" 
+                                      Style="{StaticResource CheckboxStyle}"
+                                      Width="45"/>
+                        </Grid>
+                    </Border>
+
+                    <!-- Query Occlusion Fake Sample Count -->
+                    <Border x:Name="QueryOcclusionFakeSampleCountSetting" 
+                            Style="{StaticResource XeniaSetting}">
+                        <Grid Height="50">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition/>
+                                <ColumnDefinition/>
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Grid.Column="0" 
+                                       FontSize="20" 
+                                       Style="{StaticResource SettingText}">
+                                <TextBlock.ToolTip>
+                                    <ToolTip>
+                                        <TextBlock TextAlignment="Left">
+                                            If set to -1 no sample counts are written, games may hang
+                                            <LineBreak/>
+                                            Else, the sample count of every tile will be incremented on every EVENT_WRITE_ZPD by this number
+                                            <LineBreak/>
+                                            Setting this to 0 means everything is reported as occluded
+                                        </TextBlock>
+                                    </ToolTip>
+                                </TextBlock.ToolTip>
+                                Query Occlusion Fake Sample Count
+                            </TextBlock>
+
+                            <TextBox x:Name="QueryOcclusionFakeSampleCountTextBox" 
+                                     Grid.Column="1"
+                                     AutomationProperties.Name="Max Queued Frames"
+                                     AutomationProperties.HelpText="Allows changing max buffered audio frames to reduce audio delay"
+                                     FontSize="18" 
+                                     HorizontalContentAlignment="Center"
+                                     Margin="0,10"
+                                     Style="{StaticResource TextBoxStyle}"
+                                     VerticalContentAlignment="Center"
+                                     Width="130"/>
+                        </Grid>
+                    </Border>
+
+                    <!-- Use Fuzzy Alpha Epsilon -->
+                    <Border x:Name="UseFuzzyAlphaEpsilonSetting" Style="{StaticResource XeniaSetting}">
+                        <Grid Height="50">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition/>
+                                <ColumnDefinition/>
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Grid.Column="0" 
+                                       FontSize="24" 
+                                       Style="{StaticResource SettingText}">
+                                <TextBlock.ToolTip>
+                                    <ToolTip>
+                                        <TextBlock TextAlignment="Left">
+                                            Use approximate compare for alpha values to prevent flickering on NVIDIA graphics cards
+                                        </TextBlock>
+                                    </ToolTip>
+                                </TextBlock.ToolTip>
+                                Use Fuzzy Alpha Epsilon
+                            </TextBlock>
+
+                            <CheckBox x:Name="UseFuzzyAlphaEpsilon" 
                                       Grid.Column="1" 
                                       AutomationProperties.Name="Gamma render target as sRGB"
                                       Cursor="Hand"

--- a/Xenia Manager/Pages/XeniaSettings.xaml.cs
+++ b/Xenia Manager/Pages/XeniaSettings.xaml.cs
@@ -209,15 +209,6 @@ namespace Xenia_Manager.Pages
                             Log.Information("Content settings");
                             // "license_mask" setting
                             Log.Information($"license_mask - {int.Parse(sectionTable["license_mask"].ToString())}");
-                            /*
-                            if (int.Parse(sectionTable["license_mask"].ToString()) == -1)
-                            {
-                                licenseMaskSelector.SelectedIndex = 0;
-                            }
-                            else
-                            {
-                                licenseMaskSelector.SelectedIndex = int.Parse(sectionTable["license_mask"].ToString());
-                            }*/
                             switch (int.Parse(sectionTable["license_mask"].ToString()))
                             {
                                 case -1:
@@ -535,11 +526,35 @@ namespace Xenia_Manager.Pages
                             Log.Information("Live settings");
                             NetplaySettings.Visibility = Visibility.Visible;
 
+                            // "api_list" setting
+                            if (sectionTable.ContainsKey("api_list"))
+                            {
+                                Log.Information($"api_list - {sectionTable["api_list"]}");
+                                ApiAddress.Items.Clear();
+                                string[] split = sectionTable["api_list"].ToString().Split(',');
+                                foreach (string apiAddress in split)
+                                {
+                                    if (apiAddress != "")
+                                    {
+                                        ApiAddress.Items.Add(apiAddress);
+                                    }
+                                }
+                            }
+
                             // "api_address" setting
                             if (sectionTable.ContainsKey("api_address"))
                             {
                                 Log.Information($"api_address - {sectionTable["api_address"]}");
-                                apiAddressTextBox.Text = sectionTable["api_address"].ToString();
+                                // Looking for the current API Address
+                                if (ApiAddress.Items.Contains(sectionTable["api_address"].ToString()))
+                                {
+                                    ApiAddress.SelectedItem = sectionTable["api_address"].ToString();
+                                }
+                                else
+                                {
+                                    ApiAddress.Items.Add(sectionTable["api_address"].ToString());
+                                    ApiAddress.SelectedItem = sectionTable["api_address"].ToString();
+                                }
                             }
 
                             // "upnp" setting
@@ -1231,7 +1246,17 @@ namespace Xenia_Manager.Pages
                             // "api_address" setting
                             if (sectionTable.ContainsKey("api_address"))
                             {
-                                sectionTable["api_address"] = apiAddressTextBox.Text;
+                                string selectedItem = ApiAddress.Items.Cast<string>().FirstOrDefault(item => item == ApiAddress.Text);
+                                if (selectedItem != null)
+                                {
+                                    // Text is one of the items in the ItemsSource
+                                    sectionTable["api_address"] = selectedItem;
+                                }
+                                else
+                                {
+                                    // Text is not in the ItemsSource
+                                    sectionTable["api_address"] = ApiAddress.Text;
+                                }
                             }
 
                             // "upnp" setting

--- a/Xenia Manager/Pages/XeniaSettings.xaml.cs
+++ b/Xenia Manager/Pages/XeniaSettings.xaml.cs
@@ -119,7 +119,9 @@ namespace Xenia_Manager.Pages
         /// </summary>
         private void HideNonUniversalSettings()
         {
+            WidescreenSetting.Visibility = Visibility.Collapsed;
             InternalDisplayResolutionOption.Visibility = Visibility.Collapsed;
+            UseFuzzyAlphaEpsilonSetting.Visibility  = Visibility.Collapsed;
             NetplaySettings.Visibility = Visibility.Collapsed;
         }
 
@@ -347,9 +349,23 @@ namespace Xenia_Manager.Pages
                                     break;
                             }
 
+                            // "gpu_allow_invalid_fetch_constants" setting
+                            if (sectionTable.ContainsKey("gpu_allow_invalid_fetch_constants"))
+                            {
+                                Log.Information($"gpu_allow_invalid_fetch_constants - {sectionTable["gpu_allow_invalid_fetch_constants"]}");
+                                AllowInvalidFetchConstants.IsChecked = (bool)sectionTable["gpu_allow_invalid_fetch_constants"];
+                            }
+
                             // "vsync" setting
                             Log.Information($"vsync - {sectionTable["vsync"]}");
                             vSync.IsChecked = (bool)sectionTable["vsync"];
+
+                            // "query_occlusion_fake_sample_count" setting
+                            if (sectionTable.ContainsKey("query_occlusion_fake_sample_count"))
+                            {
+                                Log.Information($"query_occlusion_fake_sample_count - {sectionTable["query_occlusion_fake_sample_count"].ToString()}");
+                                QueryOcclusionFakeSampleCountTextBox.Text = sectionTable["query_occlusion_fake_sample_count"].ToString();
+                            }
 
                             // "render_target_path_d3d12" setting
                             Log.Information($"render_target_path_d3d12 - {sectionTable["render_target_path_d3d12"] as string}");
@@ -392,6 +408,14 @@ namespace Xenia_Manager.Pages
                             {
                                 // Disable the option because it's not in the configuration file
                                 ClearMemoryPageStatusOption.Visibility = Visibility.Collapsed;
+                            }
+
+                            // "use_fuzzy_alpha_epsilon" setting
+                            if (sectionTable.ContainsKey("use_fuzzy_alpha_epsilon"))
+                            {
+                                Log.Information($"use_fuzzy_alpha_epsilon - {sectionTable["use_fuzzy_alpha_epsilon"]}");
+                                UseFuzzyAlphaEpsilon.IsChecked = (bool)sectionTable["use_fuzzy_alpha_epsilon"];
+                                UseFuzzyAlphaEpsilonSetting.Visibility = Visibility.Visible;
                             }
 
                             break;
@@ -634,6 +658,14 @@ namespace Xenia_Manager.Pages
                             {
                                 // Disable the option because it's not in the configuration file
                                 InternalDisplayResolutionOption.Visibility = Visibility.Collapsed;
+                            }
+
+                            // "widescreen" setting
+                            if (sectionTable.ContainsKey("widescreen"))
+                            {
+                                Log.Information($"widescreen - {(bool)sectionTable["widescreen"]}");
+                                WidescreenSetting.Visibility = Visibility.Visible;
+                                Widescreen.IsChecked = (bool)sectionTable["widescreen"];
                             }
 
                             break;
@@ -934,7 +966,6 @@ namespace Xenia_Manager.Pages
                     }
 
                     // FrameRate Limiter
-                    Log.Information($"{(uint)NvidiaFrameRateLimiter.Value}");
                     NvidiaApi.SetSettingValue((uint)0x10835002, (uint)NvidiaFrameRateLimiter.Value);
                 }
                 await Task.Delay(1);
@@ -1122,8 +1153,18 @@ namespace Xenia_Manager.Pages
                                     break;
                             }
 
+                            // "gpu_allow_invalid_fetch_constants" setting
+                            sectionTable["gpu_allow_invalid_fetch_constants"] = AllowInvalidFetchConstants.IsChecked;
+
                             // "vsync" setting
                             sectionTable["vsync"] = vSync.IsChecked;
+
+                            // "query_occlusion_fake_sample_count" setting
+                            if (sectionTable.ContainsKey("query_occlusion_fake_sample_count"))
+                            {
+                                Log.Information($"query_occlusion_fake_sample_count - {sectionTable["query_occlusion_fake_sample_count"].ToString()}");
+                                sectionTable["query_occlusion_fake_sample_count"] = int.Parse(QueryOcclusionFakeSampleCountTextBox.Text);
+                            }
 
                             // "render_target_path_d3d12" setting
                             switch (D3D12RenderTargetPathSelector.SelectedIndex)
@@ -1157,6 +1198,12 @@ namespace Xenia_Manager.Pages
                             if (sectionTable.ContainsKey("clear_memory_page_state"))
                             {
                                 sectionTable["clear_memory_page_state"] = ClearGPUCache.IsChecked;
+                            }
+
+                            // "use_fuzzy_alpha_epsilon" setting
+                            if (sectionTable.ContainsKey("use_fuzzy_alpha_epsilon"))
+                            {
+                                sectionTable["use_fuzzy_alpha_epsilon"] = UseFuzzyAlphaEpsilon.IsChecked;
                             }
 
                             break;
@@ -1309,6 +1356,12 @@ namespace Xenia_Manager.Pages
                             if (sectionTable.ContainsKey("internal_display_resolution"))
                             {
                                 sectionTable["internal_display_resolution"] = InternalDisplayResolutionSelector.SelectedIndex;
+                            }
+
+                            // "widescreen" setting
+                            if (sectionTable.ContainsKey("widescreen"))
+                            {
+                                sectionTable["widescreen"] = Widescreen.IsChecked;
                             }
 
                             break;

--- a/Xenia Manager/Windows/EditGameInfo.xaml
+++ b/Xenia Manager/Windows/EditGameInfo.xaml
@@ -169,6 +169,36 @@
                         </Grid>
                     </Border>
 
+                    <!-- Media ID -->
+                    <Border Background="{DynamicResource SettingBackgroundColor}"
+                            BorderBrush="{DynamicResource SettingBorderBrush}" 
+                            BorderThickness="2" 
+                            CornerRadius="10"
+                            Margin="5,2" >
+                        <Grid Height="50">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Grid.Column="0"
+                                       FontSize="24" 
+                                       Style="{StaticResource SettingText}">
+                                Media ID
+                            </TextBlock>
+                            <TextBox x:Name="MediaID" 
+                                     Grid.Column="1"
+                                     Background="Transparent"
+                                     BorderThickness="0"
+                                     FontSize="24" 
+                                     HorizontalAlignment="Center"
+                                     IsReadOnly="True"
+                                     Style="{StaticResource TextBoxStyle}"
+                                     VerticalAlignment="Center">
+                                12345678
+                            </TextBox>
+                        </Grid>
+                    </Border>
+
                     <!-- Game Title -->
                     <Border Background="{DynamicResource SettingBackgroundColor}"
                             BorderBrush="{DynamicResource SettingBorderBrush}" 

--- a/Xenia Manager/Windows/EditGameInfo.xaml
+++ b/Xenia Manager/Windows/EditGameInfo.xaml
@@ -155,12 +155,17 @@
                                        Style="{StaticResource SettingText}">
                                 Game ID
                             </TextBlock>
-                            <TextBlock x:Name="GameID" 
-                                       Grid.Column="1"
-                                       FontSize="24" 
-                                       Style="{StaticResource SettingText}">
+                            <TextBox x:Name="GameID" 
+                                     Grid.Column="1"
+                                     Background="Transparent"
+                                     BorderThickness="0"
+                                     FontSize="24" 
+                                     HorizontalAlignment="Center"
+                                     IsReadOnly="True"
+                                     Style="{StaticResource TextBoxStyle}"
+                                     VerticalAlignment="Center">
                                 12345678
-                            </TextBlock>
+                            </TextBox>
                         </Grid>
                     </Border>
 

--- a/Xenia Manager/Windows/EditGameInfo.xaml
+++ b/Xenia Manager/Windows/EditGameInfo.xaml
@@ -61,16 +61,61 @@
                           HorizontalScrollBarVisibility="Disabled"
                           VerticalScrollBarVisibility="Visible">
                 <StackPanel Margin="17,0,0,0">
-                    <!-- Game Icon -->
-                    <Grid>
-                        <Button x:Name="GameIcon" 
-                                AutomationProperties.Name="Game Icon"
-                                AutomationProperties.HelpText="Clicking on it allows you to select another game icon you want to use"
+                    <Grid Margin="0,0,0,10">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition/>
+                            <ColumnDefinition/>
+                        </Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition/>
+                            <RowDefinition/>
+                        </Grid.RowDefinitions>
+                        <!-- Game Boxart -->
+                        <Button x:Name="GameBoxart" 
+                                Grid.Column="0"
+                                Grid.Row="0"
+                                AutomationProperties.Name="Game Boxart"
+                                AutomationProperties.HelpText="Clicking on it allows you to select another game boxart you want to use"
                                 Cursor="Hand"
                                 Height="207"
                                 Margin="0,10"
                                 Style="{StaticResource GameCoverButtons}"
                                 Width="150"
+                                Click="GameBoxart_Click">
+                            <Button.ToolTip>
+                                <ToolTip>
+                                    <TextBlock TextAlignment="Left">
+                                        Click on the boxart to change it
+                                        <LineBreak/>
+                                        <TextBlock Text="NOTE:" 
+                                                   FontWeight="Bold"/>
+                                        Xenia Manager uses 150x207 boxart. 
+                                        <LineBreak/>
+                                        When adding a new boxart it will auto scale it so it fits the button and fill the unused space.
+                                    </TextBlock>
+                                </ToolTip>
+                            </Button.ToolTip>
+                        </Button>
+
+                        <!-- Text under Boxart -->
+                        <TextBlock Grid.Column="0" 
+                                   Grid.Row="1"
+                                   FontSize="24" 
+                                   Style="{StaticResource SettingText}">
+                            Boxart
+                        </TextBlock>
+
+                        <!-- Game Boxart -->
+                        <Button x:Name="GameIcon" 
+                                Grid.Column="1"
+                                Grid.Row="0"
+                                AutomationProperties.Name="Game Icon"
+                                AutomationProperties.HelpText="Clicking on it allows you to select another game icon you want to use"
+                                Cursor="Hand"
+                                Height="64"
+                                Margin="0,10"
+                                Style="{StaticResource GameCoverButtons}"
+                                Width="64"
                                 Click="GameIcon_Click">
                             <Button.ToolTip>
                                 <ToolTip>
@@ -79,13 +124,19 @@
                                         <LineBreak/>
                                         <TextBlock Text="NOTE:" 
                                                    FontWeight="Bold"/>
-                                        Xenia Manager uses 150x207 icons. 
-                                        <LineBreak/>
-                                        When adding a new icon it will auto scale it so it fits the button and fill the unused space.
+                                        By default, Xenia Manager creates 64x64 icons
                                     </TextBlock>
                                 </ToolTip>
                             </Button.ToolTip>
                         </Button>
+
+                        <!-- Text under Icon -->
+                        <TextBlock Grid.Column="1"
+                                   Grid.Row="1"
+                                   FontSize="24" 
+                                   Style="{StaticResource SettingText}">
+                            Icon
+                        </TextBlock>
                     </Grid>
 
                     <!-- Game ID -->

--- a/Xenia Manager/Windows/EditGameInfo.xaml.cs
+++ b/Xenia Manager/Windows/EditGameInfo.xaml.cs
@@ -23,7 +23,7 @@ namespace Xenia_Manager.Windows
     {
         // Selected game
         private InstalledGame game = new InstalledGame();
-
+        private string cachedShortcutIconPath;
         // Used to send a signal that this window has been closed
         private TaskCompletionSource<bool> _closeTaskCompletionSource = new TaskCompletionSource<bool>();
 
@@ -49,13 +49,13 @@ namespace Xenia_Manager.Windows
         /// <summary>
         /// Creates image for the button
         /// </summary>
-        /// <param name="game">Game itself</param>
+        /// <param name="imagePath">Path to the image that will be shown</param>
         /// <returns>Border - Content of the button</returns>
-        private async Task<Border> CreateButtonContent()
+        private async Task<Border> CreateButtonContent(string imagePath)
         {
             await Task.Delay(1);
             // Cached game icon
-            BitmapImage iconImage = new BitmapImage(new Uri(game.CachedIconPath));
+            BitmapImage iconImage = new BitmapImage(new Uri(imagePath));
             Image image = new Image
             {
                 Source = iconImage,
@@ -89,7 +89,16 @@ namespace Xenia_Manager.Windows
             {
                 GameID.Text = game.GameId;
                 GameTitle.Text = game.Title;
-                GameIcon.Content = await CreateButtonContent();
+                GameBoxart.Content = await CreateButtonContent(game.CachedIconPath);
+                if (game.ShortcutIconFilePath != null)
+                {
+                    await CacheImage(game.ShortcutIconFilePath, true);
+                    GameIcon.Content = await CreateButtonContent(cachedShortcutIconPath);
+                }
+                else
+                {
+                    GameIcon.Content = await CreateButtonContent(game.CachedIconPath);
+                }
                 await Task.Delay(1);
             }
             catch (Exception ex)
@@ -241,46 +250,31 @@ namespace Xenia_Manager.Windows
         /// <param name="width">Width of the box art. Default is 150</param>
         /// <param name="height">Height of the box art. Default is 207</param>
         /// <returns></returns>
-        private async Task GetGameIconFromFile(string filePath, string outputPath, int width = 150, int height = 207)
+        private void GetIconFromFile(string filePath, string outputPath, int width = 150, int height = 207)
         {
             try
             {
-                await Task.Delay(1);
+                // Checking what format the loaded icon is
+                MagickFormat format = Path.GetExtension(filePath).ToLower() switch
+                {
+                    ".jpg" or ".jpeg" => MagickFormat.Jpeg,
+                    ".png" => MagickFormat.Png,
+                    ".ico" => MagickFormat.Ico,
+                    _ => throw new NotSupportedException($"Unsupported file extension: {Path.GetExtension(filePath)}")
+                };
+                Log.Information($"Selected file format: {format}");
+
+                // Converting it to the proper size
                 using (FileStream fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read))
                 {
-                    using (MagickImage magickImage = new MagickImage(fileStream))
+                    using (MagickImage magickImage = new MagickImage(fileStream, format))
                     {
-                        double aspectRatio = (double)width / height;
+                        // Resize the image to the specified dimensions (this will stretch the image)
                         magickImage.Resize(width, height);
 
-                        double imageRatio = (double)magickImage.Width / magickImage.Height;
-                        int newWidth, newHeight, offsetX, offsetY;
-
-                        if (imageRatio > aspectRatio)
-                        {
-                            newWidth = width;
-                            newHeight = (int)Math.Round(width / imageRatio);
-                            offsetX = 0;
-                            offsetY = (height - newHeight) / 2;
-                        }
-                        else
-                        {
-                            newWidth = (int)Math.Round(height * imageRatio);
-                            newHeight = height;
-                            offsetX = (width - newWidth) / 2;
-                            offsetY = 0;
-                        }
-
-                        // Create a canvas with black background
-                        using (var canvas = new MagickImage(MagickColors.Black, width, height))
-                        {
-                            // Composite the resized image onto the canvas
-                            canvas.Composite(magickImage, offsetX, offsetY, CompositeOperator.SrcOver);
-
-                            // Convert to ICO format
-                            canvas.Format = MagickFormat.Ico;
-                            canvas.Write(outputPath);
-                        }
+                        // Convert to ICO format
+                        magickImage.Format = MagickFormat.Ico;
+                        magickImage.Write(outputPath);
                     }
                 }
             }
@@ -295,29 +289,34 @@ namespace Xenia_Manager.Windows
         /// Checks if the game icon is cached
         /// <para>If the game icon is not cached, it'll cache it</para>
         /// </summary>
-        /// <param name="game">Game</param>
+        /// <param name="imagePath">Path to the image that needs caching</param>
         /// <returns >BitmapImage - cached game icon</returns>
-        public async Task CacheIcon()
+        public async Task CacheImage(string imagePath, bool shortcutIcon = false)
         {
             await Task.Delay(1);
-            string iconFilePath = Path.Combine(App.baseDirectory, game.IconFilePath); // Path to the game icon
+            string iconFilePath = Path.Combine(App.baseDirectory, imagePath); // Path to the game icon
             string cacheDirectory = Path.Combine(App.baseDirectory, @"Icons\Cache\"); // Path to the cached directory
 
             Log.Information("Creating new cached icon for the game");
             string randomIconName = Path.GetRandomFileName().Replace(".", "").Substring(0, 8) + ".ico";
-            game.CachedIconPath = Path.Combine(cacheDirectory, randomIconName);
-
-            File.Copy(iconFilePath, game.CachedIconPath, true);
+            if (!shortcutIcon)
+            {
+                game.CachedIconPath = Path.Combine(cacheDirectory, randomIconName);
+                File.Copy(iconFilePath, game.CachedIconPath, true);
+            }
+            else
+            {
+                cachedShortcutIconPath = Path.Combine(cacheDirectory, randomIconName);
+                File.Copy(iconFilePath, cachedShortcutIconPath, true);
+            }
             Log.Information($"Cached icon name: {randomIconName}");
         }
 
         /// <summary>
-        /// Opens the file dialog and waits for user to select a new icon for the game
-        /// <para>Afterwards it'll apply the new icon to the game</para>
+        /// Opens the file dialog and waits for user to select a new boxart for the game
+        /// <para>Afterwards it'll apply the new boxart to the game</para>
         /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
-        private async void GameIcon_Click(object sender, RoutedEventArgs e)
+        private async void GameBoxart_Click(object sender, RoutedEventArgs e)
         {
             try
             {
@@ -325,8 +324,8 @@ namespace Xenia_Manager.Windows
                 OpenFileDialog openFileDialog = new OpenFileDialog();
 
                 // Set filter for image files
-                openFileDialog.Filter = "Image Files|*.jpg;*.jpeg;*.png|All Files|*.*";
-                openFileDialog.Title = $"Select a new icon for {game.Title}";
+                openFileDialog.Filter = "Image Files|*.jpg;*.jpeg;*.png;*.ico|All Files|*.*";
+                openFileDialog.Title = $"Select new boxart for {game.Title}";
 
                 // Allow the user to only select 1 file
                 openFileDialog.Multiselect = false;
@@ -338,22 +337,20 @@ namespace Xenia_Manager.Windows
                 if (result == true)
                 {
                     Log.Information($"Selected file: {Path.GetFileName(openFileDialog.FileName)}");
-
-                    Log.Information("Converting new icon into a .ico compatible with Xenia Manager");
                     if (game.Title == GameTitle.Text)
                     {
-                        await GetGameIconFromFile(openFileDialog.FileName, Path.Combine(App.baseDirectory, @$"Icons\{game.Title}.ico"));
+                        GetIconFromFile(openFileDialog.FileName, Path.Combine(App.baseDirectory, @$"Icons\{game.Title}.ico"));
                     }
                     else
                     {
-                        await GetGameIconFromFile(openFileDialog.FileName, Path.Combine(App.baseDirectory, @$"Icons\{game.Title}.ico"));
+                        GetIconFromFile(openFileDialog.FileName, Path.Combine(App.baseDirectory, @$"Icons\{game.Title}.ico"));
                         AdjustGameTitle();
                     }
-                    Log.Information("New icon is added to Icons folder");
+                    Log.Information("New boxart is added to the Icons folder");
 
-                    Log.Information("Changing icon showed on the button to the new one");
-                    await CacheIcon();
-                    GameIcon.Content = await CreateButtonContent();
+                    Log.Information("Changing boxart showed on the button to the new one");
+                    await CacheImage(game.BoxartFilePath);
+                    GameBoxart.Content = await CreateButtonContent(game.CachedIconPath);
                 }
                 await Task.Delay(1);
             }
@@ -361,6 +358,61 @@ namespace Xenia_Manager.Windows
             {
                 Log.Error(ex.Message + "\nFull Error:\n" + ex);
                 MessageBox.Show(ex.Message);
+                return;
+            }
+        }
+
+        /// <summary>
+        /// Opens the file dialog and waits for user to select a new icon for the game
+        /// <para>Afterwards it'll apply the new icon to the game</para>
+        /// </summary>
+        private async void GameIcon_Click(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                // Create OpenFileDialog
+                OpenFileDialog openFileDialog = new OpenFileDialog();
+
+                // Set filter for image files
+                openFileDialog.Filter = "Image Files|*.jpg;*.jpeg;*.png;*.ico|All Files|*.*";
+                openFileDialog.Title = $"Select new icon for {game.Title}";
+
+                // Allow the user to only select 1 file
+                openFileDialog.Multiselect = false;
+
+                // Show the dialog and get result
+                bool? result = openFileDialog.ShowDialog();
+
+                // Process open file dialog results
+                if (result == true)
+                {
+                    Log.Information($"Selected file: {Path.GetFileName(openFileDialog.FileName)}");
+                    if (game.Title == GameTitle.Text)
+                    {
+                        GetIconFromFile(openFileDialog.FileName, Path.Combine(App.baseDirectory, @$"Icons\{game.Title} Icon.ico"));
+                    }
+                    else
+                    {
+                        GetIconFromFile(openFileDialog.FileName, Path.Combine(App.baseDirectory, @$"Icons\{game.Title} Icon.ico"));
+                        AdjustGameTitle();
+                    }
+                    if (game.ShortcutIconFilePath == null)
+                    {
+                        game.ShortcutIconFilePath = @$"Icons\{game.Title} Icon.ico";
+                    }
+                    Log.Information("New icon is added to the Icons folder");
+
+                    Log.Information("Changing icon showed on the button to the new one");
+                    await CacheImage(game.ShortcutIconFilePath, true);
+                    GameIcon.Content = await CreateButtonContent(cachedShortcutIconPath);
+                }
+                await Task.Delay(1);
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex.Message + "\nFull Error:\n" + ex);
+                MessageBox.Show(ex.Message);
+                return;
             }
         }
 
@@ -401,8 +453,8 @@ namespace Xenia_Manager.Windows
                 game.Title = RemoveUnsupportedCharacters(GameTitle.Text);
 
                 Log.Information("Changing the name of icon");
-                File.Move(Path.Combine(App.baseDirectory, game.IconFilePath), Path.Combine(App.baseDirectory, $"Icons\\{game.Title}.ico"), true);
-                game.IconFilePath = $"Icons\\{game.Title}.ico";
+                File.Move(Path.Combine(App.baseDirectory, game.BoxartFilePath), Path.Combine(App.baseDirectory, $"Icons\\{game.Title}.ico"), true);
+                game.BoxartFilePath = $"Icons\\{game.Title}.ico";
             }
             catch (Exception ex)
             {

--- a/Xenia Manager/Windows/EditGameInfo.xaml.cs
+++ b/Xenia Manager/Windows/EditGameInfo.xaml.cs
@@ -88,6 +88,14 @@ namespace Xenia_Manager.Windows
             try
             {
                 GameID.Text = game.GameId;
+                if (game.MediaId != null)
+                {
+                    MediaID.Text = game.MediaId;
+                }
+                else
+                {
+                    MediaID.Text = "N/A";
+                }
                 GameTitle.Text = game.Title;
                 GameBoxart.Content = await CreateButtonContent(game.CachedIconPath);
                 if (game.ShortcutIconFilePath != null)

--- a/Xenia Manager/Windows/InstallContent.xaml
+++ b/Xenia Manager/Windows/InstallContent.xaml
@@ -101,21 +101,37 @@
                         <ColumnDefinition/>
                         <ColumnDefinition/>
                     </Grid.ColumnDefinitions>
-                    <!-- Add button -->
+                    <!-- Add local content button -->
                     <Button x:Name="Add" 
                             Grid.Column="0" 
-                            Grid.ColumnSpan="2"
                             AutomationProperties.Name="Add Content"
                             AutomationProperties.HelpText="Used for adding locally downloaded content such as DLC's' or Title Updates"
                             Content="&#xEC50;"
-                            HorizontalAlignment="Center"
-                            Margin="0"
+                            HorizontalAlignment="Right"
                             Style="{StaticResource TitleBarButton}"
                             VerticalAlignment="Center"
                             Click="Add_Click">
                         <Button.ToolTip>
                             <TextBlock TextAlignment="Left">
                                 Opens File Dialog where you can select locally downloaded content that you want to install for this specific game
+                            </TextBlock>
+                        </Button.ToolTip>
+                    </Button>
+
+                    <!-- Add XboxUnity TU button -->
+                    <Button x:Name="XboxUnity" 
+                            Grid.Column="1" 
+                            AutomationProperties.Name="XboxUnity Search"
+                            AutomationProperties.HelpText="Looks for title updates on XboxUnity"
+                            Content="&#xE753;"
+                            HorizontalAlignment="Left"
+                            Margin="10,0,0,0"
+                            Style="{StaticResource TitleBarButton}"
+                            VerticalAlignment="Center"
+                            Click="XboxUnity_Click">
+                        <Button.ToolTip>
+                            <TextBlock TextAlignment="Left">
+                                Opens a new window and searches for Title Updates on XboxUnity
                             </TextBlock>
                         </Button.ToolTip>
                     </Button>

--- a/Xenia Manager/Windows/InstallContent.xaml
+++ b/Xenia Manager/Windows/InstallContent.xaml
@@ -74,8 +74,9 @@
             <!-- Action buttons -->
             <Grid Grid.Row="4">
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition />
-                    <ColumnDefinition />
+                    <ColumnDefinition/>
+                    <ColumnDefinition/>
+                    <ColumnDefinition/>
                 </Grid.ColumnDefinitions>
 
                 <!-- Confirm button -->
@@ -93,10 +94,36 @@
                                    Style="{StaticResource AddGameText}"/>
                     </Button.Content>
                 </Button>
+                
+                <!-- Add/Xbox Unity Lookup Button -->
+                <Grid Grid.Column="1">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition/>
+                        <ColumnDefinition/>
+                    </Grid.ColumnDefinitions>
+                    <!-- Add button -->
+                    <Button x:Name="Add" 
+                            Grid.Column="0" 
+                            Grid.ColumnSpan="2"
+                            AutomationProperties.Name="Add Content"
+                            AutomationProperties.HelpText="Used for adding locally downloaded content such as DLC's' or Title Updates"
+                            Content="&#xEC50;"
+                            HorizontalAlignment="Center"
+                            Margin="0"
+                            Style="{StaticResource TitleBarButton}"
+                            VerticalAlignment="Center"
+                            Click="Add_Click">
+                        <Button.ToolTip>
+                            <TextBlock TextAlignment="Left">
+                                Opens File Dialog where you can select locally downloaded content that you want to install for this specific game
+                            </TextBlock>
+                        </Button.ToolTip>
+                    </Button>
+                </Grid>
 
                 <!-- Remove button -->
                 <Button x:Name="Remove" 
-                        Grid.Column="1"
+                        Grid.Column="2"
                         AutomationProperties.Name="Remove Button"
                         AutomationProperties.HelpText="Used to remove items you accidentally added for installation. Select the content from the ListBox (You can multiselect) and press Remove button to remove the items"
                         HorizontalAlignment="Center"

--- a/Xenia Manager/Windows/SelectGame.xaml
+++ b/Xenia Manager/Windows/SelectGame.xaml
@@ -74,11 +74,10 @@
                           SelectionChanged="SourceSelector_SelectionChanged">
                     <ComboBox.Items>
                         <ComboBoxItem Content="Xbox Marketplace" />
+                        <ComboBoxItem Content="Launchbox Database" />
                         <ComboBoxItem Content="Wikipedia" />
-                        <ComboBoxItem Content="Andy Decarli's List" />
                     </ComboBox.Items>
                 </ComboBox>
-
 
                 <!-- Lists of games-->
                 <Grid>
@@ -101,11 +100,11 @@
                         </ListBox.Resources>
                     </ListBox>
 
-                    <!-- Wikipedia's list of games -->
-                    <ListBox x:Name="WikipediaGames" 
+                    <!-- Launchbox Database -->
+                    <ListBox x:Name="LaunchboxDatabaseGames" 
                              Grid.Row="1"
                              Visibility="Collapsed"
-                             SelectionChanged="WikipediaGames_SelectionChanged">
+                             SelectionChanged="LaunchboxDatabaseGames_SelectionChanged">
                         <ListBox.Resources>
                             <Style TargetType="Border">
                                 <Setter Property="CornerRadius" 
@@ -114,11 +113,11 @@
                         </ListBox.Resources>
                     </ListBox>
 
-                    <!-- Andy Decarli's list of games -->
-                    <ListBox x:Name="AndyDecarliGames" 
-                             Grid.Row="2"
+                    <!-- Wikipedia's list of games -->
+                    <ListBox x:Name="WikipediaGames" 
+                             Grid.Row="1"
                              Visibility="Collapsed"
-                             SelectionChanged="AndyDecarliGames_SelectionChanged">
+                             SelectionChanged="WikipediaGames_SelectionChanged">
                         <ListBox.Resources>
                             <Style TargetType="Border">
                                 <Setter Property="CornerRadius" 

--- a/Xenia Manager/Windows/SelectTitleUpdate.xaml
+++ b/Xenia Manager/Windows/SelectTitleUpdate.xaml
@@ -1,0 +1,83 @@
+﻿<Window x:Class="Xenia_Manager.Windows.SelectTitleUpdate"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:Xenia_Manager.Windows"
+        mc:Ignorable="d"
+        Title="Xenia Manager - Select Title Update" 
+        Height="440" Width="418"
+        WindowStyle="None" ResizeMode="NoResize"
+        WindowStartupLocation="CenterScreen"
+        Background="Transparent" AllowsTransparency="True"
+        IsVisibleChanged="Window_IsVisibleChanged">
+    <Border Background="{DynamicResource BackgroundColor}"
+            BorderBrush="{DynamicResource BorderBrush}"
+            BorderThickness="2"
+            CornerRadius="10">
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="50"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+
+            <!-- Title and Close -->
+            <Grid Grid.Row="0">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition/>
+                    <ColumnDefinition Width="50"/>
+                </Grid.ColumnDefinitions>
+
+                <!-- Title -->
+                <TextBlock x:Name="TitleText"
+                           Grid.Column="0"
+                           FontSize="20"
+                           HorizontalAlignment="Center"
+                           Style="{StaticResource TitleTextBlock}"
+                           Text="Game Name Updates"
+                           TextWrapping="WrapWithOverflow"/>
+
+                <!-- Exit button -->
+                <Button x:Name="Exit"
+                        Grid.Column="1" 
+                        AutomationProperties.Name="Close Button"
+                        AutomationProperties.HelpText="Closes Select Game Patch window"
+                        Content="&#xE711;"
+                        Margin="0,0,10,0"
+                        Style="{StaticResource TitleBarButton}"
+                        Click="Exit_Click"/>
+            </Grid>
+
+            <!-- Seperation Line -->
+            <Border Grid.Row="1" 
+                    Style="{StaticResource SeperationLine}"/>
+
+            <!-- List of Title Updates -->
+            <ListBox x:Name="TitleUpdatesList" 
+                     Grid.Row="2"
+                     ScrollViewer.VerticalScrollBarVisibility="Auto"
+                     SelectionChanged="TitleUpdatesList_SelectionChanged">
+                <ListBox.Resources>
+                    <Style TargetType="Border">
+                        <Setter Property="CornerRadius" 
+                                Value="0,0,20,20"/>
+                    </Style>
+                </ListBox.Resources>
+            </ListBox>
+
+            <!-- Seperation Line -->
+            <Border Grid.Row="3" 
+                    Style="{StaticResource SeperationLine}"/>
+
+            <!-- Progress Bar -->
+            <ProgressBar x:Name="Progress"
+                         Grid.Row="4"
+                         Height="40"
+                         Margin="40,10"
+                         BorderThickness="2"/>
+        </Grid>
+    </Border>
+</Window>

--- a/Xenia Manager/Windows/SelectTitleUpdate.xaml.cs
+++ b/Xenia Manager/Windows/SelectTitleUpdate.xaml.cs
@@ -1,0 +1,199 @@
+﻿using System;
+using System.IO;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media.Animation;
+
+// Imported
+using Serilog;
+using Xenia_Manager.Classes;
+
+namespace Xenia_Manager.Windows
+{
+    /// <summary>
+    /// Interaction logic for SelectTitleUpdate.xaml
+    /// </summary>
+    public partial class SelectTitleUpdate : Window
+    {
+        // Instance of XboxUnityAPI
+        private XboxUnity xboxUnity { get; set; }
+
+        // Stores all of the available title updates
+        private List<XboxUnityTitleUpdate> titleUpdates { get; set; }
+
+        // Just a check to see if there are any updates
+        private bool haveUpdates = false;
+
+        // Location to the title update
+        public string TitleUpdateLocation { get; set; }
+
+        // Used to send a signal that this window has been closed
+        private TaskCompletionSource<bool> _closeTaskCompletionSource = new TaskCompletionSource<bool>();
+
+        public SelectTitleUpdate(string title, string gameid, string mediaid)
+        {
+            InitializeComponent();
+            xboxUnity = new XboxUnity(gameid, mediaid);
+            TitleText.Text = $"{title} Updates";
+            InitializeAsync();
+            Closed += (sender, args) => _closeTaskCompletionSource.TrySetResult(true);
+        }
+
+        /// <summary>
+        /// Tries to find all of the available title updates and loads them into the UI
+        /// </summary>
+        private async Task ReadTitleUpdatesIntoUI()
+        {
+            try
+            {
+                // Get all of the title updates into the UI
+                List<XboxUnityTitleUpdate> titleUpdates = await xboxUnity.GetTitleUpdates();
+                if (titleUpdates != null && titleUpdates.Count > 0)
+                {
+                    haveUpdates = true;
+                    foreach (XboxUnityTitleUpdate titleUpdate in titleUpdates)
+                    {
+                        Log.Information($"Version: {titleUpdate.Version}, TUID: {titleUpdate.id}");
+                    }
+                    TitleUpdatesList.ItemsSource = titleUpdates; // Load them into the UI
+                }
+                else
+                {
+                    MessageBox.Show("No Title Updates found");
+                    await ClosingAnimation();
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex.Message + "\nFull Error:\n" + ex);
+                MessageBox.Show(ex.Message);
+            }
+        }
+
+        /// <summary>
+        /// Function that executes other functions asynchronously
+        /// </summary>
+        private async void InitializeAsync()
+        {
+            try
+            {
+                await Dispatcher.InvokeAsync(() =>
+                {
+                    this.Visibility = Visibility.Hidden;
+                    Mouse.OverrideCursor = Cursors.Wait;
+                });
+
+                // Load all of the Title Updates into the UI
+                await ReadTitleUpdatesIntoUI();
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex.Message + "\nFull Error:\n" + ex);
+                MessageBox.Show(ex.Message);
+            }
+            finally
+            {
+                await Dispatcher.InvokeAsync(() =>
+                {
+                    if (haveUpdates)
+                    {
+                        this.Visibility = Visibility.Visible;
+                    }
+                    Mouse.OverrideCursor = null;
+                });
+            }
+        }
+
+        /// <summary>
+        /// Used to execute fade in animation when loading is finished
+        /// </summary>
+        private void Window_IsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)
+        {
+            if (this.Visibility == Visibility.Visible)
+            {
+                Storyboard fadeInStoryboard = ((Storyboard)Application.Current.FindResource("FadeInAnimation")).Clone();
+                if (fadeInStoryboard != null)
+                {
+                    fadeInStoryboard.Begin(this);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Does fade out animation before closing the window
+        /// </summary>
+        private async Task ClosingAnimation()
+        {
+            Storyboard FadeOutClosingAnimation = ((Storyboard)Application.Current.FindResource("FadeOutAnimation")).Clone();
+
+            FadeOutClosingAnimation.Completed += (sender, e) =>
+            {
+                Log.Information("Closing SelectTitleUpdate Window");
+                this.Close();
+            };
+
+            FadeOutClosingAnimation.Begin(this);
+            await Task.Delay(1);
+        }
+
+        /// <summary>
+        /// Closes this window
+        /// </summary>
+        private async void Exit_Click(object sender, RoutedEventArgs e)
+        {
+            await ClosingAnimation();
+        }
+
+        /// <summary>
+        /// Used to emulate a WaitForCloseAsync function that is similar to the one Process Class has
+        /// </summary>
+        /// <returns></returns>
+        public Task WaitForCloseAsync()
+        {
+            return _closeTaskCompletionSource.Task;
+        }
+
+        /// <summary>
+        /// When the user selects a title update from the list
+        /// </summary>
+        private async void TitleUpdatesList_SelectionChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
+        {
+            try
+            {
+                // Checking to make sure everything is selected properly
+                ListBox listBox = sender as ListBox;
+                if (listBox == null || listBox.SelectedItem == null)
+                {
+                    return;
+                }
+                XboxUnityTitleUpdate selectedTitleUpdate = TitleUpdatesList.SelectedItem as XboxUnityTitleUpdate;
+                if (selectedTitleUpdate == null)
+                {
+                    return;
+                }
+
+                // Checks if the folder for storing TU's exist
+                // If it doesn't, create it
+                if (!Directory.Exists(Path.Combine(App.baseDirectory, @"Downloads\")))
+                {
+                    Directory.CreateDirectory(Path.Combine(App.baseDirectory, @"Downloads\"));
+                }
+                Mouse.OverrideCursor = Cursors.Wait;
+                Log.Information($"Downloading {selectedTitleUpdate.ToString()}");
+                App.downloadManager.progressBar = Progress;
+                string url = $"http://xboxunity.net/Resources/Lib/TitleUpdate.php?tuid={selectedTitleUpdate.id}";
+                await App.downloadManager.DownloadFileAsync(url, Path.Combine(App.baseDirectory, $@"Downloads\{selectedTitleUpdate.ToString()}"));
+                TitleUpdateLocation = Path.Combine(App.baseDirectory, $@"Downloads\{selectedTitleUpdate.ToString()}");
+
+                Mouse.OverrideCursor = null;
+                await ClosingAnimation();
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex.Message + "\nFull Error:\n" + ex);
+                MessageBox.Show(ex.Message);
+            }
+        }
+    }
+}

--- a/Xenia Manager/Windows/WelcomeDialog.xaml.cs
+++ b/Xenia Manager/Windows/WelcomeDialog.xaml.cs
@@ -295,9 +295,9 @@ namespace Xenia_Manager.Windows
                         Log.Information($"Removing '{game.Title}' because it's using Xenia {XeniaVersion}");
 
                         // Removing game icon
-                        if (File.Exists(game.IconFilePath))
+                        if (File.Exists(game.BoxartFilePath))
                         {
-                            File.Delete(game.IconFilePath);
+                            File.Delete(game.BoxartFilePath);
                         }
 
                         // Removing the game

--- a/Xenia Manager/Xenia Manager.csproj
+++ b/Xenia Manager/Xenia Manager.csproj
@@ -9,8 +9,8 @@
     <UseWPF>true</UseWPF>
     <PlatformTarget>x64</PlatformTarget>
 	<NoWarn>CS8604, CS8602, CS8600</NoWarn>
-	<AssemblyVersion>1.11.0</AssemblyVersion>
-	<FileVersion>1.11.0</FileVersion>
+	<AssemblyVersion>1.12.0</AssemblyVersion>
+	<FileVersion>1.12.0</FileVersion>
 	<ApplicationIcon>Assets\icon.ico</ApplicationIcon>
   </PropertyGroup>
 


### PR DESCRIPTION
* Replaced Andy Decarli's source with the Launchbox Database for game information
* Game boxart editing now supports .ico files
* Added the ability to download and edit game icons for shortcuts via the "Edit Game Info" window (Might require PC reboot or icon cache reset because of Windows)
* Added support for launching games via launch arguments (e.g., Xenia Manager.exe "game title")
* Added option to download title updates from XboxUnity (Requires Game ID and Media ID. If you added the game before 1.11 you want to re-add the game in Xenia Manager so it properly reads Game ID and Media ID otherwise you won't be able to use this)
* Moved selection of locally available title updates and content to the "Install Content" window ("Explorer" Icon)
* Added settings for "Widescreen," "Allow Invalid Fetch Constants," "Use Fuzzy Alpha Epsilon," and "Query Occlusion Fake Sample Count" (Reordered some existing settings)
* Images will now be resized correctly instead of being filled with black borders (Re-add games for this to take effect)
* Changed "Api Address" setting to a dropdown menu with previous addresses used in Xenia Netplay, now allowing manual editing of the selected address