### PR TITLE
Launch game by ID because some game titles contain spaces

### DIFF
--- a/XeniaManager.DesktopApp/App.xaml.cs
+++ b/XeniaManager.DesktopApp/App.xaml.cs
@@ -172,8 +172,14 @@ namespace XeniaManager.DesktopApp
                 if (argument != "-console")
                 {
                     Log.Information($"Current launch argument: {argument}");
-                    Game game = GameManager.Games.FirstOrDefault(game =>
+                    Game game = null;
+                    
+                    game ??= GameManager.Games.FirstOrDefault(game =>
                         string.Equals(game.Title, argument, StringComparison.OrdinalIgnoreCase));
+
+                    game ??= GameManager.Games.FirstOrDefault(game =>
+                        string.Equals(game.GameId, argument, StringComparison.OrdinalIgnoreCase));
+
                     if (game != null)
                     {
                         GameManager.LaunchGame(game);


### PR DESCRIPTION
Launch arguments are delimited by spaces, so currently any game with a space in the name can not be opened via launch args.
For example, "Amped 3" will be parsed as two different arguments for "Amped" and  "3". 