### PR TITLE
Update to Shortcut Creation

### DIFF
--- a/Xenia Manager/App.xaml.cs
+++ b/Xenia Manager/App.xaml.cs
@@ -518,6 +518,7 @@ namespace Xenia_Manager
                 catch (Exception ex)
                 {
                     Log.Error($"An error occurred: {ex.Message}");
+                    break;
                 }
             }
 

--- a/Xenia Manager/App.xaml.cs
+++ b/Xenia Manager/App.xaml.cs
@@ -507,7 +507,18 @@ namespace Xenia_Manager
             // Clearing icon cache
             foreach (string filePath in Directory.GetFiles(Path.Combine(baseDirectory, @"Icons\Cache"), "*", SearchOption.AllDirectories))
             {
-                File.Delete(filePath);  
+                try
+                {
+                    File.Delete(filePath);
+                }
+                catch (IOException IOEx)
+                {
+                    Log.Warning($"{Path.GetFileName(filePath)} won't get deleted since it's currently in use");
+                }
+                catch (Exception ex)
+                {
+                    Log.Error($"An error occurred: {ex.Message}");
+                }
             }
 
             // Clean old logs (Older than 7 days)

--- a/Xenia Manager/Classes/ShortcutCreator.cs
+++ b/Xenia Manager/Classes/ShortcutCreator.cs
@@ -52,13 +52,21 @@ namespace Xenia_Manager.Classes
 
     public static class ShortcutCreator
     {
-        public static void CreateShortcutOnDesktop(string shortcutName, string targetPath, string workingDirectory, string arguments, string? iconPath = null)
+        /// <summary>
+        /// Creates a shortcut and puts it on the desktop for the certain game
+        /// </summary>
+        /// <param name="shortcutName">Name of the game</param>
+        /// <param name="targetPath">Target towards the executable</param>
+        /// <param name="workingDirectory">Working directory</param>
+        /// <param name="gameTitle">Name of the game that we're launching</param>
+        /// <param name="iconPath">Icon used for the shortcut</param>
+        public static void CreateShortcutOnDesktop(string shortcutName, string targetPath, string workingDirectory, string gameTitle, string? iconPath = null)
         {
             Log.Information($"Creating the shortcut for {shortcutName}");
             IShellLink link = (IShellLink)new ShellLink();
             link.SetPath(targetPath);
             link.SetWorkingDirectory(workingDirectory);
-            link.SetArguments(arguments);
+            link.SetArguments(gameTitle);
 
             // Set the icon file if provided
             if (!string.IsNullOrEmpty(iconPath))

--- a/Xenia Manager/Pages/Library.xaml.cs
+++ b/Xenia Manager/Pages/Library.xaml.cs
@@ -808,30 +808,7 @@ namespace Xenia_Manager.Pages
                 {
                     IconLocation = game.BoxartFilePath;
                 }
-                switch (game.EmulatorVersion)
-                {
-                    case "Stable":
-                        ShortcutCreator.CreateShortcutOnDesktop(game.Title, Path.Combine(App.baseDirectory, App.appConfiguration.XeniaStable.ExecutableLocation), Path.Combine(App.baseDirectory, App.appConfiguration.XeniaStable.EmulatorLocation), $@"""{game.GameFilePath}"" --config ""{Path.Combine(App.baseDirectory, game.ConfigFilePath)}""", Path.Combine(App.baseDirectory, IconLocation));
-                        break;
-                    case "Canary":
-                        ShortcutCreator.CreateShortcutOnDesktop(game.Title, Path.Combine(App.baseDirectory, App.appConfiguration.XeniaCanary.ExecutableLocation), Path.Combine(App.baseDirectory, App.appConfiguration.XeniaCanary.EmulatorLocation), $@"""{game.GameFilePath}"" --config ""{Path.Combine(App.baseDirectory, game.ConfigFilePath)}""", Path.Combine(App.baseDirectory, IconLocation));
-                        break;
-                    case "Netplay":
-                        ShortcutCreator.CreateShortcutOnDesktop(game.Title, Path.Combine(App.baseDirectory, App.appConfiguration.XeniaNetplay.ExecutableLocation), Path.Combine(App.baseDirectory, App.appConfiguration.XeniaNetplay.EmulatorLocation), $@"""{game.GameFilePath}"" --config ""{Path.Combine(App.baseDirectory, game.ConfigFilePath)}""", Path.Combine(App.baseDirectory, IconLocation));
-                        break;
-                    case "Custom":
-                        if (game.GameFilePath != null)
-                        {
-                            ShortcutCreator.CreateShortcutOnDesktop(game.Title, game.EmulatorExecutableLocation, Path.GetDirectoryName(game.EmulatorExecutableLocation), $@"""{game.GameFilePath}"" --config ""{game.ConfigFilePath}""", Path.Combine(App.baseDirectory, IconLocation));
-                        }
-                        else
-                        {
-                            ShortcutCreator.CreateShortcutOnDesktop(game.Title, game.EmulatorExecutableLocation, Path.GetDirectoryName(game.EmulatorExecutableLocation), $@"""{game.GameFilePath}""", Path.Combine(App.baseDirectory, IconLocation));
-                        };
-                        break;
-                    default:
-                        break;
-                }
+                ShortcutCreator.CreateShortcutOnDesktop(game.Title, Path.Combine(App.baseDirectory, "Xenia Manager.exe"), App.baseDirectory, $@"""{game.Title}""", Path.Combine(App.baseDirectory, IconLocation));
             }));
 
             // Add "Open Compatibility Page" option


### PR DESCRIPTION
Now it will use Xenia Manager launch arguments instead of creating shortcuts based on xenia emulator location. With this change, shortcuts will now work even if the user changes the version of Xenia the game uses, as long as Xenia Manager's location hasn't changed the shortcuts should always work.