### PR TITLE
refactor(xenia): Rework `Xenia Output Handler`

### DIFF
--- a/source/XeniaManager.Core/Manage/XeniaOutputHandler.cs
+++ b/source/XeniaManager.Core/Manage/XeniaOutputHandler.cs
@@ -1,21 +1,22 @@
 using System.Diagnostics;
 using System.Globalization;
-using System.Text;
 using System.Text.RegularExpressions;
 using XeniaManager.Core.Logging;
+using XeniaManager.Core.Models;
 using XeniaManager.Core.Models.Files.Account;
 using XeniaManager.Core.Models.Game;
+using XeniaManager.Core.Utilities;
 
 namespace XeniaManager.Core.Manage;
 
 /// <summary>
-/// Handles capturing and processing output from the Xenia emulator process
-/// Detects and tracks loaded gamer profiles and game loading state
+/// Handles capturing and processing output from the Xenia emulator process by reading its log file.
+/// Detects and tracks loaded gamer profiles and game loading state.
 /// </summary>
-public class XeniaOutputHandler
+public partial class XeniaOutputHandler
 {
     private readonly Game? _game;
-    private readonly StringBuilder _outputBuffer;
+    private readonly XeniaVersion? _xeniaVersion;
     private readonly List<AccountInfo> _loadedProfiles;
     private readonly Dictionary<int, AccountInfo> _slotToProfile; // Maps slot number to profile
     private readonly Lock _lock = new Lock();
@@ -25,6 +26,10 @@ public class XeniaOutputHandler
 
     // Game details extracted from output
     private readonly ParsedGameDetails _gameDetails;
+
+    // Log file reading state
+    private CancellationTokenSource? _logReaderCts;
+    private Task? _logReaderTask;
 
     /// <summary>
     /// Maximum number of attempts to check for the game to start loading
@@ -39,29 +44,23 @@ public class XeniaOutputHandler
     /// Matches: Loaded Gamertag (GUID: XUID) to slot 0-4
     /// Case-insensitive to handle both uppercase and lowercase hex
     /// </summary>
-    private static readonly Regex _gamerProfilesRegex = new Regex(
-        @"\bLoaded\s(?<Gamertag>\w+)\s\(GUID:\s(?<GUID>[A-F0-9]+)\)\sto\sslot\s(?<Slot>[0-4])",
-        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase
-    );
+    [GeneratedRegex(@"\bLoaded\s(?<Gamertag>\w+)\s\(GUID:\s(?<GUID>[A-F0-9]+)\)\sto\sslot\s(?<Slot>[0-4])", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex GamerProfilesRegex();
 
     /// <summary>
     /// Regex pattern to detect profile XUID from [Profiles] section
     /// Matches: logged_profile_slot_0-4_xuid = "XUID"
     /// Case-insensitive to handle both uppercase and lowercase hex
     /// </summary>
-    private static readonly Regex _profileSlotRegex = new Regex(
-        @"logged_profile_slot_([0-4])_xuid\s*=\s*""(?<XUID>[A-F0-9]+)""",
-        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase
-    );
+    [GeneratedRegex(@"logged_profile_slot_([0-4])_xuid\s*=\s*""(?<XUID>[A-F0-9]+)""", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex ProfileSlotRegex();
 
     /// <summary>
     /// Regex pattern to detect game title from Xenia output
     /// Matches: Title name: GameTitle
     /// </summary>
-    private static readonly Regex _titleNameRegex = new Regex(
-        @"Title name:\s*(?<Title>.+)",
-        RegexOptions.Compiled | RegexOptions.CultureInvariant
-    );
+    [GeneratedRegex(@"Title name:\s*(?<Title>.+)", RegexOptions.CultureInvariant)]
+    private static partial Regex TitleNameRegex();
 
     /// <summary>
     /// Event raised when the game starts loading
@@ -82,19 +81,15 @@ public class XeniaOutputHandler
         }
     }
 
-    public XeniaOutputHandler(Game game) : this(game, false)
-    {
-    }
-
     /// <summary>
     /// Initializes a new instance of the XeniaOutputHandler class
     /// </summary>
     /// <param name="game">The game being launched (null when reading game details)</param>
     /// <param name="readingGameDetails">True when only reading game details, not tracking profiles</param>
-    public XeniaOutputHandler(Game? game, bool readingGameDetails)
+    public XeniaOutputHandler(Game? game, bool readingGameDetails = false)
     {
         _game = game;
-        _outputBuffer = new StringBuilder();
+        _xeniaVersion = game?.XeniaVersion;
         _loadedProfiles = [];
         _slotToProfile = new Dictionary<int, AccountInfo>();
         _readingGameDetails = readingGameDetails;
@@ -107,28 +102,26 @@ public class XeniaOutputHandler
     public ParsedGameDetails GameDetails => _gameDetails;
 
     /// <summary>
-    /// Configures a process to redirect output for handling
+    /// Configures a process for Xenia launch.
+    /// Output is captured from Xenia's log file rather than redirected stdout/stderr.
+    /// <para>
+    /// This is to fix an issue where if Console is enabled, it'll redirect everything and nothing will be parsed
+    /// </para>
     /// </summary>
     /// <param name="process">The Xenia process to configure</param>
     public void ConfigureProcess(Process process)
     {
-        process.StartInfo.UseShellExecute = false;
-        process.StartInfo.RedirectStandardOutput = true;
-        process.StartInfo.RedirectStandardError = true;
-        process.StartInfo.CreateNoWindow = !_readingGameDetails;
+        // No stdout/stderr redirection - we read from the log file instead
         process.EnableRaisingEvents = true;
-
-        process.OutputDataReceived += OnOutputDataReceived;
         process.Exited += OnProcessExited;
     }
 
     /// <summary>
-    /// Starts capturing output from the process
+    /// Starts capturing output from Xenia's log file
     /// </summary>
     /// <param name="process">The Xenia process</param>
     public void StartCapture(Process process)
     {
-        _outputBuffer.Clear();
         _isGameLoading = false;
         _gameLoadCheckAttempts = 0;
 
@@ -138,33 +131,151 @@ public class XeniaOutputHandler
             _slotToProfile.Clear();
         }
 
-        Logger.Info<XeniaOutputHandler>($"Starting output capture for {_game?.Title}");
+        Logger.Info<XeniaOutputHandler>($"Starting log file capture for {_game?.Title}");
 
-        // Begin asynchronous reading of output streams
-        process.BeginOutputReadLine();
-        process.BeginErrorReadLine();
+        // Start reading the log file asynchronously
+        _logReaderCts = new CancellationTokenSource();
+        _logReaderTask = StartLogFileReaderAsync(process, _logReaderCts.Token);
     }
 
     /// <summary>
-    /// Stops capturing output from the process
+    /// Stops capturing output from Xenia's log file
     /// </summary>
     /// <param name="process">The Xenia process</param>
     public void StopCapture(Process process)
     {
-        process.OutputDataReceived -= OnOutputDataReceived;
+        _logReaderCts?.Cancel();
+        try
+        {
+            _logReaderTask?.Wait(TimeSpan.FromSeconds(5));
+        }
+        catch (AggregateException)
+        {
+            // Ignore cancellation exceptions
+        }
+        _logReaderCts?.Dispose();
+        _logReaderCts = null;
+        _logReaderTask = null;
+
         process.Exited -= OnProcessExited;
 
         lock (_lock)
         {
-            if (_readingGameDetails)
+            Logger.Info<XeniaOutputHandler>(_readingGameDetails
+                ? $"Stopped game details extraction. Title: '{_gameDetails.Title}', Title ID: '{_gameDetails.TitleId}', Media ID: '{_gameDetails.MediaId}'"
+                : $"Stopped output capture for {_game?.Title}. Profiles loaded: {_loadedProfiles.Count}");
+        }
+    }
+
+    /// <summary>
+    /// Reads the Xenia log file continuously as it grows, processing new lines
+    /// Uses exponential backoff polling to minimize CPU usage
+    /// </summary>
+    private async Task StartLogFileReaderAsync(Process process, CancellationToken cancellationToken)
+    {
+        string logFilePath = GetLogFilePath(process);
+        if (string.IsNullOrEmpty(logFilePath))
+        {
+            Logger.Warning<XeniaOutputHandler>("Could not determine log file path, output capture disabled");
+            return;
+        }
+
+        Logger.Debug<XeniaOutputHandler>($"Watching log file: {logFilePath}");
+
+        // Wait for log file to be created (with exponential backoff)
+        int waitAttempts = 0;
+        int waitMs = 100;
+        while (!File.Exists(logFilePath) && waitAttempts < 50 && !cancellationToken.IsCancellationRequested)
+        {
+            await Task.Delay(waitMs, cancellationToken);
+            waitAttempts++;
+            waitMs = Math.Min(waitMs * 2, 1000);
+        }
+
+        if (!File.Exists(logFilePath))
+        {
+            Logger.Warning<XeniaOutputHandler>($"Log file not found at: {logFilePath}");
+            return;
+        }
+
+        // Read the log file as it grows
+        try
+        {
+            await using FileStream fileStream = new FileStream(logFilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite,
+                bufferSize: 8192, useAsync: true);
+            using StreamReader reader = new StreamReader(fileStream);
+
+            // Adaptive polling: start fast, slow down when idle
+            const int fastPollMs = 20;
+            const int slowPollMs = 200;
+            int pollDelay = fastPollMs;
+
+            while (!cancellationToken.IsCancellationRequested && !process.HasExited)
             {
-                Logger.Info<XeniaOutputHandler>($"Stopped game details extraction. Title: '{_gameDetails.Title}', Title ID: '{_gameDetails.TitleId}', Media ID: '{_gameDetails.MediaId}'");
+                string? line;
+                bool sawNewData = false;
+                while ((line = await reader.ReadLineAsync(cancellationToken)) != null)
+                {
+                    ProcessLine(line);
+                    sawNewData = true;
+                }
+
+                if (sawNewData)
+                {
+                    pollDelay = fastPollMs;
+                }
+                else
+                {
+                    // No new data - increase polling interval (exponential backoff)
+                    pollDelay = Math.Min(pollDelay * 2, slowPollMs);
+                }
+
+                await Task.Delay(pollDelay, cancellationToken);
             }
-            else
+
+            // Read any remaining data after process exits
+            while (await reader.ReadLineAsync(cancellationToken) is { } remainingLine)
             {
-                Logger.Info<XeniaOutputHandler>($"Stopped output capture for {_game?.Title}. Profiles loaded: {_loadedProfiles.Count}");
+                ProcessLine(remainingLine);
             }
         }
+        catch (OperationCanceledException)
+        {
+            // Expected on shutdown
+        }
+        catch (Exception ex)
+        {
+            Logger.Error<XeniaOutputHandler>($"Error reading log file: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Gets the log file path from the Xenia version info or process working directory
+    /// </summary>
+    private string GetLogFilePath(Process process)
+    {
+        if (_xeniaVersion.HasValue && _xeniaVersion.Value != XeniaVersion.Custom)
+        {
+            try
+            {
+                XeniaVersionInfo versionInfo = XeniaVersionInfo.GetXeniaVersionInfo(_xeniaVersion.Value);
+                string fullPath = AppPathResolver.GetFullPath(versionInfo.LogLocation);
+                return fullPath;
+            }
+            catch (Exception ex)
+            {
+                Logger.Warning<XeniaOutputHandler>($"Failed to get log location from XeniaVersionInfo");
+                Logger.LogExceptionDetails<XeniaOutputHandler>(ex);
+            }
+        }
+
+        // Fallback to working directory
+        if (!string.IsNullOrEmpty(process.StartInfo.WorkingDirectory))
+        {
+            return Path.Combine(process.StartInfo.WorkingDirectory, "xenia.log");
+        }
+
+        return string.Empty;
     }
 
     /// <summary>
@@ -178,10 +289,9 @@ public class XeniaOutputHandler
             return;
         }
 
-        _outputBuffer.AppendLine(line);
-
-        // Log the output
-        Logger.Trace<XeniaOutputHandler>($"[Xenia] {line}");
+        // Trace-log every line (disabled by default to avoid log spam during gameplay)
+        // Uncomment the line below to restore full trace logging of all Xenia output
+        // Logger.Trace<XeniaOutputHandler>($"[Xenia] {line}");
 
         // Extract game details if we're reading them
         if (_readingGameDetails)
@@ -205,17 +315,19 @@ public class XeniaOutputHandler
     /// <param name="line">The line to check</param>
     private void ExtractGameDetails(string line)
     {
+        ReadOnlySpan<char> lineSpan = line.AsSpan();
+
         // Fast pre-filter
-        if (!line.Contains("Title", StringComparison.InvariantCulture) &&
-            !line.Contains("Media", StringComparison.InvariantCulture))
+        if (lineSpan.IndexOf("Title", StringComparison.Ordinal) == -1 &&
+            lineSpan.IndexOf("Media", StringComparison.Ordinal) == -1)
         {
             return;
         }
 
         // Extract title name
-        if (!_gameDetails.IsValid && line.Contains("Title name", StringComparison.InvariantCulture))
+        if (lineSpan.IndexOf("Title name", StringComparison.Ordinal) >= 0)
         {
-            Match match = _titleNameRegex.Match(line);
+            Match match = TitleNameRegex().Match(line);
             if (match.Success)
             {
                 _gameDetails.Title = match.Groups["Title"].Value.Trim();
@@ -224,41 +336,41 @@ public class XeniaOutputHandler
         }
 
         // Extract title ID
-        if (line.Contains("Title ID", StringComparison.InvariantCulture))
+        if (lineSpan.IndexOf("Title ID", StringComparison.Ordinal) is int titleIdIdx and >= 0)
         {
-            string[] split = line.Split(':');
-            if (split.Length > 1 && !string.IsNullOrWhiteSpace(split[1]))
+            int colonIdx = lineSpan[titleIdIdx..].IndexOf(':');
+            if (colonIdx != -1)
             {
-                string titleId = split[1].Trim();
+                ReadOnlySpan<char> titleId = lineSpan[(titleIdIdx + colonIdx + 1)..].Trim();
                 // Validate that Title ID is a valid hex value
                 if (ulong.TryParse(titleId, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out _))
                 {
-                    _gameDetails.TitleId = titleId;
+                    _gameDetails.TitleId = titleId.ToString();
                     Logger.Debug<XeniaOutputHandler>($"Extracted valid title ID: '{_gameDetails.TitleId}'");
                 }
                 else
                 {
-                    Logger.Warning<XeniaOutputHandler>($"Invalid title ID format in output: '{titleId}'");
+                    Logger.Warning<XeniaOutputHandler>($"Invalid title ID format in output: '{titleId.ToString()}'");
                 }
             }
         }
 
         // Extract media ID
-        if (line.Contains("Media ID", StringComparison.InvariantCulture))
+        if (lineSpan.IndexOf("Media ID", StringComparison.Ordinal) is int mediaIdIdx and >= 0)
         {
-            string[] split = line.Split(':');
-            if (split.Length > 1 && !string.IsNullOrWhiteSpace(split[1]))
+            int colonIdx = lineSpan[mediaIdIdx..].IndexOf(':');
+            if (colonIdx != -1)
             {
-                string mediaId = split[1].Trim();
+                ReadOnlySpan<char> mediaId = lineSpan[(mediaIdIdx + colonIdx + 1)..].Trim();
                 // Validate that Media ID is a valid hex value
                 if (ulong.TryParse(mediaId, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out _))
                 {
-                    _gameDetails.MediaId = mediaId;
+                    _gameDetails.MediaId = mediaId.ToString();
                     Logger.Debug<XeniaOutputHandler>($"Extracted valid media ID: '{_gameDetails.MediaId}'");
                 }
                 else
                 {
-                    Logger.Warning<XeniaOutputHandler>($"Invalid media ID format in output: '{mediaId}'");
+                    Logger.Warning<XeniaOutputHandler>($"Invalid media ID format in output: '{mediaId.ToString()}'");
                 }
             }
         }
@@ -283,12 +395,12 @@ public class XeniaOutputHandler
         }
 
         // Fast pre-filter: skip lines that don't contain "Title name"
-        if (!line.Contains("Title name", StringComparison.InvariantCulture))
+        if (!line.Contains("Title name", StringComparison.Ordinal))
         {
             return;
         }
 
-        Match match = _titleNameRegex.Match(line);
+        Match match = TitleNameRegex().Match(line);
         if (!match.Success)
         {
             return;
@@ -312,17 +424,17 @@ public class XeniaOutputHandler
     private void CheckForProfileLoad(string line)
     {
         // Fast pre-filter: skip lines that don't contain relevant keywords
-        if (!line.Contains("Loaded", StringComparison.InvariantCultureIgnoreCase) &&
-            !line.Contains("logged_profile_slot", StringComparison.InvariantCultureIgnoreCase))
+        if (!line.Contains("Loaded", StringComparison.OrdinalIgnoreCase) &&
+            !line.Contains("logged_profile_slot", StringComparison.OrdinalIgnoreCase))
         {
             return;
         }
 
         // First, try to match the [Profiles] section format: logged_profile_slot_X_xuid = "XUID"
-        Match slotMatch = _profileSlotRegex.Match(line);
+        Match slotMatch = ProfileSlotRegex().Match(line);
         if (slotMatch.Success)
         {
-            string xuidString = slotMatch.Groups["XUID"].Value.ToUpperInvariant();
+            string xuidString = slotMatch.Groups["XUID"].Value;
             int profileSlot = int.Parse(slotMatch.Groups[1].Value, CultureInfo.InvariantCulture);
 
             // Skip if XUID is null/empty or zero
@@ -336,14 +448,14 @@ public class XeniaOutputHandler
         }
 
         // Second, try to match the full profile load format: "Loaded Gamertag (GUID: XUID) to slot X"
-        Match match = _gamerProfilesRegex.Match(line);
+        Match match = GamerProfilesRegex().Match(line);
         if (!match.Success)
         {
             return;
         }
 
         string gamertag = match.Groups["Gamertag"].Value;
-        string guid = match.Groups["GUID"].Value.ToUpperInvariant();
+        string guid = match.Groups["GUID"].Value;
         int slot = int.Parse(match.Groups["Slot"].Value, CultureInfo.InvariantCulture);
 
         // Parse XUID from hex string
@@ -413,12 +525,7 @@ public class XeniaOutputHandler
         }
     }
 
-    // Event handlers for process output
-    private void OnOutputDataReceived(object sender, DataReceivedEventArgs e)
-    {
-        ProcessLine(e.Data ?? string.Empty);
-    }
-
+    // Event handlers for process exit
     private void OnProcessExited(object? sender, EventArgs e)
     {
         Logger.Info<XeniaOutputHandler>($"Xenia process exited for {_game?.Title}");

--- a/source/XeniaManager.Core/Manage/XeniaOutputHandler.cs
+++ b/source/XeniaManager.Core/Manage/XeniaOutputHandler.cs
@@ -211,8 +211,21 @@ public partial class XeniaOutputHandler
             const int slowPollMs = 200;
             int pollDelay = fastPollMs;
 
-            while (!cancellationToken.IsCancellationRequested && !process.HasExited)
+            while (!cancellationToken.IsCancellationRequested)
             {
+                bool hasExited = false;
+                try
+                {
+                    hasExited = process.HasExited;
+                }
+                catch
+                {
+                    hasExited = true;
+                }
+                if (hasExited)
+                {
+                    break;
+                }
                 string? line;
                 bool sawNewData = false;
                 while ((line = await reader.ReadLineAsync(cancellationToken)) != null)

--- a/source/XeniaManager.Core/Manage/XeniaOutputHandler.cs
+++ b/source/XeniaManager.Core/Manage/XeniaOutputHandler.cs
@@ -18,11 +18,13 @@ public partial class XeniaOutputHandler
     private readonly Game? _game;
     private readonly XeniaVersion? _xeniaVersion;
     private readonly List<AccountInfo> _loadedProfiles;
-    private readonly Dictionary<int, AccountInfo> _slotToProfile; // Maps slot number to profile
+    private readonly Dictionary<int, AccountInfo> _slotToProfile;
+    private readonly Dictionary<ulong, AccountInfo> _xuidToProfile;
     private readonly Lock _lock = new Lock();
     private bool _isGameLoading;
-    private int _gameLoadCheckAttempts;
+    private Stopwatch? _gameLoadStopwatch;
     private readonly bool _readingGameDetails;
+    private readonly TimeSpan _gameLoadTimeout;
 
     // Game details extracted from output
     private readonly ParsedGameDetails _gameDetails;
@@ -32,12 +34,9 @@ public partial class XeniaOutputHandler
     private Task? _logReaderTask;
 
     /// <summary>
-    /// Maximum number of attempts to check for the game to start loading
-    /// <remarks>
-    /// This is just a magic number and should probably be replaced with a stopwatch
-    /// </remarks>
+    /// Default timeout for game loading detection (30 seconds)
     /// </summary>
-    private const int MaxGameLoadCheckAttempts = 3000;
+    private static readonly TimeSpan DefaultGameLoadTimeout = TimeSpan.FromSeconds(30);
 
     /// <summary>
     /// Regex pattern to detect loaded gamer profiles
@@ -92,8 +91,10 @@ public partial class XeniaOutputHandler
         _xeniaVersion = game?.XeniaVersion;
         _loadedProfiles = [];
         _slotToProfile = new Dictionary<int, AccountInfo>();
+        _xuidToProfile = new Dictionary<ulong, AccountInfo>();
         _readingGameDetails = readingGameDetails;
         _gameDetails = new ParsedGameDetails();
+        _gameLoadTimeout = DefaultGameLoadTimeout;
     }
 
     /// <summary>
@@ -122,13 +123,13 @@ public partial class XeniaOutputHandler
     /// <param name="process">The Xenia process</param>
     public void StartCapture(Process process)
     {
-        _isGameLoading = false;
-        _gameLoadCheckAttempts = 0;
-
         lock (_lock)
         {
+            _isGameLoading = false;
+            _gameLoadStopwatch = Stopwatch.StartNew();
             _loadedProfiles.Clear();
             _slotToProfile.Clear();
+            _xuidToProfile.Clear();
         }
 
         Logger.Info<XeniaOutputHandler>($"Starting log file capture for {_game?.Title}");
@@ -219,6 +220,9 @@ public partial class XeniaOutputHandler
                     ProcessLine(line);
                     sawNewData = true;
                 }
+
+                // Check game load timeout on every poll tick, not just when lines arrive
+                CheckGameLoadTimeout();
 
                 if (sawNewData)
                 {
@@ -377,23 +381,46 @@ public partial class XeniaOutputHandler
     }
 
     /// <summary>
-    /// Checks if a line indicates the game is loading and extracts the game title
-    /// Also tracks attempts and marks the game as loaded after max attempts
+    /// Checks if the game load timeout has elapsed and fires the event if so.
+    /// Called on every poll tick to ensure the timeout fires promptly regardless
+    /// of whether new log output has arrived.
+    /// </summary>
+    private void CheckGameLoadTimeout()
+    {
+        if (_isGameLoading)
+        {
+            return;
+        }
+
+        Stopwatch? stopwatch;
+        lock (_lock)
+        {
+            stopwatch = _gameLoadStopwatch;
+        }
+
+        if (stopwatch == null || stopwatch.Elapsed < _gameLoadTimeout)
+        {
+            return;
+        }
+
+        lock (_lock)
+        {
+            if (!_isGameLoading)
+            {
+                _isGameLoading = true;
+                Logger.Info<XeniaOutputHandler>($"Game marked as loaded after {_gameLoadTimeout.TotalSeconds} seconds");
+                GameLoadingStarted?.Invoke(this, EventArgs.Empty);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Checks if a line indicates the game is loading and extracts the game title.
+    /// For timeout-based detection, see <see cref="CheckGameLoadTimeout"/>.
     /// </summary>
     /// <param name="line">The line to check</param>
     private void CheckForGameLoad(string line)
     {
-        _gameLoadCheckAttempts++;
-
-        // Check if we've exceeded max attempts and mark the game as loaded
-        if (_gameLoadCheckAttempts >= MaxGameLoadCheckAttempts)
-        {
-            _isGameLoading = true;
-            Logger.Info<XeniaOutputHandler>($"Game marked as loaded after {MaxGameLoadCheckAttempts} check attempts");
-            GameLoadingStarted?.Invoke(this, EventArgs.Empty);
-            return;
-        }
-
         // Fast pre-filter: skip lines that don't contain "Title name"
         if (!line.Contains("Title name", StringComparison.Ordinal))
         {
@@ -408,11 +435,14 @@ public partial class XeniaOutputHandler
 
         string gameTitle = match.Groups["Title"].Value.Trim();
 
-        if (!_isGameLoading)
+        lock (_lock)
         {
-            _isGameLoading = true;
-            Logger.Info<XeniaOutputHandler>($"Game loading detected: {gameTitle}");
-            GameLoadingStarted?.Invoke(this, EventArgs.Empty);
+            if (!_isGameLoading)
+            {
+                _isGameLoading = true;
+                Logger.Info<XeniaOutputHandler>($"Game loading detected: {gameTitle}");
+                GameLoadingStarted?.Invoke(this, EventArgs.Empty);
+            }
         }
     }
 
@@ -487,14 +517,13 @@ public partial class XeniaOutputHandler
                 {
                     _loadedProfiles.Remove(existingProfileInSlot);
                     _slotToProfile.Remove(slot);
+                    _xuidToProfile.Remove(existingProfileInSlot.Xuid.Value);
                     Logger.Info<XeniaOutputHandler>($"Removed profile from slot {slot}: {existingProfileInSlot.Gamertag} (XUID: {existingProfileInSlot.Xuid}) - profile switch detected");
                 }
             }
 
-            // Check if a profile with this XUID already exists
-            AccountInfo? existingProfile = _loadedProfiles.FirstOrDefault(p => p.Xuid.Value == xuidValue);
-
-            if (existingProfile != null)
+            // Check if a profile with this XUID already exists (O(1) lookup)
+            if (_xuidToProfile.TryGetValue(xuidValue, out AccountInfo? existingProfile))
             {
                 // Update gamertag if it was missing before
                 if (!string.IsNullOrEmpty(gamertag) && string.IsNullOrEmpty(existingProfile.Gamertag))
@@ -520,6 +549,7 @@ public partial class XeniaOutputHandler
                 };
                 _loadedProfiles.Add(profile);
                 _slotToProfile[slot] = profile;
+                _xuidToProfile[xuidValue] = profile;
                 Logger.Info<XeniaOutputHandler>($"Profile {(gamertag != null ? "loaded" : "detected")}: {(gamertag ?? "Unknown")} (XUID: {xuidValue:X16}, Slot: {slot})");
             }
         }

--- a/source/XeniaManager.Core/Manage/XeniaOutputHandler.cs
+++ b/source/XeniaManager.Core/Manage/XeniaOutputHandler.cs
@@ -22,7 +22,7 @@ public partial class XeniaOutputHandler
     private readonly Dictionary<ulong, AccountInfo> _xuidToProfile;
     private readonly Lock _lock = new Lock();
     private bool _isGameLoading;
-    private Stopwatch? _gameLoadStopwatch;
+    private DateTime? _gameLoadStartTime;
     private readonly bool _readingGameDetails;
     private readonly TimeSpan _gameLoadTimeout;
 
@@ -126,7 +126,7 @@ public partial class XeniaOutputHandler
         lock (_lock)
         {
             _isGameLoading = false;
-            _gameLoadStopwatch = Stopwatch.StartNew();
+            _gameLoadStartTime = DateTime.UtcNow;
             _loadedProfiles.Clear();
             _slotToProfile.Clear();
             _xuidToProfile.Clear();
@@ -392,13 +392,13 @@ public partial class XeniaOutputHandler
             return;
         }
 
-        Stopwatch? stopwatch;
+        DateTime? startTime;
         lock (_lock)
         {
-            stopwatch = _gameLoadStopwatch;
+            startTime = _gameLoadStartTime;
         }
 
-        if (stopwatch == null || stopwatch.Elapsed < _gameLoadTimeout)
+        if (startTime == null || (DateTime.UtcNow - startTime.Value) < _gameLoadTimeout)
         {
             return;
         }

--- a/source/XeniaManager.Core/Manage/XeniaOutputHandler.cs
+++ b/source/XeniaManager.Core/Manage/XeniaOutputHandler.cs
@@ -400,30 +400,22 @@ public partial class XeniaOutputHandler
     /// </summary>
     private void CheckGameLoadTimeout()
     {
-        if (_isGameLoading)
-        {
-            return;
-        }
-
-        DateTime? startTime;
         lock (_lock)
         {
-            startTime = _gameLoadStartTime;
-        }
-
-        if (startTime == null || (DateTime.UtcNow - startTime.Value) < _gameLoadTimeout)
-        {
-            return;
-        }
-
-        lock (_lock)
-        {
-            if (!_isGameLoading)
+            if (_isGameLoading)
             {
-                _isGameLoading = true;
-                Logger.Info<XeniaOutputHandler>($"Game marked as loaded after {_gameLoadTimeout.TotalSeconds} seconds");
-                GameLoadingStarted?.Invoke(this, EventArgs.Empty);
+                return;
             }
+            DateTime? startTime = _gameLoadStartTime;
+
+            if (startTime == null || (DateTime.UtcNow - startTime.Value) < _gameLoadTimeout)
+            {
+                return;
+            }
+
+            _isGameLoading = true;
+            Logger.Info<XeniaOutputHandler>($"Game marked as loaded after {_gameLoadTimeout.TotalSeconds} seconds");
+            GameLoadingStarted?.Invoke(this, EventArgs.Empty);
         }
     }
 

--- a/source/XeniaManager.Core/Manage/XeniaOutputHandler.cs
+++ b/source/XeniaManager.Core/Manage/XeniaOutputHandler.cs
@@ -314,6 +314,7 @@ public partial class XeniaOutputHandler
         if (_readingGameDetails)
         {
             ExtractGameDetails(line);
+            return;
         }
 
         // Check for game loading events (only if the game hasn't started loading yet)
@@ -400,6 +401,7 @@ public partial class XeniaOutputHandler
     /// </summary>
     private void CheckGameLoadTimeout()
     {
+        EventHandler? handler;
         lock (_lock)
         {
             if (_isGameLoading)
@@ -415,8 +417,9 @@ public partial class XeniaOutputHandler
 
             _isGameLoading = true;
             Logger.Info<XeniaOutputHandler>($"Game marked as loaded after {_gameLoadTimeout.TotalSeconds} seconds");
-            GameLoadingStarted?.Invoke(this, EventArgs.Empty);
+            handler = GameLoadingStarted;
         }
+        handler?.Invoke(this, EventArgs.Empty);
     }
 
     /// <summary>
@@ -439,16 +442,17 @@ public partial class XeniaOutputHandler
         }
 
         string gameTitle = match.Groups["Title"].Value.Trim();
-
+        EventHandler? handler = null;
         lock (_lock)
         {
             if (!_isGameLoading)
             {
                 _isGameLoading = true;
                 Logger.Info<XeniaOutputHandler>($"Game loading detected: {gameTitle}");
-                GameLoadingStarted?.Invoke(this, EventArgs.Empty);
+                handler = GameLoadingStarted;
             }
         }
+        handler?.Invoke(this, EventArgs.Empty);
     }
 
     /// <summary>


### PR DESCRIPTION
Now it will read `xenia.log` file instead of trying to read `Console Output`.

This is to fix not being able to read Xenia logs when it's console window is enabled.