### PR TITLE
fix(ui): Correct grammar in Steam Shortcut tooltip

### DIFF
--- a/source/XeniaManager/Resources/Language/en.axaml
+++ b/source/XeniaManager/Resources/Language/en.axaml
@@ -409,7 +409,7 @@
     <sys:String x:Key="GameButton.ContextFlyout.CreateShortcut.Desktop.Header">Desktop</sys:String>
     <sys:String x:Key="GameButton.ContextFlyout.CreateShortcut.Desktop.ToolTip">Creates a shortcut of the game on desktop</sys:String>
     <sys:String x:Key="GameButton.ContextFlyout.CreateShortcut.Steam.Header">Steam</sys:String>
-    <sys:String x:Key="GameButton.ContextFlyout.CreateShortcut.Steam.ToolTip">Adds a shortcut on Steam&#10;NOTE: This will create a shortcut for the last that logged in on Steam on the PC</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.CreateShortcut.Steam.ToolTip">Adds a shortcut to Steam&#10;NOTE: This will create a shortcut for the last user who logged in to Steam on this PC</sys:String>
     <sys:String x:Key="GameButton.ContextFlyout.Shortcut.Desktop.Success.Title">Shortcut Created</sys:String>
     <sys:String x:Key="GameButton.ContextFlyout.Shortcut.Desktop.Success.Message">Successfully created a desktop shortcut for {0}.</sys:String>
     <sys:String x:Key="GameButton.ContextFlyout.Shortcut.Desktop.Error.Title">Failed to Create Shortcut</sys:String>


### PR DESCRIPTION
- Fixed a grammatical error in the Steam shortcut tooltip on the Library page.
- Updated `source/XeniaManager/Resources/Language/en.axaml`
- Corrected the tooltip text from:
  > "Adds a shortcut on Steam. NOTE: This will create a shortcut for the last that logged in on Steam on the PC"
  
  to:
  
  > "Adds a shortcut to Steam. NOTE: This will create a shortcut for the last user who logged in to Steam on this PC"
