### PR TITLE
fix(launcher): Launching games with invalid game path

### DIFF
--- a/source/XeniaManager.Core/Manage/Launcher.cs
+++ b/source/XeniaManager.Core/Manage/Launcher.cs
@@ -198,6 +198,12 @@ public class Launcher
             throw new Exception("Xenia is updating, please wait for it to finish updating before launching the emulator");
         }
 
+        if (!game.FileLocations.IsGamePathValid)
+        {
+            Logger.Error<Launcher>($"Invalid game path: {game.FileLocations.Game}");
+            throw new Exception($"Invalid game path: {game.FileLocations.Game}");
+        }
+
         Logger.Info<Launcher>($"Launching game: {game.Title} using Xenia version: {game.XeniaVersion}");
 
         // Load settings to check automatic save backup configuration

--- a/source/XeniaManager.Core/Models/Game/GameFiles.cs
+++ b/source/XeniaManager.Core/Models/Game/GameFiles.cs
@@ -30,4 +30,11 @@ public class GameFiles
     /// </summary>
     [JsonPropertyName("custom_emulator_executable")]
     public string? CustomEmulatorExecutable { get; set; }
+
+    /// <summary>
+    /// Whether the game's path is valid
+    /// </summary>
+    [JsonIgnore]
+    public bool IsGamePathValid => !string.IsNullOrEmpty(Game)
+                                   && File.Exists(Game);
 }

--- a/source/XeniaManager.Core/Utilities/ArgumentParser.cs
+++ b/source/XeniaManager.Core/Utilities/ArgumentParser.cs
@@ -64,14 +64,20 @@ public class ArgumentParser
             string trimmedArg = arg.Trim('"');
 
             // Search for a matching game in GameManager.Games
-            Game? matchingGame = GameManager.Games.FirstOrDefault(g => g.Title.Equals(trimmedArg, StringComparison.OrdinalIgnoreCase)
-            );
+            Game? matchingGame = GameManager.Games.FirstOrDefault(g => g.Title.Equals(trimmedArg, StringComparison.OrdinalIgnoreCase));
 
-            if (matchingGame != null)
+            if (matchingGame == null)
             {
-                Logger.Debug<ArgumentParser>($"Found game '{matchingGame.Title}' ({matchingGame.GameId}) in desktop arguments");
-                return matchingGame;
+                continue;
             }
+
+            if (!matchingGame.FileLocations.IsGamePathValid)
+            {
+                Logger.Warning<ArgumentParser>($"Game '{matchingGame.Title}' ({matchingGame.GameId}) has an invalid path, skipping");
+                continue;
+            }
+            Logger.Debug<ArgumentParser>($"Found game '{matchingGame.Title}' ({matchingGame.GameId}) in desktop arguments");
+            return matchingGame;
         }
 
         Logger.Debug<ArgumentParser>("No matching game found in desktop arguments");

--- a/source/XeniaManager/Resources/Language/en.axaml
+++ b/source/XeniaManager/Resources/Language/en.axaml
@@ -133,6 +133,9 @@
     <sys:String x:Key="LibraryPage.DeleteSelected.Error.Message">Failed to delete selected games:&#10;{0}</sys:String>
     <sys:String x:Key="LibraryPage.ClearSelection.Button">Clear Selection</sys:String>
 
+    <!-- Library Game ToolTips -->
+    <sys:String x:Key="LibraryPage.Game.ToolTip.Path.Invalid">Game path is invalid</sys:String>
+
     <!-- Compatibility Rating -->
     <sys:String x:Key="CompatibilityRating.Unknown">Unknown</sys:String>
     <sys:String x:Key="CompatibilityRating.Unplayable">Unplayable</sys:String>

--- a/source/XeniaManager/Resources/Language/hr.axaml
+++ b/source/XeniaManager/Resources/Language/hr.axaml
@@ -133,6 +133,9 @@
     <sys:String x:Key="LibraryPage.DeleteSelected.Error.Message">Nije uspjelo brisanje odabranih igara:&#10;{0}</sys:String>
     <sys:String x:Key="LibraryPage.ClearSelection.Button">Očisti odabir</sys:String>
 
+    <!-- Library Game ToolTips -->
+    <sys:String x:Key="LibraryPage.Game.ToolTip.Path.Invalid">Putanja do igre je nevaljana</sys:String>
+
     <!-- Compatibility Rating -->
     <sys:String x:Key="CompatibilityRating.Unknown">Nepoznato</sys:String>
     <sys:String x:Key="CompatibilityRating.Unplayable">Nemoguće igrati</sys:String>

--- a/source/XeniaManager/ViewModels/Items/GameItemViewModel.cs
+++ b/source/XeniaManager/ViewModels/Items/GameItemViewModel.cs
@@ -66,6 +66,12 @@ public partial class GameItemViewModel : ViewModelBase
     [RelayCommand]
     private async Task Launch()
     {
+        if (!Game.FileLocations.IsGamePathValid)
+        {
+            Logger.Warning<GameItemViewModel>($"Invalid game path: {Game.FileLocations.Game}");
+            return;
+        }
+
         LoadingScreenWindow? loadingScreen = null;
         try
         {

--- a/source/XeniaManager/Views/Pages/LibraryPage.axaml
+++ b/source/XeniaManager/Views/Pages/LibraryPage.axaml
@@ -470,22 +470,42 @@
                                              StrokeThickness="1"
                                              IsVisible="{Binding DataContext.ShowCompatibilityRating, ElementName=Root}" />
 
-                                    <!-- Xenia Version Icon (top-right corner) -->
-                                    <Border Grid.Row="0"
-                                            Background="#99000000"
-                                            CornerRadius="4"
-                                            Padding="3"
-                                            Margin="4"
-                                            HorizontalAlignment="Right"
-                                            VerticalAlignment="Top"
-                                            IsVisible="{Binding DataContext.ShowXeniaVersion, ElementName=Root}">
-                                        <ToolTip.Tip>
-                                            <TextBlock Text="{Binding Game.XeniaVersion, Converter={StaticResource XeniaVersionToStringConverter}}" />
-                                        </ToolTip.Tip>
-                                        <icons:SymbolIcon Symbol="{Binding Game.XeniaVersion, Converter={StaticResource XeniaVersionToIconConverter}}"
-                                                          FontSize="{Binding DataContext.ZoomValue, ElementName=Root, Converter={StaticResource ZoomScaleConverter}, ConverterParameter=14}"
-                                                          Foreground="White" />
-                                    </Border>
+                                    <!-- Top-right badges -->
+                                    <StackPanel Grid.Row="0"
+                                                Orientation="Horizontal"
+                                                Spacing="4"
+                                                Margin="2"
+                                                HorizontalAlignment="Right"
+                                                VerticalAlignment="Top">
+
+                                        <!-- Invalid Game Path Badge -->
+                                        <Border Background="{DynamicResource SystemFillColorCritical}"
+                                                CornerRadius="4"
+                                                Padding="3"
+                                                IsVisible="{Binding !Game.FileLocations.IsGamePathValid}">
+                                            <ToolTip.Tip>
+                                                <TextBlock Text="Game path is invalid" />
+                                            </ToolTip.Tip>
+
+                                            <icons:SymbolIcon Symbol="ErrorCircle"
+                                                              FontSize="{Binding DataContext.ZoomValue, ElementName=Root, Converter={StaticResource ZoomScaleConverter}, ConverterParameter=14}"
+                                                              Foreground="White" />
+                                        </Border>
+
+                                        <!-- Xenia Version Icon -->
+                                        <Border Background="#99000000"
+                                                CornerRadius="4"
+                                                Padding="3"
+                                                IsVisible="{Binding DataContext.ShowXeniaVersion, ElementName=Root}">
+                                            <ToolTip.Tip>
+                                                <TextBlock Text="{Binding Game.XeniaVersion, Converter={StaticResource XeniaVersionToStringConverter}}" />
+                                            </ToolTip.Tip>
+
+                                            <icons:SymbolIcon Symbol="{Binding Game.XeniaVersion, Converter={StaticResource XeniaVersionToIconConverter}}"
+                                                              FontSize="{Binding DataContext.ZoomValue, ElementName=Root, Converter={StaticResource ZoomScaleConverter}, ConverterParameter=14}"
+                                                              Foreground="White" />
+                                        </Border>
+                                    </StackPanel>
 
                                     <!-- Game Title Overlay (shown when enabled) -->
                                     <Border Grid.Row="0"

--- a/source/XeniaManager/Views/Pages/LibraryPage.axaml
+++ b/source/XeniaManager/Views/Pages/LibraryPage.axaml
@@ -484,7 +484,7 @@
                                                 Padding="3"
                                                 IsVisible="{Binding !Game.FileLocations.IsGamePathValid}">
                                             <ToolTip.Tip>
-                                                <TextBlock Text="Game path is invalid" />
+                                                <TextBlock Text="{DynamicResource LibraryPage.Game.ToolTip.Path.Invalid}" />
                                             </ToolTip.Tip>
 
                                             <icons:SymbolIcon Symbol="ErrorCircle"


### PR DESCRIPTION
In the UI there's an icon showing that game path is invalid and now the game won't be launched if this is the case.

<img width="885" height="937" alt="XeniaManager_JTxfOGCvK7" src="https://github.com/user-attachments/assets/c61d2aac-0d38-4470-9c5b-66cded3c5d9a" />
