### PR TITLE
Add scan directory button

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ If you have any questions, hop over to the [frequently asked questions](https://
 ## Contributors
 [![Contributors](https://contrib.rocks/image?repo=xenia-manager/xenia-manager)](https://github.com/xenia-manager/xenia-manager/graphs/contributors)
 
-## Research & refrences
+## Research & references
 - [Icons8 (for compatibility rating icons)](https://icons8.com/icons)
 - [NvAPI Documentation (for settings not available in NvAPIWrapper)](https://developer.nvidia.com/rtx/path-tracing/nvapi/get-started)
 - [NVIDIA Profile Inspector by Orbmu2k (for checking NVIDIA Driver settings)](https://github.com/Orbmu2k/nvidiaProfileInspector)

--- a/Xenia Manager/App.xaml
+++ b/Xenia Manager/App.xaml
@@ -149,11 +149,11 @@
             <Style x:Key="NavigationButtonIcon" TargetType="TextBlock">
                 <Setter Property="FontFamily" Value="{StaticResource SegoeFluentIcons}"/>
                 <Setter Property="Foreground" Value="{DynamicResource ForegroundColor}"/>
+                <Setter Property="FontWeight" Value="Normal"/>
                 <Setter Property="HorizontalAlignment" Value="Center"/>
             </Style>
             <Style x:Key="NavigationButtonText" TargetType="TextBlock">
                 <Setter Property="FontFamily" Value="{StaticResource SegoeFluent}"/>
-                <Setter Property="FontWeight" Value="SemiBold"/>
                 <Setter Property="Foreground" Value="{DynamicResource ForegroundColor}"/>
                 <Setter Property="HorizontalAlignment" Value="Center"/>
             </Style>
@@ -191,7 +191,7 @@
             </Style>
             <Style x:Key="AddGameText" TargetType="TextBlock">
                 <Setter Property="FontFamily" Value="{StaticResource SegoeFluent}"/>
-                <Setter Property="FontWeight" Value="SemiBold"/>
+                <Setter Property="FontWeight" Value="Normal"/>
                 <Setter Property="Foreground" Value="{DynamicResource ForegroundColor}"/>
                 <Setter Property="Margin" Value="10,0,10,0"/>
             </Style>

--- a/Xenia Manager/App.xaml
+++ b/Xenia Manager/App.xaml
@@ -201,7 +201,6 @@
                 <Setter Property="Background" Value="Transparent"/>
                 <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushSecondary}"/>
                 <Setter Property="BorderThickness" Value="3"/>
-                <Setter Property="Height" Value="207"/>
                 <Setter Property="Margin" Value="5"/>
                 <Setter Property="OverridesDefaultStyle" Value="True"/>
                 <Setter Property="Template">
@@ -219,7 +218,6 @@
                         </ControlTemplate>
                     </Setter.Value>
                 </Setter>
-                <Setter Property="Width" Value="150"/>
                 <Style.Triggers>
                     <Trigger Property="IsMouseOver" Value="True">
                         <Setter Property="BorderBrush" Value="{DynamicResource ButtonBorderBrushTrigger}"/>

--- a/Xenia Manager/App.xaml.cs
+++ b/Xenia Manager/App.xaml.cs
@@ -330,7 +330,7 @@ namespace Xenia_Manager
                                         currentConfig.Version = (string)latestRelease["tag_name"];
                                         currentConfig.ReleaseDate = releaseDate;
                                         currentConfig.LastUpdateCheckDate = DateTime.Now;
-                                        await appConfiguration.SaveAsync(Path.Combine(baseDirectory, "config.json"));
+                                        await appConfiguration.SaveAsync();
                                         Log.Information($"Xenia {Version} updated to version {currentConfig.Version}");
                                         MessageBox.Show($"Xenia {Version} has been updated to the latest build.");
                                     }
@@ -378,7 +378,7 @@ namespace Xenia_Manager
                     _ => throw new InvalidOperationException("Unexpected build type")
                 };
                 currentConfig.LastUpdateCheckDate = DateTime.Now;
-                await appConfiguration.SaveAsync(Path.Combine(baseDirectory, "config.json"));
+                await appConfiguration.SaveAsync();
                 Log.Information("Update check date updated");
             }
         }
@@ -698,7 +698,7 @@ namespace Xenia_Manager
                     // If Xenia XFS Dump tool isn't installed, install it
                     await DownloadXeniaVFSDumper();
                     appConfiguration.VFSDumpToolLocation = @"Xenia VFS Dump Tool\xenia-vfs-dump.exe";
-                    await appConfiguration.SaveAsync(Path.Combine(baseDirectory, "config.json"));
+                    await appConfiguration.SaveAsync();
                 }
             }
             else
@@ -714,7 +714,7 @@ namespace Xenia_Manager
                     LastUpdateCheckDate = DateTime.Now
                 };
                 appConfiguration.VFSDumpToolLocation = @"Xenia VFS Dump Tool\xenia-vfs-dump.exe";
-                await appConfiguration.SaveAsync(Path.Combine(baseDirectory, "config.json"));
+                await appConfiguration.SaveAsync();
                 WelcomeDialog welcome = new WelcomeDialog();
                 welcome.Show();
             }

--- a/Xenia Manager/Classes/JSONParse.cs
+++ b/Xenia Manager/Classes/JSONParse.cs
@@ -302,6 +302,8 @@ namespace Xenia_Manager.Classes
     /// </summary>
     public class Configuration
     {
+        public const string FILE_NAME = "config.json";
+
         /// <summary>
         /// <para>This stores the location where the Xenia VFS Dump is stored</para>
         /// </summary>
@@ -325,6 +327,12 @@ namespace Xenia_Manager.Classes
         /// </summary>
         [JsonProperty("auto_game_adding")]
         public bool? AutoGameAdding { get; set; }
+
+        /// <summary>
+        /// <para>The zoom multiplier for the games in the library</para>
+        /// </summary>
+        [JsonProperty("zoom_level")]
+        public double ZoomLevel { get; set; } = 1.0;
 
         /// <summary>
         /// This is to store Xenia Manager update checks
@@ -353,14 +361,13 @@ namespace Xenia_Manager.Classes
         /// <summary>
         /// Saves the configuration object to a JSON file asynchronously
         /// </summary>
-        /// <param name="filePath">The file path where the JSON file will be saved.</param>
-        public async Task SaveAsync(string filePath)
+        public async Task SaveAsync()
         {
             // Serialize the object to JSON
             string json = JsonConvert.SerializeObject(this, Formatting.Indented);
 
             // Write JSON to file asynchronously
-            await File.WriteAllTextAsync(filePath, json);
+            await File.WriteAllTextAsync(Path.Combine(App.baseDirectory, FILE_NAME), json);
         }
     }
 

--- a/Xenia Manager/Pages/Library.xaml
+++ b/Xenia Manager/Pages/Library.xaml
@@ -12,8 +12,8 @@
         <Grid>
             <Grid.RowDefinitions>
                 <RowDefinition Height="60"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition/>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="15"/>
             </Grid.RowDefinitions>
 
             <!-- Buttons -->
@@ -39,18 +39,20 @@ Click="ScanGames_Click" ToolTip="Scan a directory for games">
                 </StackPanel>
             </Grid>
 
-            <!-- Seperation Line -->
-            <Border Grid.Row="1" 
-                    Style="{StaticResource SeperationLine}"/>
-
             <!-- Games -->
-            <Grid Grid.Row="2">
+            <Grid Grid.Row="1">
                 <ScrollViewer HorizontalScrollBarVisibility="Disabled" 
                               VerticalScrollBarVisibility="Auto">
                     <WrapPanel x:Name="wrapPanel" 
                                Orientation="Horizontal"/>
                 </ScrollViewer>
             </Grid>
+
+            <StackPanel Grid.Row="3" Background="{DynamicResource BackgroundColor}" Orientation="Horizontal">
+                <TextBlock Style="{StaticResource AddGameText}" Text="Zoom"/>
+                <Slider x:Name="ZoomSlider" Minimum="0.25" Maximum="2.0" Value="0.5" Width="100" ValueChanged="ZoomSlider_ValueChanged" MouseRightButtonDown="ZoomSlider_MouseRightButtonDown"/>
+                <TextBlock Style="{StaticResource AddGameText}" x:Name="ZoomValue"/>
+            </StackPanel>
         </Grid>
     </Border>
 </Page>

--- a/Xenia Manager/Pages/Library.xaml
+++ b/Xenia Manager/Pages/Library.xaml
@@ -18,14 +18,25 @@
 
             <!-- Buttons -->
             <Grid Grid.Row="0">
-                <Button x:Name="AddGame" 
-                        Style="{StaticResource AddGame}"
-                        Click="AddGame_Click">
-                    <Button.Content>
-                        <TextBlock Style="{StaticResource AddGameText}"
-                                   Text="Add Game"/>
-                    </Button.Content>
-                </Button>
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                    <Button x:Name="AddGame" 
+                Style="{StaticResource AddGame}"
+                Click="AddGame_Click">
+                        <Button.Content>
+                            <TextBlock Style="{StaticResource AddGameText}"
+                           Text="Add Game"/>
+                        </Button.Content>
+                    </Button>
+                    <Separator Margin="4"/>
+                    <Button x:Name="ScanGames" 
+Style="{StaticResource AddGame}"
+Click="ScanGames_Click" ToolTip="Scan a directory for games">
+                        <Button.Content>
+                            <TextBlock Style="{StaticResource AddGameText}"
+           Text="Scan Directory"/>
+                        </Button.Content>
+                    </Button>
+                </StackPanel>
             </Grid>
 
             <!-- Seperation Line -->

--- a/Xenia Manager/Pages/Library.xaml.cs
+++ b/Xenia Manager/Pages/Library.xaml.cs
@@ -1239,20 +1239,27 @@ namespace Xenia_Manager.Pages
                 bool? result = openFolderDialog.ShowDialog();
                 if (result == true)
                 {
-                    foreach (var folder in Directory.EnumerateDirectories(openFolderDialog.FolderName, "*", new EnumerationOptions() { MaxRecursionDepth = 3, RecurseSubdirectories = true}))
+                    foreach (var folder in Directory.EnumerateDirectories(openFolderDialog.FolderName, "*", new EnumerationOptions() { MaxRecursionDepth = 4, RecurseSubdirectories = true}))
                     {
                         string[] systemEntries = Directory.GetFileSystemEntries(folder);
-
-                        //Stock console method
-                        if (systemEntries.Length != 2) //A game path contains only 1 folder (the game content) & 1 file (the game)
-                            continue;
-
                         string[] directories = Directory.GetDirectories(folder);
                         string[] files = Directory.GetFiles(folder);
-                        if (directories.Length != 1 || files.Length != 1)
-                            continue;
 
-                        await TryAddGame(files[0], false, false);
+                        //Stock console method
+                        if (systemEntries.Length == 2) //A game path contains only 1 folder (the game content) & 1 file (the game){
+                        {
+                            if (directories.Length != 1 || files.Length != 1)
+                                continue;
+
+                            await TryAddGame(files[0], false, false);
+                        }
+                        else //XLBA games
+                        {
+                            if (directories.Length != 0 || files.Length != 1)
+                                continue;
+
+                            await TryAddGame(files[0], false, false);
+                        }
                     }
                 }
 

--- a/Xenia Manager/Pages/Settings.xaml.cs
+++ b/Xenia Manager/Pages/Settings.xaml.cs
@@ -158,31 +158,31 @@ namespace Xenia_Manager.Pages
                                 // Apply the Light theme
                                 App.appConfiguration.ThemeSelected = "Light";
                                 await App.LoadTheme();
-                                await App.appConfiguration.SaveAsync(Path.Combine(App.baseDirectory, "config.json"));
+                                await App.appConfiguration.SaveAsync();
                                 break;
                             case 2:
                                 // Apply the Dark theme
                                 App.appConfiguration.ThemeSelected = "Dark";
                                 await App.LoadTheme();
-                                await App.appConfiguration.SaveAsync(Path.Combine(App.baseDirectory, "config.json"));
+                                await App.appConfiguration.SaveAsync();
                                 break;
                             case 3:
                                 // Apply the Dark AMOLED theme
                                 App.appConfiguration.ThemeSelected = "AMOLED";
                                 await App.LoadTheme();
-                                await App.appConfiguration.SaveAsync(Path.Combine(App.baseDirectory, "config.json"));
+                                await App.appConfiguration.SaveAsync();
                                 break;
                             case 4:
                                 // Apply the Nord theme
                                 App.appConfiguration.ThemeSelected = "Nord";
                                 await App.LoadTheme();
-                                await App.appConfiguration.SaveAsync(Path.Combine(App.baseDirectory, "config.json"));
+                                await App.appConfiguration.SaveAsync();
                                 break;
                             default:
                                 // Check system and then apply the correct one
                                 App.appConfiguration.ThemeSelected = "Default";
                                 await App.LoadTheme();
-                                await App.appConfiguration.SaveAsync(Path.Combine(App.baseDirectory, "config.json"));
+                                await App.appConfiguration.SaveAsync();
                                 break;
                         }
                     }
@@ -344,7 +344,7 @@ namespace Xenia_Manager.Pages
                     Log.Information("Configuration file has the correct path to Xenia VFS Dump tool");
                 }
 
-                await App.appConfiguration.SaveAsync(Path.Combine(App.baseDirectory, "config.json"));
+                await App.appConfiguration.SaveAsync();
                 InitializeAsync();
                 MessageBox.Show("The configuration file has been repaired.");
             }
@@ -457,7 +457,7 @@ namespace Xenia_Manager.Pages
         {
             Log.Information($"Automatic adding of games - {AutomaticAddingGamesCheckbox.IsChecked}");
             App.appConfiguration.AutoGameAdding = AutomaticAddingGamesCheckbox.IsChecked;
-            await App.appConfiguration.SaveAsync(Path.Combine(App.baseDirectory, "config.json"));
+            await App.appConfiguration.SaveAsync();
         }
     }
 }

--- a/Xenia Manager/Windows/MainWindow.xaml
+++ b/Xenia Manager/Windows/MainWindow.xaml
@@ -19,62 +19,71 @@
             CornerRadius="10">
         <Grid Margin="0,0,0,0">
             <Grid.RowDefinitions>
-                <RowDefinition Height="50" />
+                <RowDefinition Height="32" />
                 <RowDefinition />
             </Grid.RowDefinitions>
 
             <!-- Title Bar -->
             <Border Grid.Row="0" 
                     CornerRadius="10,10,0,0">
-                <Grid>
-                    <!-- Open Repository Button -->
-                    <Button x:Name="OpenRepository"
-                            Grid.Column="0"
+                <Grid MouseDown="TitleBar_MouseDown" Background="{DynamicResource BackgroundColor}">
+                    <StackPanel Orientation="Horizontal">
+                        <!-- Open Repository Button -->
+                        <Button x:Name="OpenRepository" Width="64"
                             AutomationProperties.Name="Open Repository Button"
-                            Content="&#xED15;"
-                            HorizontalAlignment="Left"
-                            Margin="21,0,0,0"
                             Style="{StaticResource TitleBarButton}"
                             Click="OpenRepository_Click">
-                        <Button.ToolTip>
-                            <TextBlock TextAlignment="Left">
-                                Opens the repository page in the default web browser
-                            </TextBlock>
-                        </Button.ToolTip>
-                    </Button>
+                            <Button.Content>
+                                <Viewbox Stretch="Uniform">
+                                    <TextBlock Text="&#xED15;" Margin="5"/>
+                                </Viewbox>
+                            </Button.Content>
+                            <Button.ToolTip>
+                                <TextBlock TextAlignment="Left" Text="Opens the repository page in the default web browser"/>
+                            </Button.ToolTip>
+                        </Button>
 
-                    <!-- Title text -->
-                    <TextBlock x:Name="TitleText" 
+                        <!-- Title text -->
+                        <Grid HorizontalAlignment="Left">
+                            <TextBlock x:Name="TitleText" 
                                FontFamily="{StaticResource SegoeFluent}"
-                               FontSize="36"
-                               FontWeight="Bold"
                                Foreground="{DynamicResource ForegroundColor}"
                                HorizontalAlignment="Center"
                                Text="Xenia Manager" 
                                VerticalAlignment="Center"/>
+                        </Grid>
+                    </StackPanel>
+                    
                     <Grid HorizontalAlignment="Right">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition/>
-                            <ColumnDefinition/>
-                        </Grid.ColumnDefinitions>
+                        <StackPanel Orientation="Horizontal" Margin="5 5 0 5">
+                            <!-- Maximize Button -->
+                            <Viewbox StretchDirection="Both">
+                                <Button x:Name="Minimize"
+                                        AutomationProperties.Name="Maximize Button"
+                                        AutomationProperties.HelpText="Maximizes the application window"
+                                        Content="&#xE949;"
+                                        Style="{StaticResource TitleBarButton}"
+                                        Click="Minimize_Click"/>
+                            </Viewbox>
+                            <Viewbox StretchDirection="Both">
+                                <Button x:Name="Maximize"
+                                        AutomationProperties.Name="Maximize Button"
+                                        AutomationProperties.HelpText="Maximizes the application window"
+                                        Content="&#xE923;"
+                                        Style="{StaticResource TitleBarButton}"
+                                        Click="Maximize_Click"/>
+                            </Viewbox>
 
-                        <!-- Maximize Button -->
-                        <Button x:Name="Maximize"
-                                Grid.Column="0"
-                                AutomationProperties.Name="Maximize Button"
-                                AutomationProperties.HelpText="Maximizes the application window"
-                                Content="&#xE923;"
-                                Style="{StaticResource TitleBarButton}"
-                                Click="Maximize_Click"/>
-
-                        <!-- Exit Button -->
-                        <Button x:Name="Exit"
-                                Grid.Column="1"
-                                AutomationProperties.Name="Exit Button"
-                                AutomationProperties.HelpText="Closes the application"
-                                Content="&#xE711;"
-                                Style="{StaticResource TitleBarButton}"
-                                Click="Exit_Click"/>
+                            <!-- Exit Button -->
+                            <Viewbox StretchDirection="Both">
+                                <Button x:Name="Exit"
+                                    AutomationProperties.Name="Exit Button"
+                                    AutomationProperties.HelpText="Closes the application"
+                                    Content="&#xE711;"
+                                    Style="{StaticResource TitleBarButton}"
+                                    Click="Exit_Click"/>
+                            </Viewbox>
+                        </StackPanel>
                     </Grid>
                 </Grid>
             </Border>
@@ -84,7 +93,7 @@
                     CornerRadius="0,0,10,10">
                 <Grid>
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="65"/>
+                        <ColumnDefinition Width="64"/>
                         <ColumnDefinition />
                     </Grid.ColumnDefinitions>
 

--- a/Xenia Manager/Windows/MainWindow.xaml.cs
+++ b/Xenia Manager/Windows/MainWindow.xaml.cs
@@ -277,6 +277,14 @@ namespace Xenia_Manager
         }
 
         /// <summary>
+        /// Minimizes the Xenia Manager window
+        /// </summary>
+        private void Minimize_Click(object sender, RoutedEventArgs e)
+        {
+            this.WindowState = WindowState.Minimized;
+        }
+
+        /// <summary>
         /// Does fade out animation before closing the window
         /// </summary>
         private async Task ClosingAnimation()
@@ -382,6 +390,14 @@ namespace Xenia_Manager
 
             Log.Information("Closing Xenia Manager for update");
             Environment.Exit(0);
+        }
+
+        private void TitleBar_MouseDown(object sender, MouseButtonEventArgs e)
+        {
+            if(e.ClickCount == 2 & e.LeftButton == MouseButtonState.Pressed)
+            {
+                Maximize_Click(sender, new RoutedEventArgs());
+            }
         }
     }
 }

--- a/Xenia Manager/Windows/MainWindow.xaml.cs
+++ b/Xenia Manager/Windows/MainWindow.xaml.cs
@@ -273,7 +273,7 @@ namespace Xenia_Manager
                 MainWindowBorder.CornerRadius = new CornerRadius(0);
             }
 
-            await App.appConfiguration.SaveAsync(Path.Combine(App.baseDirectory, "config.json"));
+            await App.appConfiguration.SaveAsync();
         }
 
         /// <summary>
@@ -362,7 +362,7 @@ namespace Xenia_Manager
             App.appConfiguration.Manager.LastUpdateCheckDate = latestXeniaManagerRelease.LastUpdateCheckDate;
 
             // Updating configuration
-            await App.appConfiguration.SaveAsync(Path.Combine(App.baseDirectory, "config.json"));
+            await App.appConfiguration.SaveAsync();
 
             Process.Start(new ProcessStartInfo
             {

--- a/Xenia Manager/Windows/WelcomeDialog.xaml.cs
+++ b/Xenia Manager/Windows/WelcomeDialog.xaml.cs
@@ -372,7 +372,7 @@ namespace Xenia_Manager.Windows
 
                     Log.Information("Saving the configuration for Xenia Stable");
                     // Saving the configuration file
-                    await App.appConfiguration.SaveAsync(Path.Combine(App.baseDirectory, "config.json"));
+                    await App.appConfiguration.SaveAsync();
 
                     // Add portable.txt so the Xenia Emulator is in portable mode
                     if (!File.Exists(Path.Combine(App.baseDirectory, @"Xenia Stable\portable.txt")))
@@ -444,7 +444,7 @@ namespace Xenia_Manager.Windows
 
                     // Update the configuration file of Xenia Manager
                     App.appConfiguration.XeniaStable = null;
-                    await App.appConfiguration.SaveAsync(Path.Combine(App.baseDirectory, "config.json"));
+                    await App.appConfiguration.SaveAsync();
 
                     // Hiding the uninstall button and showing install button again
                     InstallXeniaStable.Visibility = Visibility.Visible;
@@ -499,7 +499,7 @@ namespace Xenia_Manager.Windows
 
                     Log.Information("Saving the configuration for Xenia Canary");
                     // Saving the configuration file
-                    await App.appConfiguration.SaveAsync(Path.Combine(App.baseDirectory, "config.json"));
+                    await App.appConfiguration.SaveAsync();
 
                     // Add portable.txt so the Xenia Emulator is in portable mode
                     if (!File.Exists(Path.Combine(App.baseDirectory, @"Xenia Canary\portable.txt")))
@@ -572,7 +572,7 @@ namespace Xenia_Manager.Windows
 
                     // Update the configuration file of Xenia Manager
                     App.appConfiguration.XeniaCanary = null;
-                    await App.appConfiguration.SaveAsync(Path.Combine(App.baseDirectory, "config.json"));
+                    await App.appConfiguration.SaveAsync();
 
                     // Hiding the uninstall button and showing install button again
                     InstallXeniaCanary.Visibility = Visibility.Visible;
@@ -663,7 +663,7 @@ namespace Xenia_Manager.Windows
 
                     Log.Information("Saving the configuration for Xenia Netplay");
                     // Saving the configuration file
-                    await App.appConfiguration.SaveAsync(Path.Combine(App.baseDirectory, "config.json"));
+                    await App.appConfiguration.SaveAsync();
 
                     // Add portable.txt so the Xenia Emulator is in portable mode
                     if (!File.Exists(Path.Combine(App.baseDirectory, @"Xenia Netplay\portable.txt")))
@@ -740,7 +740,7 @@ namespace Xenia_Manager.Windows
 
                     // Update the configuration file of Xenia Manager
                     App.appConfiguration.XeniaNetplay = null;
-                    await App.appConfiguration.SaveAsync(Path.Combine(App.baseDirectory, "config.json"));
+                    await App.appConfiguration.SaveAsync();
 
                     // Hiding the uninstall button and showing install button again
                     InstallXeniaNetplay.Visibility = Visibility.Visible;


### PR DESCRIPTION
I just added a button that scans for games within a directory that the user selects. I only tested it with the intallation format from the "Stock console method" listed in the Xenia Quickstart guide. 

https://github.com/xenia-project/xenia/wiki/Quickstart

Also fixed a spelling error

Example of it being used:
![Scan Directory](https://github.com/user-attachments/assets/443f8b42-95ff-4026-9ecb-fd70886d1a2a)

Duplicate entries are also skipped when scanning directories:
![NoDuplicates](https://github.com/user-attachments/assets/8ca36a0f-324c-4c8e-8ce1-74dbcedd2435)
