### PR TITLE
Improvements to Xenia Manager Settings & Bugfixes

### DIFF
--- a/Xenia Manager/Pages/Settings.xaml
+++ b/Xenia Manager/Pages/Settings.xaml
@@ -158,7 +158,7 @@
                                     Margin="20,0"
                                     Style="{StaticResource ButtonStyle}"
                                     VerticalAlignment="Center"
-                                    MaxWidth="500"
+                                    MaxWidth="410"
                                     Click="ResetXeniaManagerConfigurationFile_Click">
                                 <Button.Content>
                                     <TextBlock FontSize="24"
@@ -169,6 +169,32 @@
                                     <ToolTip>
                                         <TextBlock TextAlignment="Left">
                                             This will reset the configuration file of Xenia Manager.
+                                            <LineBreak/>
+                                            Useful if something isn't working.
+                                        </TextBlock>
+                                    </ToolTip>
+                                </Button.ToolTip>
+                            </Button>
+
+                            <!-- Reset Xenia Manager Configuration -->
+                            <Button x:Name="ResetXeniaConfigurationFile" 
+                                    Grid.Column="1"
+                                    Grid.Row="1"
+                                    HorizontalAlignment="Stretch"
+                                    Margin="20,0"
+                                    Style="{StaticResource ButtonStyle}"
+                                    VerticalAlignment="Center"
+                                    MaxWidth="310"
+                                    Click="ResetXeniaConfigurationFile_Click">
+                                <Button.Content>
+                                    <TextBlock FontSize="24"
+                                               Style="{StaticResource AddGameText}"
+                                               Text="Reset Xenia Configuration"/>
+                                </Button.Content>
+                                <Button.ToolTip>
+                                    <ToolTip>
+                                        <TextBlock TextAlignment="Left">
+                                            This will delete the current configuration file of the selected Xenia Emulator and generate a new one.
                                             <LineBreak/>
                                             Useful if something isn't working.
                                         </TextBlock>

--- a/Xenia Manager/Pages/Settings.xaml
+++ b/Xenia Manager/Pages/Settings.xaml
@@ -35,84 +35,6 @@
                           HorizontalScrollBarVisibility="Hidden"
                           VerticalScrollBarVisibility="Hidden">
                 <StackPanel>
-                    <!-- Buttons -->
-                    <Border Background="{DynamicResource SettingBackgroundColor}"
-                            BorderBrush="{DynamicResource SettingBorderBrush}" 
-                            BorderThickness="2"
-                            CornerRadius="10"
-                            Margin="5,2">
-                        <Grid Height="50">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="*"/>
-                                <ColumnDefinition Width="*"/>
-                                <ColumnDefinition Width="*"/>
-                            </Grid.ColumnDefinitions>
-                            <!-- Xenia Installer -->
-                            <Button x:Name="OpenXeniaInstaller" 
-                                    Grid.Column="0"
-                                    HorizontalAlignment="Stretch"
-                                    Margin="20,0"
-                                    Style="{StaticResource ButtonStyle}"
-                                    VerticalAlignment="Center"
-                                    MaxWidth="250"
-                                    Click="OpenXeniaInstaller_Click">
-                                <Button.Content>
-                                    <TextBlock FontSize="24"
-                                               Style="{StaticResource AddGameText}"
-                                               Text="Open Xenia Installer"/>
-                                </Button.Content>
-                                <Button.ToolTip>
-                                    <ToolTip>
-                                        <TextBlock TextAlignment="Left">
-                                            In case you want to install Stable or Canary version of Xenia
-                                        </TextBlock>
-                                    </ToolTip>
-                                </Button.ToolTip>
-                            </Button>
-
-                            <!-- Reset Configuration -->
-                            <Button x:Name="ResetConfigurationFile" 
-                                    Grid.Column="1"
-                                    HorizontalAlignment="Stretch"
-                                    Margin="20,0"
-                                    Style="{StaticResource ButtonStyle}"
-                                    VerticalAlignment="Center"
-                                    MaxWidth="250"
-                                    Click="ResetConfigurationFile_Click">
-                                <Button.Content>
-                                    <TextBlock FontSize="24"
-                                               Style="{StaticResource AddGameText}"
-                                               Text="Reset Configuration"/>
-                                </Button.Content>
-                                <Button.ToolTip>
-                                    <ToolTip>
-                                        <TextBlock TextAlignment="Left">
-                                            This will reset the configuration file of Xenia Manager.
-                                            <LineBreak/>
-                                            Useful if something isn't working.
-                                        </TextBlock>
-                                    </ToolTip>
-                                </Button.ToolTip>
-                            </Button>
-
-                            <!-- Show changelog -->
-                            <Button x:Name="OpenChangelog" 
-                                    Grid.Column="2"
-                                    HorizontalAlignment="Center"
-                                    Margin="0"
-                                    Style="{StaticResource ButtonStyle}"
-                                    VerticalAlignment="Center"
-                                    MaxWidth="250"
-                                    Click="OpenChangelog_Click">
-                                <Button.Content>
-                                    <TextBlock FontSize="24"
-                                               Style="{StaticResource AddGameText}"
-                                               Text="Changelog"/>
-                                </Button.Content>
-                            </Button>
-                        </Grid>
-                    </Border>
-                    
                     <!-- Theme Selector-->
                     <Border Background="{DynamicResource SettingBackgroundColor}"
                             BorderBrush="{DynamicResource SettingBorderBrush}" 
@@ -168,6 +90,91 @@
                                     <ComboBoxItem Content="Nord" />
                                 </ComboBox.Items>
                             </ComboBox>
+                        </Grid>
+                    </Border>
+                    
+                    <!-- Buttons -->
+                    <Border Background="{DynamicResource SettingBackgroundColor}"
+                            BorderBrush="{DynamicResource SettingBorderBrush}" 
+                            BorderThickness="2"
+                            CornerRadius="10"
+                            Margin="5,2">
+                        <Grid Height="100">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="*"/>
+                            </Grid.ColumnDefinitions>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="*"/>
+                                <RowDefinition Height="*"/>
+                            </Grid.RowDefinitions>
+
+                            <!-- Xenia Installer -->
+                            <Button x:Name="OpenXeniaInstaller" 
+                                    Grid.Column="0"
+                                    Grid.Row="0"
+                                    HorizontalAlignment="Stretch"
+                                    Margin="20,0"
+                                    Style="{StaticResource ButtonStyle}"
+                                    VerticalAlignment="Center"
+                                    MaxWidth="250"
+                                    Click="OpenXeniaInstaller_Click">
+                                <Button.Content>
+                                    <TextBlock FontSize="24"
+                                               Style="{StaticResource AddGameText}"
+                                               Text="Open Xenia Installer"/>
+                                </Button.Content>
+                                <Button.ToolTip>
+                                    <ToolTip>
+                                        <TextBlock TextAlignment="Left">
+                                            In case you want to install Stable or Canary version of Xenia
+                                        </TextBlock>
+                                    </ToolTip>
+                                </Button.ToolTip>
+                            </Button>
+
+                            <!-- Show changelog -->
+                            <Button x:Name="OpenChangelog" 
+                                    Grid.Column="2"
+                                    Grid.Row="0"
+                                    HorizontalAlignment="Center"
+                                    Margin="0"
+                                    Style="{StaticResource ButtonStyle}"
+                                    VerticalAlignment="Center"
+                                    MaxWidth="250"
+                                    Click="OpenChangelog_Click">
+                                <Button.Content>
+                                    <TextBlock FontSize="24"
+                                               Style="{StaticResource AddGameText}"
+                                               Text="Changelog"/>
+                                </Button.Content>
+                            </Button>
+
+                            <!-- Reset Xenia Manager Configuration -->
+                            <Button x:Name="ResetXeniaManagerConfigurationFile" 
+                                    Grid.Column="0"
+                                    Grid.Row="1"
+                                    HorizontalAlignment="Stretch"
+                                    Margin="20,0"
+                                    Style="{StaticResource ButtonStyle}"
+                                    VerticalAlignment="Center"
+                                    MaxWidth="500"
+                                    Click="ResetXeniaManagerConfigurationFile_Click">
+                                <Button.Content>
+                                    <TextBlock FontSize="24"
+                                               Style="{StaticResource AddGameText}"
+                                               Text="Reset Xenia Manager Configuration"/>
+                                </Button.Content>
+                                <Button.ToolTip>
+                                    <ToolTip>
+                                        <TextBlock TextAlignment="Left">
+                                            This will reset the configuration file of Xenia Manager.
+                                            <LineBreak/>
+                                            Useful if something isn't working.
+                                        </TextBlock>
+                                    </ToolTip>
+                                </Button.ToolTip>
+                            </Button>
                         </Grid>
                     </Border>
                 </StackPanel>

--- a/Xenia Manager/Pages/Settings.xaml.cs
+++ b/Xenia Manager/Pages/Settings.xaml.cs
@@ -160,7 +160,7 @@ namespace Xenia_Manager.Pages
         /// <summary>
         /// Resets the configuration file of Xenia Manager and tries to assign new paths to Xenia stuff
         /// </summary>
-        private async void ResetConfigurationFile_Click(object sender, RoutedEventArgs e)
+        private async void ResetXeniaManagerConfigurationFile_Click(object sender, RoutedEventArgs e)
         {
             try
             {

--- a/Xenia Manager/Pages/Settings.xaml.cs
+++ b/Xenia Manager/Pages/Settings.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.IO;
 using System.Windows;
 using System.Windows.Controls;
@@ -158,13 +159,31 @@ namespace Xenia_Manager.Pages
         }
 
         /// <summary>
+        /// Shows changelog
+        /// </summary>
+        private async void OpenChangelog_Click(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                ChangelogWindow changelogWindow = new ChangelogWindow();
+                changelogWindow.Show();
+                await changelogWindow.WaitForCloseAsync();
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex.Message + "\nFull Error:\n" + ex);
+                MessageBox.Show(ex.Message);
+                return;
+            }
+        }
+
+        /// <summary>
         /// Resets the configuration file of Xenia Manager and tries to assign new paths to Xenia stuff
         /// </summary>
         private async void ResetXeniaManagerConfigurationFile_Click(object sender, RoutedEventArgs e)
         {
             try
             {
-                await Task.Delay(1);
                 int numberOfXeniaInstallation = 0;
                 // Checking if Xenia Stable is installed
                 if (App.appConfiguration.XeniaStable != null)
@@ -284,17 +303,92 @@ namespace Xenia_Manager.Pages
                 return;
             }
         }
-
+        
         /// <summary>
-        /// Shows changelog
+        /// Deletes current configuration file of selected Xenia Version and launches Xenia to generate new configuration file
         /// </summary>
-        private async void OpenChangelog_Click(object sender, RoutedEventArgs e)
+        /// <param name="XeniaVersion">Selected Xenia Version</param>
+        private async Task ResetXeniaEmulatorConfigurationFile(string XeniaVersion)
         {
             try
             {
-                ChangelogWindow changelogWindow = new ChangelogWindow();
-                changelogWindow.Show();
-                await changelogWindow.WaitForCloseAsync();
+                Log.Information(XeniaVersion);
+                EmulatorInfo SelectedXeniaVersion = XeniaVersion switch
+                {
+                    "Canary" => App.appConfiguration.XeniaCanary,
+                    "Stable" => App.appConfiguration.XeniaStable,
+                    "Netplay" => App.appConfiguration.XeniaNetplay,
+                    _ => throw new InvalidOperationException("Unexpected build type")
+                };
+
+                // Deleting the configuration file
+                Log.Information("Deleting the current configuration file");
+                if (File.Exists(Path.Combine(App.baseDirectory, SelectedXeniaVersion.ConfigurationFileLocation)))
+                {
+                    File.Delete(Path.Combine(App.baseDirectory, SelectedXeniaVersion.ConfigurationFileLocation));
+                }
+
+                // Launching Xenia to generate new configuration file
+                Process xenia = new Process();
+                xenia.StartInfo.FileName = Path.Combine(App.baseDirectory, SelectedXeniaVersion.ExecutableLocation);
+                xenia.Start();
+                Log.Information("Emulator Launched");
+                Log.Information("Waiting for configuration file to be generated");
+                while (!File.Exists(Path.Combine(App.baseDirectory, SelectedXeniaVersion.ConfigurationFileLocation)))
+                {
+                    await Task.Delay(100);
+                }
+                Log.Information("Configuration file found");
+                Log.Information("Closing the emulator");
+                xenia.Kill();
+                Log.Information("Emulator closed");
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex.Message + "\nFull Error:\n" + ex);
+                return;
+            }
+        }
+
+        /// <summary>
+        /// Opens XeniaSelection dialog and resets the configuration file of the selected Xenia Emulator
+        /// </summary>
+        private async void ResetXeniaConfigurationFile_Click(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                // Checking for existing Xenia versions
+                Log.Information("Checking for existing Xenia versions");
+                List<string> availableXeniaVersions = new List<string>();
+                if (App.appConfiguration.XeniaStable != null) availableXeniaVersions.Add("Stable");
+                if (App.appConfiguration.XeniaCanary != null) availableXeniaVersions.Add("Canary");
+                if (App.appConfiguration.XeniaNetplay != null) availableXeniaVersions.Add("Netplay");
+
+                // Check how many Xenia's are installed
+                switch (availableXeniaVersions.Count)
+                {
+                    case 0:
+                        // If there are no Xenia versions installed, don't do anything
+                        Log.Information("No Xenia installations detected");
+                        MessageBox.Show("No Xenia installations detected");
+                        break;
+                    case 1:
+                        // If there is only 1 version of Xenia installed, reset configuration file of that Xenia Version
+                        Log.Information($"Only Xenia {availableXeniaVersions[0]} is installed");
+                        await ResetXeniaEmulatorConfigurationFile(availableXeniaVersions[0]);
+                        MessageBox.Show($"Configuration file for Xenia {availableXeniaVersions[0]} has been reset to default.");
+                        break;
+                    default:
+                        // If there are 2 or more versions of Xenia installed, ask the user which configuration file he wants to reset
+                        Log.Information("Detected multiple Xenia installations");
+                        Log.Information("Asking user what Xenia version's configuration file should be reset");
+                        XeniaSelection xs = new XeniaSelection();
+                        await xs.WaitForCloseAsync();
+                        Log.Information($"User selected Xenia {xs.UserSelection}");
+                        await ResetXeniaEmulatorConfigurationFile(xs.UserSelection);
+                        MessageBox.Show($"Configuration file for Xenia {xs.UserSelection} has been reset to default.");
+                        break;
+                }
             }
             catch (Exception ex)
             {

--- a/Xenia Manager/Pages/XeniaSettings.xaml.cs
+++ b/Xenia Manager/Pages/XeniaSettings.xaml.cs
@@ -1016,18 +1016,24 @@ namespace Xenia_Manager.Pages
                                 try
                                 {
                                     int apuint = int.Parse(apuMaxQueuedFramesTextBox.Text);
-                                    if (apuint < 16)
+                                    if (apuint < 4)
                                     {
-                                        MessageBox.Show("apu_max_queued_frames minimal value is 16");
-                                        apuint = 16;
+                                        MessageBox.Show("apu_max_queued_frames minimal value is 4");
+                                        apuint = 4;
                                     }
+                                    else if (apuint > 64)
+                                    {
+                                        MessageBox.Show("apu_max_queued_frames maximum value is 64");
+                                        apuint = 64;
+                                    }
+                                    apuMaxQueuedFramesTextBox.Text = apuint.ToString();
                                     sectionTable["apu_max_queued_frames"] = apuint;
                                 }
                                 catch (Exception ex)
                                 {
                                     Log.Error(ex.Message + "\nFull Error:\n" + ex);
-                                    MessageBox.Show("Invalid input: apu_max_queued_frames must be a number.\nSetting the default value of 64.");
-                                    sectionTable["apu_max_queued_frames"] = 64;
+                                    MessageBox.Show("Invalid input: apu_max_queued_frames must be a number.\nSetting the default value of 16.");
+                                    sectionTable["apu_max_queued_frames"] = 16;
                                 }
                             }
 
@@ -1578,7 +1584,7 @@ namespace Xenia_Manager.Pages
             if (apuMaxQueuedFramesTextBox.Text.Length > 12)
             {
                 MessageBox.Show("You went over the allowed limit");
-                apuMaxQueuedFramesTextBox.Text = "64";
+                apuMaxQueuedFramesTextBox.Text = "16";
             }
         }
 

--- a/Xenia Manager/Windows/SelectGame.xaml.cs
+++ b/Xenia Manager/Windows/SelectGame.xaml.cs
@@ -114,7 +114,7 @@ namespace Xenia_Manager.Windows
                 // Xbox Marketplace List
                 Log.Information("Loading Xbox Marketplace list of games");
                 List<string> displayItems = new List<string>();
-                string url = "https://raw.githubusercontent.com/xenia-manager/Database/main/Database/olds_xbox_marketplace_games.json";
+                string url = "https://raw.githubusercontent.com/xenia-manager/Database/main/Database/old_xbox_marketplace_games.json";
                 using (HttpClient client = new HttpClient())
                 {
                     try


### PR DESCRIPTION
- Reordered the settings so all of the useful buttons are in their own space
- Theme switcher is now on top
- Renamed "Reset Configuration File" to "Reset Xenia Manager Configuration File"
- Added "Reset Xenia Configuration" option (Deletes the current "default" configuration file for specified Xenia Emulator (If there are more than 1 installed, asks the user, otherwise it uses the one installed) and launch the selected Xenia to generate a new version)
- "apu_max_queued_frames" value range is now [4,64] and the default value set if there is an incorrect input is now 16 instead of 64
- Fixed the URL for reading Xbox Marketplace source