### PR TITLE
Xenia Settings Improvements

### DIFF
--- a/XeniaManager.DesktopApp/Pages/Xenia Settings/Xenia Settings/HID.cs
+++ b/XeniaManager.DesktopApp/Pages/Xenia Settings/Xenia Settings/HID.cs
@@ -46,6 +46,22 @@ namespace XeniaManager.DesktopApp.Pages
                 BrdInputSystemSetting.Visibility = Visibility.Collapsed;
                 BrdInputSystemSetting.Tag = "Ignore";
             }
+            
+            // "keyboard_mode" setting
+            if (sectionTable.ContainsKey("keyboard_mode"))
+            {
+                Log.Information($"keyboard_mode - {sectionTable["keyboard_mode"]}");
+                CmbKeyboardMode.SelectedIndex = int.Parse(sectionTable["keyboard_mode"].ToString());
+                
+                BrdKeyboardModeSetting.Visibility = Visibility.Visible;
+                BrdKeyboardModeSetting.Tag = null;
+            }
+            else
+            {
+                Log.Warning("`keyboard_mode` is missing from configuration file");
+                BrdKeyboardModeSetting.Visibility = Visibility.Collapsed;
+                BrdKeyboardModeSetting.Tag = "Ignore";
+            }
 
             // "left_stick_deadzone_percentage" setting
             if (sectionTable.ContainsKey("left_stick_deadzone_percentage"))
@@ -127,6 +143,13 @@ namespace XeniaManager.DesktopApp.Pages
                         sectionTable["hid"] = "any";
                         break;
                 }
+            }
+            
+            // "keyboard_mode" setting
+            if (sectionTable.ContainsKey("keyboard_mode"))
+            {
+                Log.Information($"keyboard_mode - {CmbKeyboardMode.SelectedIndex}");
+                sectionTable["keyboard_mode"] = CmbKeyboardMode.SelectedIndex;
             }
 
             // "left_stick_deadzone_percentage" setting

--- a/XeniaManager.DesktopApp/Pages/Xenia Settings/XeniaSettings.xaml
+++ b/XeniaManager.DesktopApp/Pages/Xenia Settings/XeniaSettings.xaml
@@ -2113,6 +2113,58 @@
                                 </ComboBox>
                             </Grid>
                         </Border>
+                        
+                        <!-- keyboard_mode -->
+                        <Border x:Name="BrdKeyboardModeSetting"
+                                Style="{StaticResource XeniaSetting}">
+                            <Grid Height="50">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition />
+                                    <ColumnDefinition />
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0"
+                                           FontSize="24"
+                                           Style="{StaticResource SettingText}">
+                                    <TextBlock.ToolTip>
+                                        <ToolTip>
+                                            <TextBlock TextAlignment="Left">
+                                                Allows user do specify keyboard working mode
+                                                <LineBreak />
+                                                <TextBlock FontWeight="SemiBold"
+                                                           Text="Options:"
+                                                           TextDecorations="Underline" />
+                                                <LineBreak />
+                                                <TextBlock Padding="10,0,0,0"
+                                                           TextAlignment="Left">
+                                                    - Disabled
+                                                    <LineBreak />
+                                                    - Enabled
+                                                    <LineBreak />
+                                                    - Passthrough (Requires controller being connected)
+                                                </TextBlock>
+                                            </TextBlock>
+                                        </ToolTip>
+                                    </TextBlock.ToolTip>
+                                    Keyboard Mode
+                                </TextBlock>
+                                <ComboBox x:Name="CmbKeyboardMode"
+                                          Grid.Column="1"
+                                          AutomationProperties.Name="Keyboard Mode"
+                                          AutomationProperties.HelpText="Allows user do specify keyboard working mode"
+                                          FontSize="18"
+                                          HorizontalContentAlignment="Center"
+                                          Margin="0,10"
+                                          Style="{StaticResource ComboBoxStyle}"
+                                          VerticalContentAlignment="Center"
+                                          Width="150">
+                                    <ComboBox.Items>
+                                        <ComboBoxItem Content="Disabled" />
+                                        <ComboBoxItem Content="Enabled" />
+                                        <ComboBoxItem Content="Passthrough" />
+                                    </ComboBox.Items>
+                                </ComboBox>
+                            </Grid>
+                        </Border>
 
                         <!-- left_stick_deadzone_percentage -->
                         <Border x:Name="BrdLeftStickDeadzoneSetting"

--- a/XeniaManager.DesktopApp/Windows/MainWindow.xaml.cs
+++ b/XeniaManager.DesktopApp/Windows/MainWindow.xaml.cs
@@ -164,7 +164,15 @@ namespace XeniaManager.DesktopApp.Windows
         /// </summary>
         private void BtnXeniaSettings_Click(object sender, RoutedEventArgs e)
         {
-            if (GameManager.Games.Count > 0)
+            // Checking what emulator versions are installed
+            List<EmulatorVersion> installedXeniaVersions = new List<EmulatorVersion>();
+            if (ConfigurationManager.AppConfig.XeniaCanary != null)
+                installedXeniaVersions.Add(EmulatorVersion.Canary);
+            if (ConfigurationManager.AppConfig.XeniaMousehook != null)
+                installedXeniaVersions.Add(EmulatorVersion.Mousehook);
+            if (ConfigurationManager.AppConfig.XeniaNetplay != null)
+                installedXeniaVersions.Add(EmulatorVersion.Netplay);
+            if (GameManager.Games.Count > 0 || installedXeniaVersions.Count > 0)
             {
                 TblkWindowTitle.Text = "Xenia Manager";
                 PageNavigationManager.NavigateToPage<XeniaSettings>(FrmNavigation);


### PR DESCRIPTION
Features:
- [x] Add `keyboard_mode` setting (0 to disable it entirely, 1 for controller use, 2 for games that support dev consoles)

Bugfixes:
- [x] Fixed a bug that prevented Xenia Settings from being opened when no game is installed