### PR TITLE
Version 1.15.1

### DIFF
--- a/Xenia Manager/Pages/Library.xaml.cs
+++ b/Xenia Manager/Pages/Library.xaml.cs
@@ -626,8 +626,6 @@ namespace Xenia_Manager.Pages
                     Log.Information($"Selected file: {openFileDialog.FileName}");
                     System.IO.File.Copy(openFileDialog.FileName, Path.Combine(App.baseDirectory, EmulatorLocation, @$"patches\{Path.GetFileName(openFileDialog.FileName)}"), true);
                     Log.Information("Copying the file to the patches folder.");
-                    System.IO.File.Delete(openFileDialog.FileName);
-                    Log.Information("Deleting the original file.");
                     game.PatchFilePath = Path.Combine(EmulatorLocation, @$"patches\{Path.GetFileName(openFileDialog.FileName)}");
                     MessageBox.Show($"{game.Title} patch has been installed");
                 }

--- a/Xenia Manager/Windows/EditGameInfo.xaml.cs
+++ b/Xenia Manager/Windows/EditGameInfo.xaml.cs
@@ -347,11 +347,11 @@ namespace Xenia_Manager.Windows
                     Log.Information($"Selected file: {Path.GetFileName(openFileDialog.FileName)}");
                     if (game.Title == GameTitle.Text)
                     {
-                        GetIconFromFile(openFileDialog.FileName, Path.Combine(App.baseDirectory, @$"Icons\{game.Title}.ico"));
+                        GetIconFromFile(openFileDialog.FileName, Path.Combine(App.baseDirectory, @$"Icons\{game.Title} Boxart.ico"));
                     }
                     else
                     {
-                        GetIconFromFile(openFileDialog.FileName, Path.Combine(App.baseDirectory, @$"Icons\{game.Title}.ico"));
+                        GetIconFromFile(openFileDialog.FileName, Path.Combine(App.baseDirectory, @$"Icons\{game.Title} Boxart.ico"));
                         AdjustGameTitle();
                     }
                     Log.Information("New boxart is added to the Icons folder");


### PR DESCRIPTION
* Fixed a bug where changing boxart wasn't working properly
* When installing locally available patches, the original file won't be deleted anymore (It will just copy and paste the patches file to the correct folder)