### PR TITLE
fix(patches): Various `PatchFile` fixes & improvements

### DIFF
--- a/source/XeniaManager.Core/Files/PatchFile.cs
+++ b/source/XeniaManager.Core/Files/PatchFile.cs
@@ -201,7 +201,7 @@ public class PatchFile
                 continue;
             }
 
-            if (isInPatchSection && currentPatch != null && trimmedLine.StartsWith("[[patch.") && trimmedLine.EndsWith("]]"))
+            if (isInPatchSection && currentPatch != null && trimmedLine.StartsWith("[[patch."))
             {
                 Match m = Regex.Match(trimmedLine, @"^\[\[patch\.([^\]]+)\]\]");
                 if (m.Success)
@@ -487,6 +487,7 @@ public class PatchFile
         }
 
         string valueStr = valueMatch.Groups[1].Value.Trim().TrimEnd(',');
+        valueStr = StripInlineComment(valueStr);
         object? value = ParseValue(valueStr, commandType);
         if (value == null)
         {
@@ -503,6 +504,26 @@ public class PatchFile
 
         patch.Commands.Add(cmd);
         Logger.Debug<PatchFile>($"Parsed {commandType} command: address=0x{address:x8}, value={value}");
+    }
+
+    /// <summary>
+    /// Strips inline TOML comments from a value string, preserving # inside quoted strings.
+    /// </summary>
+    private static string StripInlineComment(string valueStr)
+    {
+        bool inQuotes = false;
+        for (int i = 0; i < valueStr.Length; i++)
+        {
+            if (valueStr[i] == '"' && (i == 0 || valueStr[i - 1] != '\\'))
+            {
+                inQuotes = !inQuotes;
+            }
+            else if (valueStr[i] == '#' && !inQuotes)
+            {
+                return valueStr.Substring(0, i).TrimEnd();
+            }
+        }
+        return valueStr;
     }
 
     /// <summary>
@@ -746,13 +767,13 @@ public class PatchFile
         {
             sb.AppendLine("[[patch]]");
             sb.AppendLine($"    name = \"{patch.Name}\"");
-            sb.AppendLine($"    author = \"{patch.Author}\"");
 
             if (!string.IsNullOrEmpty(patch.Description))
             {
                 sb.AppendLine($"    desc = \"{patch.Description}\"");
             }
 
+            sb.AppendLine($"    author = \"{patch.Author}\"");
             sb.AppendLine($"    is_enabled = {patch.IsEnabled.ToString().ToLower()}");
             sb.AppendLine();
 

--- a/source/XeniaManager.Core/Files/PatchFile.cs
+++ b/source/XeniaManager.Core/Files/PatchFile.cs
@@ -151,6 +151,7 @@ public class PatchFile
         string[] lines = content.Split(["\r\n", "\r", "\n"], StringSplitOptions.None);
         PatchEntry? currentPatch = null;
         string? currentCommandType = null;
+        string? currentCommandTypeComment = null;
         bool isInPatchSection = false;
 
         for (int i = 0; i < lines.Length; i++)
@@ -158,39 +159,70 @@ public class PatchFile
             string line = lines[i];
             string trimmedLine = line.Trim();
 
-            // Skip empty lines and pure comment lines in most contexts
-            // Exception: #media_id lines need to be processed
-            if (string.IsNullOrEmpty(trimmedLine) || (trimmedLine.StartsWith("#") && !trimmedLine.StartsWith("#media_id")))
+            if (string.IsNullOrEmpty(trimmedLine))
             {
                 continue;
             }
 
-            if (trimmedLine.StartsWith("title_name"))
+            // Special handling for [[patch.type]] - extract comment BEFORE stripping
+            if (isInPatchSection && trimmedLine.StartsWith("[[patch.", StringComparison.OrdinalIgnoreCase))
             {
-                ParseTitleName(trimmedLine, patchFile);
+                // Extract command type from raw line
+                Match typeMatch = Regex.Match(trimmedLine, @"^\[\[patch\.([^\]]+)\]\]", RegexOptions.IgnoreCase);
+                if (typeMatch.Success)
+                {
+                    currentCommandType = typeMatch.Groups[1].Value;
+                }
+
+                // Note: This regex has TWO groups - group 1 is type, group 2 is comment
+                Match inlineCommentMatch = Regex.Match(trimmedLine, @"^\[\[patch\.([^\]]+)\]\]\s*#\s*(.+)$", RegexOptions.IgnoreCase);
+                if (inlineCommentMatch.Success)
+                {
+                    currentCommandTypeComment = inlineCommentMatch.Groups[2].Value.Trim();
+                    Logger.Debug<PatchFile>($"Command type '{currentCommandType}' has inline comment: {currentCommandTypeComment}");
+                }
+
                 continue;
             }
 
-            if (trimmedLine.StartsWith("title_id"))
+            // Special handling for header fields - extract comments BEFORE stripping
+            if (trimmedLine.StartsWith("title_name", StringComparison.OrdinalIgnoreCase))
             {
-                ParseTitleId(trimmedLine, patchFile);
+                ParseTitleNameWithComment(trimmedLine, patchFile);
                 continue;
             }
 
-            if (trimmedLine.StartsWith("hash"))
+            if (trimmedLine.StartsWith("title_id", StringComparison.OrdinalIgnoreCase))
+            {
+                ParseTitleIdWithComment(trimmedLine, patchFile);
+                continue;
+            }
+
+            // Parse hash before stripping to preserve comments
+            if (trimmedLine.StartsWith("hash", StringComparison.OrdinalIgnoreCase))
             {
                 ParseHashValue(trimmedLine, lines, i, patchFile);
                 continue;
             }
 
-            if (trimmedLine.StartsWith("#media_id") || trimmedLine.StartsWith("media_id"))
+            if (trimmedLine.StartsWith("#media_id", StringComparison.OrdinalIgnoreCase) ||
+                trimmedLine.StartsWith("media_id", StringComparison.OrdinalIgnoreCase))
             {
                 ParseMediaIdArray(trimmedLine, lines, i, patchFile);
                 continue;
             }
 
-            if (trimmedLine.StartsWith("[[patch]]"))
+            // Strip inline comments for all other lines (preserve # inside quoted strings)
+            string processedLine = StripInlineComment(trimmedLine);
+
+            string lineToProcess = processedLine;
+
+            if (lineToProcess.StartsWith("[[patch]]", StringComparison.OrdinalIgnoreCase))
             {
+                // Capture [[patch]] header comment if present
+                Match patchHeaderMatch = Regex.Match(lineToProcess, @"^\[\[patch\]\]\s*#\s*(.*)", RegexOptions.IgnoreCase);
+                string patchHeaderComment = patchHeaderMatch.Success ? patchHeaderMatch.Groups[1].Value.Trim() : string.Empty;
+
                 if (currentPatch != null && !string.IsNullOrEmpty(currentPatch.Name) && !string.IsNullOrEmpty(currentPatch.Author))
                 {
                     patchFile.Document.Patches.Add(currentPatch);
@@ -201,25 +233,16 @@ public class PatchFile
                 continue;
             }
 
-            if (isInPatchSection && currentPatch != null && trimmedLine.StartsWith("[[patch."))
+            if (currentPatch != null && currentCommandType != null && lineToProcess.StartsWith("address", StringComparison.OrdinalIgnoreCase))
             {
-                Match m = Regex.Match(trimmedLine, @"^\[\[patch\.([^\]]+)\]\]");
-                if (m.Success)
-                {
-                    currentCommandType = m.Groups[1].Value;
-                }
+                ParsePatchCommand(lines, i, currentPatch, currentCommandType, currentCommandTypeComment);
+                currentCommandTypeComment = null;
                 continue;
             }
 
-            if (currentPatch != null && currentCommandType != null && trimmedLine.StartsWith("address"))
+            if (currentPatch != null && (lineToProcess.StartsWith("name", StringComparison.OrdinalIgnoreCase)))
             {
-                ParsePatchCommand(lines, i, currentPatch, currentCommandType);
-                continue;
-            }
-
-            if (currentPatch != null && trimmedLine.StartsWith("name"))
-            {
-                Match m = Regex.Match(trimmedLine, @"^name\s*=\s*""([^""]*)""");
+                Match m = Regex.Match(lineToProcess, @"^name\s*=\s*""([^""]*)""", RegexOptions.IgnoreCase);
                 if (m.Success)
                 {
                     currentPatch.Name = m.Groups[1].Value;
@@ -227,9 +250,9 @@ public class PatchFile
                 continue;
             }
 
-            if (currentPatch != null && trimmedLine.StartsWith("author"))
+            if (currentPatch != null && (lineToProcess.StartsWith("author", StringComparison.OrdinalIgnoreCase)))
             {
-                Match m = Regex.Match(trimmedLine, @"^author\s*=\s*""([^""]*)""");
+                Match m = Regex.Match(lineToProcess, @"^author\s*=\s*""([^""]*)""", RegexOptions.IgnoreCase);
                 if (m.Success)
                 {
                     currentPatch.Author = m.Groups[1].Value;
@@ -237,19 +260,19 @@ public class PatchFile
                 continue;
             }
 
-            if (currentPatch != null && trimmedLine.StartsWith("desc"))
+            if (currentPatch != null && (lineToProcess.StartsWith("desc", StringComparison.OrdinalIgnoreCase) || lineToProcess.StartsWith("Desc", StringComparison.OrdinalIgnoreCase)))
             {
-                Match m = Regex.Match(trimmedLine, @"^desc\s*=\s*""([^""]*)""");
+                Match m = Regex.Match(lineToProcess, @"^(desc|Desc)\s*=\s*""([^""]*)""", RegexOptions.IgnoreCase);
                 if (m.Success)
                 {
-                    currentPatch.Description = m.Groups[1].Value;
+                    currentPatch.Description = m.Groups[2].Value;
                 }
                 continue;
             }
 
-            if (currentPatch != null && trimmedLine.StartsWith("is_enabled"))
+            if (currentPatch != null && lineToProcess.StartsWith("is_enabled", StringComparison.OrdinalIgnoreCase))
             {
-                Match m = Regex.Match(trimmedLine, @"^is_enabled\s*=\s*(true|false)", RegexOptions.IgnoreCase);
+                Match m = Regex.Match(lineToProcess, @"^is_enabled\s*=\s*(true|false)", RegexOptions.IgnoreCase);
                 if (m.Success)
                 {
                     currentPatch.IsEnabled = m.Groups[1].Value.Equals("true", StringComparison.OrdinalIgnoreCase);
@@ -271,6 +294,46 @@ public class PatchFile
                 continue;
             }
             Logger.Debug<PatchFile>($"Parsed patch: {patch.Name} by {patch.Author} ({patch.Commands.Count} commands)");
+        }
+    }
+
+    /// <summary>
+    /// Parses the title_name field from a line (with inline comment extraction).
+    /// </summary>
+    private static void ParseTitleNameWithComment(string rawLine, PatchFile patchFile)
+    {
+        // Extract comment first
+        Match commentMatch = Regex.Match(rawLine, @"^title_name\s*=\s*""[^""]+""\s*#\s*(.+)$");
+        string? comment = commentMatch.Success ? commentMatch.Groups[1].Value.Trim() : null;
+
+        // Now strip comment and extract title name
+        string strippedLine = StripInlineComment(rawLine);
+        Match m = Regex.Match(strippedLine, @"^title_name\s*=\s*""([^""]+)""");
+        if (m.Success)
+        {
+            patchFile.Document.TitleName = m.Groups[1].Value;
+            patchFile.Document.TitleNameComment = comment ?? string.Empty;
+            Logger.Debug<PatchFile>($"Title Name: {patchFile.Document.TitleName}");
+        }
+    }
+
+    /// <summary>
+    /// Parses the title_id field from a line (with inline comment extraction).
+    /// </summary>
+    private static void ParseTitleIdWithComment(string rawLine, PatchFile patchFile)
+    {
+        // Extract comment first
+        Match commentMatch = Regex.Match(rawLine, @"^title_id\s*=\s*""[A-Fa-f0-9]+""\s*#\s*(.+)$");
+        string? comment = commentMatch.Success ? commentMatch.Groups[1].Value.Trim() : null;
+
+        // Now strip comment and extract title id
+        string strippedLine = StripInlineComment(rawLine);
+        Match m = Regex.Match(strippedLine, @"^title_id\s*=\s*""([A-Fa-f0-9]+)""");
+        if (m.Success)
+        {
+            patchFile.Document.TitleId = m.Groups[1].Value.ToUpper();
+            patchFile.Document.TitleIdComment = comment ?? string.Empty;
+            Logger.Debug<PatchFile>($"Title ID: {patchFile.Document.TitleId}");
         }
     }
 
@@ -319,12 +382,12 @@ public class PatchFile
     }
 
     /// <summary>
-    /// Parses the hash field from the TOML content.
+    /// Parses the hash field from the TOML content (handles raw line with comment).
     /// </summary>
-    private static void ParseHashValue(string line, string[] lines, int lineIndex, PatchFile patchFile)
+    private static void ParseHashValue(string rawLine, string[] lines, int lineIndex, PatchFile patchFile)
     {
         // Single hash with optional comment
-        Match m = Regex.Match(line, @"^hash\s*=\s*""([A-Fa-f0-9]+)""\s*#\s*(.*)");
+        Match m = Regex.Match(rawLine, @"^hash\s*=\s*""([A-Fa-f0-9]+)""\s*#\s*(.*)");
         if (m.Success)
         {
             patchFile.Document.Hashes.Add(m.Groups[1].Value.ToUpper());
@@ -334,7 +397,7 @@ public class PatchFile
         }
 
         // Single hash without comment
-        m = Regex.Match(line, @"^hash\s*=\s*""([A-Fa-f0-9]+)""");
+        m = Regex.Match(rawLine, @"^hash\s*=\s*""([A-Fa-f0-9]+)""");
         if (m.Success)
         {
             patchFile.Document.Hashes.Add(m.Groups[1].Value.ToUpper());
@@ -343,18 +406,34 @@ public class PatchFile
         }
 
         // Hash array format
-        m = Regex.Match(line, @"^hash\s*=\s*\[");
+        m = Regex.Match(rawLine, @"^hash\s*=\s*\[");
         if (m.Success)
         {
             for (int i = lineIndex + 1; i < lines.Length; i++)
             {
-                string trimmed = lines[i].Trim();
+                string rawLineArray = lines[i];
+                string trimmed = rawLineArray.Trim();
+
                 if (trimmed == "]")
                 {
                     break;
                 }
-                // Extract hash from array line (handles comments)
-                m = Regex.Match(trimmed, @"""([A-Fa-f0-9]+)""");
+
+                // Skip commented-out hash entries (lines starting with #)
+                if (trimmed.StartsWith("#"))
+                {
+                    // Check if it's a commented hash entry for logging/marking disabled
+                    Match commentedMatch = Regex.Match(trimmed, @"^#\s*""([A-Fa-f0-9]+)""\s*,?\s*(?:#\s*(.*))?$");
+                    if (commentedMatch.Success)
+                    {
+                        Logger.Debug<PatchFile>($"Hash (disabled): {commentedMatch.Groups[1].Value}");
+                    }
+                    continue;
+                }
+
+                // Strip inline comment before extracting hash
+                string processedLine = StripInlineComment(trimmed);
+                m = Regex.Match(processedLine, @"""([A-Fa-f0-9]+)""");
                 if (m.Success)
                 {
                     patchFile.Document.Hashes.Add(m.Groups[1].Value.ToUpper());
@@ -365,12 +444,21 @@ public class PatchFile
     }
 
     /// <summary>
-    /// Parses the media_id field from the TOML content.
+    /// Parses the media_id field from the TOML content (handles raw line with comment).
     /// </summary>
-    private static void ParseMediaIdArray(string line, string[] lines, int lineIndex, PatchFile patchFile)
+    private static void ParseMediaIdArray(string rawLine, string[] lines, int lineIndex, PatchFile patchFile)
     {
-        bool isCommented = line.StartsWith("#");
-        bool hasBracket = line.Contains("[");
+        // The rawLine still has inline comment
+        // First extract the comment from the header line if present
+        string? headerComment = null;
+        Match headerCommentMatch = Regex.Match(rawLine, @"^#media_id\s*=\s*""[A-Fa-f0-9]+""\s*#\s*(.+)$");
+        if (headerCommentMatch.Success)
+        {
+            headerComment = headerCommentMatch.Groups[1].Value.Trim();
+        }
+
+        bool isCommented = rawLine.StartsWith("#");
+        bool hasBracket = rawLine.Contains("[");
 
         if (hasBracket)
         {
@@ -417,41 +505,41 @@ public class PatchFile
         }
         else if (!isCommented)
         {
-            // Single media_id (not commented)
-            Match m = Regex.Match(line, @"^media_id\s*=\s*""([A-Fa-f0-9]+)""\s*#\s*(.*)");
+            // Single media_id (not commented) - use rawLine with comment
+            Match m = Regex.Match(rawLine, @"^media_id\s*=\s*""([A-Fa-f0-9]+)""\s*#\s*(.*)");
             if (m.Success)
             {
                 string mediaId = m.Groups[1].Value.ToUpper();
-                string comment = m.Groups[2].Value.Trim();
+                string comment = m.Groups[2].Success ? m.Groups[2].Value.Trim() : (headerComment ?? string.Empty);
                 patchFile.Document.MediaIds.Add(new MediaIdEntry(mediaId, comment, false));
                 Logger.Debug<PatchFile>($"Media ID: {mediaId}");
                 return;
             }
-            m = Regex.Match(line, @"^media_id\s*=\s*""([A-Fa-f0-9]+)""");
+            m = Regex.Match(rawLine, @"^media_id\s*=\s*""([A-Fa-f0-9]+)""");
             if (m.Success)
             {
                 string mediaId = m.Groups[1].Value.ToUpper();
-                patchFile.Document.MediaIds.Add(new MediaIdEntry(mediaId, string.Empty, false));
+                patchFile.Document.MediaIds.Add(new MediaIdEntry(mediaId, headerComment ?? string.Empty, false));
                 Logger.Debug<PatchFile>($"Media ID: {mediaId}");
             }
         }
         else
         {
-            // Single commented media_id
-            Match m = Regex.Match(line, @"#media_id\s*=\s*""([A-Fa-f0-9]+)""\s*#\s*(.*)");
+            // Single commented media_id - use rawLine with comment
+            Match m = Regex.Match(rawLine, @"^#media_id\s*=\s*""([A-Fa-f0-9]+)""\s*#\s*(.*)");
             if (m.Success)
             {
                 string mediaId = m.Groups[1].Value.ToUpper();
-                string comment = m.Groups[2].Value.Trim();
+                string comment = m.Groups[2].Success ? m.Groups[2].Value.Trim() : (headerComment ?? string.Empty);
                 patchFile.Document.MediaIds.Add(new MediaIdEntry(mediaId, comment, true));
                 Logger.Debug<PatchFile>($"Media ID: {mediaId}");
                 return;
             }
-            m = Regex.Match(line, @"#media_id\s*=\s*""([A-Fa-f0-9]+)""");
+            m = Regex.Match(rawLine, @"^#media_id\s*=\s*""([A-Fa-f0-9]+)""");
             if (m.Success)
             {
                 string mediaId = m.Groups[1].Value.ToUpper();
-                patchFile.Document.MediaIds.Add(new MediaIdEntry(mediaId, string.Empty, true));
+                patchFile.Document.MediaIds.Add(new MediaIdEntry(mediaId, headerComment ?? string.Empty, true));
                 Logger.Debug<PatchFile>($"Media ID: {mediaId}");
             }
         }
@@ -460,9 +548,21 @@ public class PatchFile
     /// <summary>
     /// Parses a patch command from the TOML content.
     /// </summary>
-    private static void ParsePatchCommand(string[] lines, int lineIndex, PatchEntry patch, string commandType)
+    private static void ParsePatchCommand(string[] lines, int lineIndex, PatchEntry patch, string commandType, string? typeComment)
     {
-        string addressLine = lines[lineIndex].Trim();
+        string rawAddressLine = lines[lineIndex].Trim();
+
+        // Extract address comment - more flexible regex to handle whitespace
+        string? addressComment = null;
+        Match addressCommentMatch = Regex.Match(rawAddressLine, @"address\s*=\s*0x[0-9a-fA-F]+\s*#\s*(.+?)\s*$");
+        if (addressCommentMatch.Success)
+        {
+            addressComment = addressCommentMatch.Groups[1].Value.Trim();
+        }
+
+        // Strip inline comment from address line (preserve # inside quotes)
+        string addressLine = StripInlineComment(rawAddressLine);
+
         Match addressMatch = Regex.Match(addressLine, @"address\s*=\s*0x([0-9a-fA-F]+)");
         if (!addressMatch.Success)
         {
@@ -478,7 +578,19 @@ public class PatchFile
             return;
         }
 
-        string valueLine = lines[lineIndex + 1].Trim();
+        string rawValueLine = lines[lineIndex + 1].Trim();
+
+        // Extract value comment - more flexible regex to handle whitespace
+        string? valueComment = null;
+        Match valueCommentMatch = Regex.Match(rawValueLine, @"value\s*=\s*.+?\s*#\s*(.+?)\s*$");
+        if (valueCommentMatch.Success)
+        {
+            valueComment = valueCommentMatch.Groups[1].Value.Trim();
+        }
+
+        // Strip inline comment from value line (preserve # inside quotes)
+        string valueLine = StripInlineComment(rawValueLine);
+
         Match valueMatch = Regex.Match(valueLine, @"value\s*=\s*(.+)");
         if (!valueMatch.Success)
         {
@@ -487,7 +599,6 @@ public class PatchFile
         }
 
         string valueStr = valueMatch.Groups[1].Value.Trim().TrimEnd(',');
-        valueStr = StripInlineComment(valueStr);
         object? value = ParseValue(valueStr, commandType);
         if (value == null)
         {
@@ -499,7 +610,10 @@ public class PatchFile
         {
             Address = address,
             Value = value,
-            Type = ParsePatchType(commandType)
+            Type = ParsePatchType(commandType),
+            TypeComment = typeComment,
+            AddressComment = addressComment,
+            ValueComment = valueComment
         };
 
         patch.Commands.Add(cmd);
@@ -508,21 +622,39 @@ public class PatchFile
 
     /// <summary>
     /// Strips inline TOML comments from a value string, preserving # inside quoted strings.
+    /// Handles escaped quotes (\").
     /// </summary>
     private static string StripInlineComment(string valueStr)
     {
         bool inQuotes = false;
+        bool escaped = false;
+
         for (int i = 0; i < valueStr.Length; i++)
         {
-            if (valueStr[i] == '"' && (i == 0 || valueStr[i - 1] != '\\'))
+            char c = valueStr[i];
+
+            if (escaped)
+            {
+                escaped = false;
+                continue;
+            }
+
+            if (c == '\\')
+            {
+                escaped = true;
+                continue;
+            }
+
+            if (c == '"')
             {
                 inQuotes = !inQuotes;
             }
-            else if (valueStr[i] == '#' && !inQuotes)
+            else if (c == '#' && !inQuotes)
             {
                 return valueStr.Substring(0, i).TrimEnd();
             }
         }
+
         return valueStr;
     }
 
@@ -713,23 +845,36 @@ public class PatchFile
         StringBuilder sb = new StringBuilder();
 
         // Write header
-        string titleNameComment = !string.IsNullOrEmpty(Document.TitleNameComment)
-            ? $"    # {Document.TitleNameComment}"
-            : string.Empty;
-        sb.AppendLine($"title_name = \"{Document.TitleName}\"{titleNameComment}");
+        if (!string.IsNullOrEmpty(Document.TitleNameComment))
+        {
+            sb.AppendLine($"title_name = \"{Document.TitleName}\" # {Document.TitleNameComment}");
+        }
+        else
+        {
+            sb.AppendLine($"title_name = \"{Document.TitleName}\"");
+        }
 
-        string titleIdComment = !string.IsNullOrEmpty(Document.TitleIdComment)
-            ? $"    # {Document.TitleIdComment}"
-            : string.Empty;
-        sb.AppendLine($"title_id = \"{Document.TitleId.ToUpper()}\"{titleIdComment}");
+        if (!string.IsNullOrEmpty(Document.TitleIdComment))
+        {
+            sb.AppendLine($"title_id = \"{Document.TitleId.ToUpper()}\" # {Document.TitleIdComment}");
+        }
+        else
+        {
+            sb.AppendLine($"title_id = \"{Document.TitleId.ToUpper()}\"");
+        }
+        ;
 
         // Write hashes
         if (Document.Hashes.Count == 1)
         {
-            string hashComment = !string.IsNullOrEmpty(Document.HashComment)
-                ? $"    # {Document.HashComment}"
-                : string.Empty;
-            sb.AppendLine($"hash = \"{Document.Hashes[0].ToUpper()}\"{hashComment}");
+            if (!string.IsNullOrEmpty(Document.HashComment))
+            {
+                sb.AppendLine($"hash = \"{Document.Hashes[0].ToUpper()}\" # {Document.HashComment}");
+            }
+            else
+            {
+                sb.AppendLine($"hash = \"{Document.Hashes[0].ToUpper()}\"");
+            }
         }
         else
         {
@@ -747,20 +892,35 @@ public class PatchFile
             if (Document.MediaIds.Count == 1)
             {
                 MediaIdEntry entry = Document.MediaIds[0];
-                string comment = !string.IsNullOrEmpty(entry.Comment) ? entry.Comment : string.Empty;
-                sb.AppendLine($"#media_id = \"{entry.Id}\"    # {comment}");
+                if (!string.IsNullOrEmpty(entry.Comment))
+                {
+                    sb.AppendLine($"#media_id = \"{entry.Id}\" # {entry.Comment}");
+                }
+                else
+                {
+                    sb.AppendLine($"#media_id = \"{entry.Id}\"");
+                }
             }
             else
             {
                 sb.AppendLine("#media_id = [");
                 foreach (MediaIdEntry entry in Document.MediaIds)
                 {
-                    string commentSuffix = !string.IsNullOrEmpty(entry.Comment) ? $" # {entry.Comment}" : string.Empty;
-                    sb.AppendLine($"#    \"{entry.Id}\"{commentSuffix}");
+                    if (!string.IsNullOrEmpty(entry.Comment))
+                    {
+                        sb.AppendLine($"#    \"{entry.Id}\" # {entry.Comment}");
+                    }
+                    else
+                    {
+                        sb.AppendLine($"#    \"{entry.Id}\"");
+                    }
                 }
                 sb.AppendLine("#]");
             }
         }
+
+        // Empty line between header (and media_ids if present) and patches
+        sb.AppendLine();
 
         // Write patches
         foreach (PatchEntry patch in Document.Patches)
@@ -781,11 +941,36 @@ public class PatchFile
             foreach (PatchCommand command in patch.Commands)
             {
                 string typeString = GetPatchTypeString(command.Type);
-                sb.AppendLine($"    [[patch.{typeString}]]");
-                sb.AppendLine($"        address = 0x{command.Address:x}");
+                bool hasTypeComment = !string.IsNullOrWhiteSpace(command.TypeComment);
+                if (hasTypeComment)
+                {
+                    sb.AppendLine($"    [[patch.{typeString}]] # {command.TypeComment}");
+                }
+                else
+                {
+                    sb.AppendLine($"    [[patch.{typeString}]]");
+                }
+
+                bool hasAddressComment = !string.IsNullOrWhiteSpace(command.AddressComment);
+                if (hasAddressComment)
+                {
+                    sb.AppendLine($"        address = 0x{command.Address:x} # {command.AddressComment}");
+                }
+                else
+                {
+                    sb.AppendLine($"        address = 0x{command.Address:x}");
+                }
 
                 string valueStr = command.GetValueAsString() ?? "0x00";
-                sb.AppendLine($"        value = {valueStr}");
+                bool hasValueComment = !string.IsNullOrWhiteSpace(command.ValueComment);
+                if (hasValueComment)
+                {
+                    sb.AppendLine($"        value = {valueStr} # {command.ValueComment}");
+                }
+                else
+                {
+                    sb.AppendLine($"        value = {valueStr}");
+                }
             }
 
             sb.AppendLine();

--- a/source/XeniaManager.Core/Files/PatchFile.cs
+++ b/source/XeniaManager.Core/Files/PatchFile.cs
@@ -470,7 +470,7 @@ public class PatchFile
             return;
         }
 
-        uint address = Convert.ToUInt32(addressMatch.Groups[1].Value, 16);
+        ulong address = Convert.ToUInt64(addressMatch.Groups[1].Value, 16);
 
         if (lineIndex >= lines.Length - 1)
         {
@@ -503,7 +503,7 @@ public class PatchFile
         };
 
         patch.Commands.Add(cmd);
-        Logger.Debug<PatchFile>($"Parsed {commandType} command: address=0x{address:x8}, value={value}");
+        Logger.Debug<PatchFile>($"Parsed {commandType} command: address=0x{address:x}, value={value}");
     }
 
     /// <summary>
@@ -782,7 +782,7 @@ public class PatchFile
             {
                 string typeString = GetPatchTypeString(command.Type);
                 sb.AppendLine($"    [[patch.{typeString}]]");
-                sb.AppendLine($"        address = 0x{command.Address:x8}");
+                sb.AppendLine($"        address = 0x{command.Address:x}");
 
                 string valueStr = command.GetValueAsString() ?? "0x00";
                 sb.AppendLine($"        value = {valueStr}");

--- a/source/XeniaManager.Core/Files/PatchFile.cs
+++ b/source/XeniaManager.Core/Files/PatchFile.cs
@@ -217,17 +217,24 @@ public class PatchFile
 
             string lineToProcess = processedLine;
 
+            // Extract [[patch]] header comment from raw trimmed line BEFORE stripping
+            string? patchHeaderComment = null;
+            if (trimmedLine.StartsWith("[[patch]]", StringComparison.OrdinalIgnoreCase))
+            {
+                Match patchHeaderMatch = Regex.Match(trimmedLine, @"^\[\[patch\]\]\s*#\s*(.+)$", RegexOptions.IgnoreCase);
+                patchHeaderComment = patchHeaderMatch.Success ? patchHeaderMatch.Groups[1].Value.Trim() : null;
+            }
+
             if (lineToProcess.StartsWith("[[patch]]", StringComparison.OrdinalIgnoreCase))
             {
-                // Capture [[patch]] header comment if present
-                Match patchHeaderMatch = Regex.Match(lineToProcess, @"^\[\[patch\]\]\s*#\s*(.*)", RegexOptions.IgnoreCase);
-                string patchHeaderComment = patchHeaderMatch.Success ? patchHeaderMatch.Groups[1].Value.Trim() : string.Empty;
-
                 if (currentPatch != null && !string.IsNullOrEmpty(currentPatch.Name) && !string.IsNullOrEmpty(currentPatch.Author))
                 {
                     patchFile.Document.Patches.Add(currentPatch);
                 }
-                currentPatch = new PatchEntry();
+                currentPatch = new PatchEntry
+                {
+                    HeaderComment = patchHeaderComment
+                };
                 currentCommandType = null;
                 isInPatchSection = true;
                 continue;
@@ -333,50 +340,6 @@ public class PatchFile
         {
             patchFile.Document.TitleId = m.Groups[1].Value.ToUpper();
             patchFile.Document.TitleIdComment = comment ?? string.Empty;
-            Logger.Debug<PatchFile>($"Title ID: {patchFile.Document.TitleId}");
-        }
-    }
-
-    /// <summary>
-    /// Parses the title_name field from a line.
-    /// </summary>
-    private static void ParseTitleName(string line, PatchFile patchFile)
-    {
-        Match m = Regex.Match(line, @"^title_name\s*=\s*""([^""]+)""\s*#\s*(.*)");
-        if (m.Success)
-        {
-            patchFile.Document.TitleName = m.Groups[1].Value;
-            patchFile.Document.TitleNameComment = m.Groups[2].Value.Trim();
-            Logger.Debug<PatchFile>($"Title Name: {patchFile.Document.TitleName}");
-            return;
-        }
-
-        m = Regex.Match(line, @"^title_name\s*=\s*""([^""]*)""");
-        if (m.Success)
-        {
-            patchFile.Document.TitleName = m.Groups[1].Value;
-            Logger.Debug<PatchFile>($"Title Name: {patchFile.Document.TitleName}");
-        }
-    }
-
-    /// <summary>
-    /// Parses the title_id field from a line.
-    /// </summary>
-    private static void ParseTitleId(string line, PatchFile patchFile)
-    {
-        Match m = Regex.Match(line, @"^title_id\s*=\s*""([A-Fa-f0-9]+)""\s*#\s*(.*)");
-        if (m.Success)
-        {
-            patchFile.Document.TitleId = m.Groups[1].Value.ToUpper();
-            patchFile.Document.TitleIdComment = m.Groups[2].Value.Trim();
-            Logger.Debug<PatchFile>($"Title ID: {patchFile.Document.TitleId}");
-            return;
-        }
-
-        m = Regex.Match(line, @"^title_id\s*=\s*""([A-Fa-f0-9]+)""");
-        if (m.Success)
-        {
-            patchFile.Document.TitleId = m.Groups[1].Value.ToUpper();
             Logger.Debug<PatchFile>($"Title ID: {patchFile.Document.TitleId}");
         }
     }
@@ -733,7 +696,7 @@ public class PatchFile
     }
 
     /// <summary>
-    /// Parses an array value (hex string like "0x##*").
+    /// Parses an array value (hex string like "0x##*" or just "##*").
     /// </summary>
     private static byte[]? ParseArrayValue(string valueStr)
     {
@@ -743,13 +706,15 @@ public class PatchFile
             testStr = testStr.Substring(1, testStr.Length - 2);
         }
 
-        if (!testStr.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+        string hex;
+        if (testStr.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
         {
-            Logger.Warning<PatchFile>($"Array value must start with 0x: {valueStr}");
-            return null;
+            hex = testStr.Substring(2);
         }
-
-        string hex = testStr.Substring(2);
+        else
+        {
+            hex = testStr;
+        }
         if (hex.Length % 2 != 0)
         {
             Logger.Warning<PatchFile>($"Array hex length must be even: {hex}");
@@ -925,7 +890,14 @@ public class PatchFile
         // Write patches
         foreach (PatchEntry patch in Document.Patches)
         {
-            sb.AppendLine("[[patch]]");
+            if (!string.IsNullOrEmpty(patch.HeaderComment))
+            {
+                sb.AppendLine($"[[patch]] # {patch.HeaderComment}");
+            }
+            else
+            {
+                sb.AppendLine("[[patch]]");
+            }
             sb.AppendLine($"    name = \"{patch.Name}\"");
 
             if (!string.IsNullOrEmpty(patch.Description))

--- a/source/XeniaManager.Core/Files/PatchFile.cs
+++ b/source/XeniaManager.Core/Files/PatchFile.cs
@@ -562,25 +562,36 @@ public class PatchFile
         }
 
         string valueStr = valueMatch.Groups[1].Value.Trim().TrimEnd(',');
-        object? value = ParseValue(valueStr, commandType);
-        if (value == null)
-        {
-            Logger.Warning<PatchFile>($"Failed to parse value '{valueStr}' for type {commandType} at line {lineIndex + 2}");
-            return;
-        }
 
         PatchCommand cmd = new PatchCommand
         {
             Address = address,
-            Value = value,
             Type = ParsePatchType(commandType),
             TypeComment = typeComment,
             AddressComment = addressComment,
             ValueComment = valueComment
         };
 
+        if (commandType.ToLower() == "array")
+        {
+            (byte[]? bytes, bool usePrefix) = ParseArrayValue(valueStr);
+            cmd.Value = bytes;
+            cmd.UseArrayPrefix = usePrefix;
+            Logger.Debug<PatchFile>($"Array parsed: usePrefix={usePrefix}, bytes={bytes?.Length}");
+        }
+        else
+        {
+            cmd.Value = ParseValue(valueStr, commandType, cmd);
+        }
+
+        if (cmd.Value == null)
+        {
+            Logger.Warning<PatchFile>($"Failed to parse value '{valueStr}' for type {commandType} at line {lineIndex + 2}");
+            return;
+        }
+
         patch.Commands.Add(cmd);
-        Logger.Debug<PatchFile>($"Parsed {commandType} command: address=0x{address:x}, value={value}");
+        Logger.Debug<PatchFile>($"Parsed {commandType} command: address=0x{address:x}, value={cmd.Value}");
     }
 
     /// <summary>
@@ -624,7 +635,7 @@ public class PatchFile
     /// <summary>
     /// Parses a value string based on the patch type.
     /// </summary>
-    private static object? ParseValue(string valueStr, string patchType)
+    private static object? ParseValue(string valueStr, string patchType, PatchCommand? command)
     {
         valueStr = valueStr.Trim();
         string typeLower = patchType.ToLower();
@@ -688,7 +699,12 @@ public class PatchFile
         // Array type
         if (typeLower == "array")
         {
-            return ParseArrayValue(valueStr);
+            (byte[]? bytes, bool usePrefix) = ParseArrayValue(valueStr);
+            if (bytes != null && command != null)
+            {
+                command.UseArrayPrefix = usePrefix;
+            }
+            return bytes;
         }
 
         Logger.Warning<PatchFile>($"Unknown patch type: {typeLower}");
@@ -697,10 +713,14 @@ public class PatchFile
 
     /// <summary>
     /// Parses an array value (hex string like "0x##*" or just "##*").
+    /// Supports both "0x-prefixed" and "non-prefixed" formats per spec.
+    /// Returns the byte array and a flag indicating if "0x" prefix was used.
     /// </summary>
-    private static byte[]? ParseArrayValue(string valueStr)
+    private static (byte[]? Bytes, bool UsedPrefix) ParseArrayValue(string valueStr)
     {
         string testStr = valueStr;
+        bool usedPrefix = false;
+
         if (testStr.StartsWith("\"") && testStr.EndsWith("\""))
         {
             testStr = testStr.Substring(1, testStr.Length - 2);
@@ -710,15 +730,25 @@ public class PatchFile
         if (testStr.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
         {
             hex = testStr.Substring(2);
+            usedPrefix = true;
         }
         else
         {
             hex = testStr;
         }
+
+        hex = hex.Trim();
+
+        if (hex.Length == 0)
+        {
+            Logger.Warning<PatchFile>("Array hex value is empty");
+            return (Array.Empty<byte>(), usedPrefix);
+        }
+
         if (hex.Length % 2 != 0)
         {
             Logger.Warning<PatchFile>($"Array hex length must be even: {hex}");
-            return null;
+            return (null, usedPrefix);
         }
 
         int byteCount = hex.Length / 2;
@@ -729,11 +759,11 @@ public class PatchFile
             if (!byte.TryParse(hex.Substring(i * 2, 2), NumberStyles.HexNumber, null, out bytes[i]))
             {
                 Logger.Warning<PatchFile>($"Failed to parse array byte at position {i}: {hex.Substring(i * 2, 2)}");
-                return null;
+                return (null, usedPrefix);
             }
         }
 
-        return bytes;
+        return (bytes, usedPrefix);
     }
 
     /// <summary>

--- a/source/XeniaManager.Core/Models/Files/Patches/PatchCommand.cs
+++ b/source/XeniaManager.Core/Models/Files/Patches/PatchCommand.cs
@@ -9,10 +9,10 @@ namespace XeniaManager.Core.Models.Files.Patches;
 public class PatchCommand
 {
     /// <summary>
-    /// The memory address to patch (typically starts with 0x8, always 4 bytes).
+    /// The memory address to patch (typically starts with 0x8, can be up to 8 bytes).
     /// Stored as lowercase hex in TOML.
     /// </summary>
-    public uint Address { get; set; }
+    public ulong Address { get; set; }
 
     /// <summary>
     /// The value to write at the address.
@@ -41,7 +41,7 @@ public class PatchCommand
     /// <param name="address">The memory address to patch.</param>
     /// <param name="value">The value to write.</param>
     /// <param name="type">The type of patch.</param>
-    public PatchCommand(uint address, object? value, PatchType type)
+    public PatchCommand(ulong address, object? value, PatchType type)
     {
         Address = address;
         Value = value;

--- a/source/XeniaManager.Core/Models/Files/Patches/PatchCommand.cs
+++ b/source/XeniaManager.Core/Models/Files/Patches/PatchCommand.cs
@@ -29,6 +29,21 @@ public class PatchCommand
     public PatchType Type { get; set; }
 
     /// <summary>
+    /// Optional inline comment from the [[patch.type]] line.
+    /// </summary>
+    public string? TypeComment { get; set; }
+
+    /// <summary>
+    /// Optional inline comment from the address line.
+    /// </summary>
+    public string? AddressComment { get; set; }
+
+    /// <summary>
+    /// Optional inline comment from the value line.
+    /// </summary>
+    public string? ValueComment { get; set; }
+
+    /// <summary>
     /// Creates a new instance of PatchCommand.
     /// </summary>
     public PatchCommand()

--- a/source/XeniaManager.Core/Models/Files/Patches/PatchCommand.cs
+++ b/source/XeniaManager.Core/Models/Files/Patches/PatchCommand.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using XeniaManager.Core.Logging;
 
 namespace XeniaManager.Core.Models.Files.Patches;
 
@@ -44,6 +45,12 @@ public class PatchCommand
     public string? ValueComment { get; set; }
 
     /// <summary>
+    /// For Array type: tracks whether the original format used "0x" prefix.
+    /// null = default behavior (use 0x prefix), true = use prefix, false = no prefix.
+    /// </summary>
+    public bool? UseArrayPrefix { get; set; }
+
+    /// <summary>
     /// Creates a new instance of PatchCommand.
     /// </summary>
     public PatchCommand()
@@ -66,6 +73,7 @@ public class PatchCommand
     /// <summary>
     /// Converts the value to a string representation suitable for TOML output.
     /// Hex values are lowercase, strings are quoted. Floats use invariant culture.
+    /// Array values preserve the original format's "0x" prefix if present.
     /// </summary>
     /// <returns>The string representation of the value.</returns>
     public string? GetValueAsString()
@@ -76,12 +84,23 @@ public class PatchCommand
             ushort shortValue => $"0x{shortValue:x4}",
             uint uIntValue => $"0x{uIntValue:x8}",
             ulong longValue => $"0x{longValue:x16}",
-            byte[] byteArrayValue => $"\"0x{BitConverter.ToString(byteArrayValue).Replace("-", "").ToLower()}\"",
+            byte[] byteArrayValue => FormatArrayValue(byteArrayValue),
             float floatValue => floatValue.ToString(CultureInfo.InvariantCulture),
             double doubleValue => doubleValue.ToString(CultureInfo.InvariantCulture),
             string stringValue => $"\"{stringValue}\"",
             null => null,
             _ => Value.ToString()
         };
+    }
+
+    /// <summary>
+    /// Formats array value preserving original prefix format.
+    /// </summary>
+    private string FormatArrayValue(byte[] bytes)
+    {
+        string hex = BitConverter.ToString(bytes).Replace("-", "").ToLower();
+        bool usePrefix = UseArrayPrefix ?? true;
+        Logger.Debug<PatchCommand>($"FormatArrayValue: UseArrayPrefix={UseArrayPrefix}, usePrefix={usePrefix}");
+        return usePrefix ? $"\"0x{hex}\"" : $"\"{hex}\"";
     }
 }

--- a/source/XeniaManager.Core/Models/Files/Patches/PatchEntry.cs
+++ b/source/XeniaManager.Core/Models/Files/Patches/PatchEntry.cs
@@ -34,6 +34,11 @@ public class PatchEntry
     public List<PatchCommand> Commands { get; set; } = [];
 
     /// <summary>
+    /// Optional inline comment from the [[patch]] header line (e.g., [[patch]] # Netplay).
+    /// </summary>
+    public string? HeaderComment { get; set; }
+
+    /// <summary>
     /// Creates a new instance of PatchEntry.
     /// </summary>
     public PatchEntry()

--- a/source/XeniaManager/Controls/PatchConfigurationDialog.axaml
+++ b/source/XeniaManager/Controls/PatchConfigurationDialog.axaml
@@ -61,6 +61,11 @@
                                             <TextBlock Text="{Binding Author}"
                                                        FontSize="11"
                                                        Foreground="{DynamicResource TextFillColorSecondaryBrush}" />
+                                            <TextBlock Text="{Binding HeaderComment, StringFormat='#{0}'}"
+                                                       FontSize="10"
+                                                       FontStyle="Italic"
+                                                       Foreground="{DynamicResource TextFillColorTertiaryBrush}"
+                                                       IsVisible="{Binding HeaderComment, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
                                         </StackPanel>
                                         <Button x:Name="DeletePatchButton"
                                                 Grid.Column="2"
@@ -87,12 +92,16 @@
                                                  Watermark="{DynamicResource PatchConfigurationDialog.Author.Watermark}"
                                                  Margin="0,4,0,12"
                                                  IsEnabled="{Binding ParentViewModel.IsEditingEnabled}" />
-                                        <TextBox Text="{Binding Description}"
-                                                 Watermark="{DynamicResource PatchConfigurationDialog.Description.Watermark}"
-                                                 AcceptsReturn="True"
-                                                 TextWrapping="Wrap"
-                                                 Margin="0,4,0,12"
-                                                 IsEnabled="{Binding ParentViewModel.IsEditingEnabled}" />
+<TextBox Text="{Binding Description}"
+                                                  Watermark="{DynamicResource PatchConfigurationDialog.Description.Watermark}"
+                                                  AcceptsReturn="True"
+                                                  TextWrapping="Wrap"
+                                                  Margin="0,4,0,12"
+                                                  IsEnabled="{Binding ParentViewModel.IsEditingEnabled}" />
+                                        <TextBox Text="{Binding HeaderComment}"
+                                                  Watermark="{DynamicResource PatchConfigurationDialog.HeaderComment.Watermark}"
+                                                  Margin="0,4,0,12"
+                                                  IsEnabled="{Binding ParentViewModel.IsEditingEnabled}" />
 
                                         <!-- Commands -->
                                         <TextBlock Text="{DynamicResource PatchConfigurationDialog.PatchCommands}" Classes="sectionHeader" />
@@ -101,7 +110,7 @@
                                             <ItemsControl.ItemTemplate>
                                                 <DataTemplate>
                                                     <Border Classes="commandItem">
-                                                        <Grid ColumnDefinitions="Auto,Auto,Auto,*,Auto" RowDefinitions="Auto,Auto">
+                                                        <Grid ColumnDefinitions="Auto,Auto,Auto,*,Auto" RowDefinitions="Auto,Auto,Auto,Auto,Auto">
                                                             <TextBlock Grid.Row="0" Grid.Column="0"
                                                                        Text="{DynamicResource PatchConfigurationDialog.CommandType}"
                                                                        VerticalAlignment="Center"
@@ -124,15 +133,12 @@
                                                                 </ComboBox.Items>
                                                             </ComboBox>
 
-                                                            <TextBlock Grid.Row="0" Grid.Column="2"
-                                                                       Text="{DynamicResource PatchConfigurationDialog.CommandAddress}"
-                                                                       VerticalAlignment="Center"
-                                                                       Margin="0,0,8,0" />
-                                                            <TextBox Grid.Row="0" Grid.Column="3"
-                                                                     Text="{Binding Address, StringFormat='0x{0:X8}'}"
-                                                                     Watermark="{DynamicResource PatchConfigurationDialog.CommandAddress.Watermark}"
-                                                                     Margin="0,0,16,0"
-                                                                     IsEnabled="{Binding ParentViewModel.IsEditingEnabled}" />
+                                                            <TextBox Grid.Row="0" Grid.Column="2" Grid.ColumnSpan="2"
+                                                                     Text="{Binding TypeComment}"
+                                                                     Watermark="{DynamicResource PatchConfigurationDialog.TypeComment.Watermark}"
+                                                                     Margin="0,0,8,0"
+                                                                     IsEnabled="{Binding ParentViewModel.IsEditingEnabled}"
+                                                                     VerticalAlignment="Center" />
 
                                                             <Button x:Name="DeleteCommandButton"
                                                                     Grid.Row="0" Grid.Column="4"
@@ -148,10 +154,32 @@
                                                             </Button>
 
                                                             <TextBlock Grid.Row="1" Grid.Column="0"
-                                                                       Text="{DynamicResource PatchConfigurationDialog.CommandValue}"
+                                                                       Text="{DynamicResource PatchConfigurationDialog.CommandAddress}"
                                                                        VerticalAlignment="Center"
                                                                        Margin="0,8,8,0" />
                                                             <TextBox Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="3"
+                                                                     Text="{Binding Address, StringFormat='0x{0:X8}'}"
+                                                                     Watermark="{DynamicResource PatchConfigurationDialog.CommandAddress.Watermark}"
+                                                                     Margin="0,8,0,0"
+                                                                     IsEnabled="{Binding ParentViewModel.IsEditingEnabled}" />
+
+                                                            <TextBlock Grid.Row="2" Grid.Column="0"
+                                                                       Text="{DynamicResource PatchConfigurationDialog.AddressComment}"
+                                                                       VerticalAlignment="Center"
+                                                                       Margin="0,4,8,0"
+                                                                       Foreground="{DynamicResource TextFillColorSecondaryBrush}" />
+                                                            <TextBox Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="3"
+                                                                     Text="{Binding AddressComment}"
+                                                                     Watermark="{DynamicResource PatchConfigurationDialog.Comment.Watermark}"
+                                                                     Margin="0,4,0,0"
+                                                                     IsEnabled="{Binding ParentViewModel.IsEditingEnabled}"
+                                                                     FontSize="11" />
+
+                                                            <TextBlock Grid.Row="3" Grid.Column="0"
+                                                                       Text="{DynamicResource PatchConfigurationDialog.CommandValue}"
+                                                                       VerticalAlignment="Center"
+                                                                       Margin="0,8,8,0" />
+                                                            <TextBox Grid.Row="3" Grid.Column="1" Grid.ColumnSpan="3"
                                                                      Text="{Binding Value}"
                                                                      Watermark="{DynamicResource PatchConfigurationDialog.CommandValue}"
                                                                      Margin="0,8,0,0"
@@ -169,6 +197,18 @@
                                                                     </ToolTip>
                                                                 </ToolTip.Tip>
                                                             </TextBox>
+
+                                                            <TextBlock Grid.Row="4" Grid.Column="0"
+                                                                       Text="{DynamicResource PatchConfigurationDialog.ValueComment}"
+                                                                       VerticalAlignment="Center"
+                                                                       Margin="0,4,8,0"
+                                                                       Foreground="{DynamicResource TextFillColorSecondaryBrush}" />
+                                                            <TextBox Grid.Row="4" Grid.Column="1" Grid.ColumnSpan="3"
+                                                                     Text="{Binding ValueComment}"
+                                                                     Watermark="{DynamicResource PatchConfigurationDialog.Comment.Watermark}"
+                                                                     Margin="0,4,0,0"
+                                                                     IsEnabled="{Binding ParentViewModel.IsEditingEnabled}"
+                                                                     FontSize="11" />
                                                         </Grid>
                                                     </Border>
                                                 </DataTemplate>

--- a/source/XeniaManager/Resources/Language/en.axaml
+++ b/source/XeniaManager/Resources/Language/en.axaml
@@ -443,8 +443,13 @@
     <sys:String x:Key="PatchConfigurationDialog.PatchName.Watermark">Patch Name</sys:String>
     <sys:String x:Key="PatchConfigurationDialog.Author.Watermark">Author</sys:String>
     <sys:String x:Key="PatchConfigurationDialog.Description.Watermark">Description (optional)</sys:String>
+    <sys:String x:Key="PatchConfigurationDialog.HeaderComment.Watermark">Header Comment (optional)</sys:String>
     <sys:String x:Key="PatchConfigurationDialog.PatchCommands">Patch Commands</sys:String>
     <sys:String x:Key="PatchConfigurationDialog.CommandType">Type:</sys:String>
+    <sys:String x:Key="PatchConfigurationDialog.TypeComment.Watermark">Type comment</sys:String>
+    <sys:String x:Key="PatchConfigurationDialog.AddressComment">Comment:</sys:String>
+    <sys:String x:Key="PatchConfigurationDialog.ValueComment">Comment:</sys:String>
+    <sys:String x:Key="PatchConfigurationDialog.Comment.Watermark">Comment (optional)</sys:String>
     <sys:String x:Key="PatchConfigurationDialog.CommandAddress">Address:</sys:String>
     <sys:String x:Key="PatchConfigurationDialog.CommandValue">Value:</sys:String>
     <sys:String x:Key="PatchConfigurationDialog.CommandAddress.Watermark">0x00000000</sys:String>

--- a/source/XeniaManager/Resources/Language/hr.axaml
+++ b/source/XeniaManager/Resources/Language/hr.axaml
@@ -443,8 +443,13 @@
     <sys:String x:Key="PatchConfigurationDialog.PatchName.Watermark">Naziv zakrpe</sys:String>
     <sys:String x:Key="PatchConfigurationDialog.Author.Watermark">Autor</sys:String>
     <sys:String x:Key="PatchConfigurationDialog.Description.Watermark">Opis (neobavezno)</sys:String>
+    <sys:String x:Key="PatchConfigurationDialog.HeaderComment.Watermark">Koment zaglavlja (neobavezno)</sys:String>
     <sys:String x:Key="PatchConfigurationDialog.PatchCommands">Naredbe zakrpe</sys:String>
     <sys:String x:Key="PatchConfigurationDialog.CommandType">Tip:</sys:String>
+    <sys:String x:Key="PatchConfigurationDialog.TypeComment.Watermark">Koment tipa</sys:String>
+    <sys:String x:Key="PatchConfigurationDialog.AddressComment">Koment:</sys:String>
+    <sys:String x:Key="PatchConfigurationDialog.ValueComment">Koment:</sys:String>
+    <sys:String x:Key="PatchConfigurationDialog.Comment.Watermark">Koment (neobavezno)</sys:String>
     <sys:String x:Key="PatchConfigurationDialog.CommandAddress">Adresa:</sys:String>
     <sys:String x:Key="PatchConfigurationDialog.CommandValue">Vrijednost:</sys:String>
     <sys:String x:Key="PatchConfigurationDialog.CommandAddress.Watermark">0x00000000</sys:String>

--- a/source/XeniaManager/ViewModels/Controls/PatchConfigurationViewModel.cs
+++ b/source/XeniaManager/ViewModels/Controls/PatchConfigurationViewModel.cs
@@ -30,6 +30,7 @@ public partial class PatchCommandViewModel : ObservableObject
     [ObservableProperty] private string? _typeComment;
     [ObservableProperty] private string? _addressComment;
     [ObservableProperty] private string? _valueComment;
+    [ObservableProperty] private bool? _useArrayPrefix;
 
     public PatchCommandViewModel()
     {
@@ -43,6 +44,7 @@ public partial class PatchCommandViewModel : ObservableObject
         _typeComment = command.TypeComment;
         _addressComment = command.AddressComment;
         _valueComment = command.ValueComment;
+        _useArrayPrefix = command.UseArrayPrefix;
 
         string? rawValue = command.GetValueAsString();
 
@@ -145,35 +147,95 @@ public partial class PatchCommandViewModel : ObservableObject
     }
 
     /// <summary>
-    /// Validates an array value (hex string of any size).
+    /// Parses an array value string to byte array.
+    /// Supports: "0x0102030405", "0102030405", "0x01 0x02 0x03", "01 02 03 04 05"
     /// </summary>
-    /// <param name="value">The array value to validate (e.g., "0x01 0x02 0x03").</param>
+    private static byte[] ParseArrayString(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return Array.Empty<byte>();
+        }
+
+        string input = value.Trim();
+
+        if (input.StartsWith("\"") && input.EndsWith("\""))
+        {
+            input = input.Substring(1, input.Length - 2);
+        }
+
+        bool hasPrefix = input.StartsWith("0x", StringComparison.OrdinalIgnoreCase);
+        string hex = hasPrefix ? input.Substring(2) : input;
+        hex = hex.Replace(" ", "");
+
+        if (hex.Length == 0)
+        {
+            return Array.Empty<byte>();
+        }
+
+        if (hex.Length % 2 != 0)
+        {
+            Logger.Warning<PatchConfigurationViewModel>($"Array hex length must be even: {hex}");
+            return Array.Empty<byte>();
+        }
+
+        int byteCount = hex.Length / 2;
+        byte[] bytes = new byte[byteCount];
+
+        for (int i = 0; i < byteCount; i++)
+        {
+            if (!byte.TryParse(hex.Substring(i * 2, 2), NumberStyles.HexNumber, null, out bytes[i]))
+            {
+                Logger.Warning<PatchConfigurationViewModel>($"Failed to parse array byte: {hex.Substring(i * 2, 2)}");
+                return Array.Empty<byte>();
+            }
+        }
+
+        return bytes;
+    }
+
+    /// <summary>
+    /// Validates an array value (hex string of any size).
+    /// Supports: "0x-prefixed continuous", "non-prefixed continuous"
+    /// </summary>
+    /// <param name="value">The array value to validate (e.g., "0x0102030405" or "0102030405").</param>
     /// <returns>A tuple containing (isValid, errorMessage).</returns>
     private static (bool IsValid, string ErrorMessage) ValidateArray(string value)
     {
         string arrayValue = value.Trim();
 
-        // Array can be specified as "0x##*" format or space-separated hex bytes
+        if (arrayValue.StartsWith("\"") && arrayValue.EndsWith("\""))
+        {
+            arrayValue = arrayValue.Substring(1, arrayValue.Length - 2);
+        }
+
         if (arrayValue.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
         {
             string hexPart = arrayValue.Substring(2);
-            // Allow space-separated hex bytes or continuous hex string
             string cleanedHex = hexPart.Replace(" ", "");
             if (!Regex.IsMatch(cleanedHex, "^[0-9A-Fa-f]*$"))
             {
-                return (false, "Invalid array format. Use space-separated hex bytes (e.g., 0x01 0x02 0x03)");
+                return (false, "Invalid array format. Use hex bytes (e.g., 0x0102030405)");
+            }
+            if (cleanedHex.Length % 2 != 0)
+            {
+                return (false, "Array hex must have even number of characters");
             }
         }
         else
         {
-            // Space-separated hex bytes without 0x prefix
-            string[] bytes = arrayValue.Split(' ', StringSplitOptions.RemoveEmptyEntries);
-            foreach (string byteStr in bytes)
+            string cleanedHex = arrayValue.Replace(" ", "");
+            if (cleanedHex.Length == 0)
             {
-                if (!Regex.IsMatch(byteStr, "^[0-9A-Fa-f]{1,2}$"))
-                {
-                    return (false, $"Invalid byte value in array: {byteStr}");
-                }
+                return (true, string.Empty);
+            }
+            if (!Regex.IsMatch(cleanedHex, "^[0-9A-Fa-f]+$"))
+            {
+                return (false, "Invalid array format. Use hex bytes (e.g., 0102030405)");
+            }
+            if (cleanedHex.Length % 2 != 0)
+            {
+                return (false, "Array hex must have even number of characters");
             }
         }
 
@@ -225,7 +287,8 @@ public partial class PatchCommandViewModel : ObservableObject
             Value = ParseValue(Value, Type),
             TypeComment = TypeComment,
             AddressComment = AddressComment,
-            ValueComment = ValueComment
+            ValueComment = ValueComment,
+            UseArrayPrefix = UseArrayPrefix
         };
     }
 
@@ -247,7 +310,7 @@ public partial class PatchCommandViewModel : ObservableObject
                 PatchType.F32 => float.Parse(value, CultureInfo.InvariantCulture),
                 PatchType.F64 => double.Parse(value, CultureInfo.InvariantCulture),
                 PatchType.String or PatchType.U16String => value,
-                PatchType.Array => value,
+                PatchType.Array => ParseArrayString(value),
                 _ => value
             };
         }

--- a/source/XeniaManager/ViewModels/Controls/PatchConfigurationViewModel.cs
+++ b/source/XeniaManager/ViewModels/Controls/PatchConfigurationViewModel.cs
@@ -268,6 +268,7 @@ public partial class PatchEntryViewModel : ObservableObject
     [ObservableProperty] private string? _description;
     [ObservableProperty] private bool _isEnabled;
     [ObservableProperty] private bool _isExpanded;
+    [ObservableProperty] private string? _headerComment;
     [ObservableProperty] private ObservableCollection<PatchCommandViewModel> _commands = [];
     [ObservableProperty] private PatchEntry _originalEntry;
     [ObservableProperty] private PatchConfigurationViewModel? _parentViewModel;
@@ -280,6 +281,7 @@ public partial class PatchEntryViewModel : ObservableObject
         Author = entry.Author;
         Description = entry.Description;
         IsEnabled = entry.IsEnabled;
+        HeaderComment = entry.HeaderComment;
 
         foreach (PatchCommand command in entry.Commands)
         {
@@ -294,7 +296,8 @@ public partial class PatchEntryViewModel : ObservableObject
             Name = Name,
             Author = Author,
             Description = Description,
-            IsEnabled = IsEnabled
+            IsEnabled = IsEnabled,
+            HeaderComment = HeaderComment
         };
 
         foreach (PatchCommandViewModel commandVm in Commands)

--- a/source/XeniaManager/ViewModels/Controls/PatchConfigurationViewModel.cs
+++ b/source/XeniaManager/ViewModels/Controls/PatchConfigurationViewModel.cs
@@ -48,8 +48,8 @@ public partial class PatchCommandViewModel : ObservableObject
 
         string? rawValue = command.GetValueAsString();
 
-        // Strip quotes from string values for display in the textbox
-        if (Type is PatchType.String or PatchType.U16String && rawValue != null)
+        // Strip quotes from string/array values for display in the textbox
+        if (Type is PatchType.String or PatchType.U16String or PatchType.Array && rawValue != null)
         {
             string trimmed = rawValue.Trim();
             if ((trimmed.StartsWith("\"") && trimmed.EndsWith("\"")) ||

--- a/source/XeniaManager/ViewModels/Controls/PatchConfigurationViewModel.cs
+++ b/source/XeniaManager/ViewModels/Controls/PatchConfigurationViewModel.cs
@@ -21,7 +21,7 @@ namespace XeniaManager.ViewModels.Controls;
 public partial class PatchCommandViewModel : ObservableObject
 {
     [ObservableProperty] private PatchType _type;
-    [ObservableProperty] private uint _address;
+    [ObservableProperty] private ulong _address;
     [ObservableProperty] private string _value = string.Empty;
     [ObservableProperty] private bool _isSelected;
     [ObservableProperty] private bool _isValid = true;

--- a/source/XeniaManager/ViewModels/Controls/PatchConfigurationViewModel.cs
+++ b/source/XeniaManager/ViewModels/Controls/PatchConfigurationViewModel.cs
@@ -27,6 +27,9 @@ public partial class PatchCommandViewModel : ObservableObject
     [ObservableProperty] private bool _isValid = true;
     [ObservableProperty] private string _validationError = string.Empty;
     [ObservableProperty] private PatchConfigurationViewModel? _parentViewModel;
+    [ObservableProperty] private string? _typeComment;
+    [ObservableProperty] private string? _addressComment;
+    [ObservableProperty] private string? _valueComment;
 
     public PatchCommandViewModel()
     {
@@ -37,6 +40,10 @@ public partial class PatchCommandViewModel : ObservableObject
         _parentViewModel = parentViewModel;
         Type = command.Type;
         Address = command.Address;
+        _typeComment = command.TypeComment;
+        _addressComment = command.AddressComment;
+        _valueComment = command.ValueComment;
+
         string? rawValue = command.GetValueAsString();
 
         // Strip quotes from string values for display in the textbox
@@ -215,7 +222,10 @@ public partial class PatchCommandViewModel : ObservableObject
         {
             Type = Type,
             Address = Address,
-            Value = ParseValue(Value, Type)
+            Value = ParseValue(Value, Type),
+            TypeComment = TypeComment,
+            AddressComment = AddressComment,
+            ValueComment = ValueComment
         };
     }
 


### PR DESCRIPTION
- Fixed parsing inline comments in patch commands
- Fixed field order (now it's `name`, `desc`, `author`)
- Comments are now saved
- Added viewing/editing of comments in the file