### PR TITLE
feat(library): Multi-disc game support

### DIFF
--- a/source/XeniaManager.Core/Constants/ArgumentFlags.cs
+++ b/source/XeniaManager.Core/Constants/ArgumentFlags.cs
@@ -24,4 +24,10 @@ public static class ArgumentFlags
     /// Supports "--xenia_args" and short alias "-x".
     /// </summary>
     public static readonly string[] XeniaArgs = ["--xenia_args"];
+
+    /// <summary>
+    /// Flag(s) to explicitly specify which disc of a multi-disc game to launch (1-based).
+    /// Supports "--disc" and short alias "-d". When omitted, the disc selection dialog is shown.
+    /// </summary>
+    public static readonly string[] Disc = ["--disc", "-d"];
 }

--- a/source/XeniaManager.Core/Converters/DiscCountConverter.cs
+++ b/source/XeniaManager.Core/Converters/DiscCountConverter.cs
@@ -1,0 +1,29 @@
+using System.Globalization;
+using Avalonia.Data.Converters;
+using XeniaManager.Core.Utilities;
+
+namespace XeniaManager.Core.Converters;
+
+/// <summary>
+/// Converts a disc count (int) to a localized "N Discs" label, shown on the
+/// library card tooltip for multi-disc games.
+/// </summary>
+public class DiscCountConverter : IValueConverter
+{
+    public static readonly DiscCountConverter Instance = new DiscCountConverter();
+
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is int discCount)
+        {
+            return string.Format(LocalizationHelper.GetText("LibraryPage.GameButton.DiscCount"), discCount);
+        }
+
+        return string.Empty;
+    }
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/source/XeniaManager.Core/Manage/GameManager.cs
+++ b/source/XeniaManager.Core/Manage/GameManager.cs
@@ -571,12 +571,29 @@ public class GameManager
     /// <param name="useMediaIdForTitle">Whether to use MediaId to find a matching media entry title.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
     /// <exception cref="Exception">Thrown when game information cannot be fetched from the database.</exception>
-    public static async Task AddGame(XeniaVersion xeniaVersion, GameInfo selectedGame, string gamePath, ParsedGameDetails details, bool useMediaIdForTitle = false)
+    public static async Task AddGame(XeniaVersion xeniaVersion, GameInfo selectedGame, string gamePath, ParsedGameDetails details, bool useMediaIdForTitle = false, Func<Game, Task<bool>>? confirmMultiDiscMerge = null)
     {
         // Use GameInfo's Id if titleId is "00000000"
         string actualTitleId = details.TitleId == "00000000" ? selectedGame.Id ?? details.TitleId : details.TitleId;
 
         Logger.Trace<GameManager>($"Starting AddGame operation - TitleId: {actualTitleId}, MediaId: {details.MediaId}, XeniaVersion: {xeniaVersion}, GamePath: {gamePath}");
+
+        // Check whether this file is likely another disc of a game already in the library
+        // (same Title ID). If the caller supplied a confirmation callback and the user agrees,
+        // attach it as an additional disc instead of creating a separate library entry.
+        Game? multiDiscMatch = FindPotentialMultiDiscMatch(actualTitleId, gamePath);
+        if (multiDiscMatch != null && confirmMultiDiscMerge != null)
+        {
+            bool shouldMerge = await confirmMultiDiscMerge(multiDiscMatch);
+            if (shouldMerge)
+            {
+                AddDiscToExistingGame(multiDiscMatch, gamePath);
+                Logger.Info<GameManager>($"'{gamePath}' merged into existing game '{multiDiscMatch.Title}' as an additional disc, skipping separate library entry");
+                return;
+            }
+
+            Logger.Info<GameManager>($"User declined multi-disc merge for '{gamePath}', adding as a separate library entry");
+        }
 
         // Grab full game information
         Logger.Info<GameManager>($"Fetching detailed game information from Xbox database for TitleId: {actualTitleId}");
@@ -858,13 +875,74 @@ public class GameManager
         bool isDuplicate = Games.Any(game => string.Equals(
             game.FileLocations.ResolvedGamePath,
             resolvedPath,
-            StringComparison.OrdinalIgnoreCase));
-
+            StringComparison.OrdinalIgnoreCase))
+            || Games.Any(game => game.FileLocations.AdditionalDiscs.Any(d => string.Equals(
+                d.Path,
+                resolvedPath,
+                StringComparison.OrdinalIgnoreCase)));
         if (isDuplicate)
         {
             Logger.Debug<GameManager>($"Duplicate game detected for path: {gamePath}");
         }
         return isDuplicate;
+    }
+
+    /// <summary>
+    /// Looks for an existing game in the library that shares the same GameId (Title ID) as the
+    /// one being added, but doesn't already reference the given file path. Used to detect that a
+    /// newly added/discovered file is likely another disc of a game already in the library
+    /// (e.g. Disc 2 of a multi-disc game like Blue Dragon).
+    /// </summary>
+    /// <param name="gameId">The Title ID of the game being added.</param>
+    /// <param name="gamePath">The file path of the game being added.</param>
+    /// <returns>The matching existing <see cref="Game"/>, or null if no candidate was found.</returns>
+    public static Game? FindPotentialMultiDiscMatch(string gameId, string gamePath)
+    {
+        if (string.IsNullOrEmpty(gameId) || gameId == "00000000")
+        {
+            return null;
+        }
+
+        Game? match = Games.FirstOrDefault(game =>
+            game.GameId == gameId
+            && game.FileLocations.Game != gamePath
+            && game.FileLocations.AdditionalDiscs.All(d => d.Path != gamePath));
+
+        if (match != null)
+        {
+            Logger.Info<GameManager>($"Potential multi-disc match found: '{match.Title}' (GameId: {gameId}) for new file '{gamePath}'");
+        }
+
+        return match;
+    }
+
+    /// <summary>
+    /// Adds a game file as an additional disc of an existing game already in the library,
+    /// instead of creating a brand-new library entry for it.
+    /// </summary>
+    /// <param name="existingGame">The game already in the library to attach the new disc to.</param>
+    /// <param name="gamePath">The file path of the new disc.</param>
+    /// <param name="label">Optional custom label for the disc (e.g. "Disco 2"). Auto-generated when null.</param>
+    /// <returns>The disc number (1-based) that was assigned to the new disc.</returns>
+    public static int AddDiscToExistingGame(Game existingGame, string gamePath, string? label = null)
+    {
+        int newDiscNumber = existingGame.FileLocations.DiscCount + 1;
+
+        Logger.Info<GameManager>($"Adding '{gamePath}' as Disc {newDiscNumber} of '{existingGame.Title}'");
+
+        existingGame.FileLocations.AdditionalDiscs.Add(new GameDisc
+        {
+            DiscNumber = newDiscNumber,
+            Path = gamePath,
+            Label = label
+        });
+
+        SaveLibrary();
+        EventManager.Instance.OnGameLibraryChanged();
+
+        Logger.Info<GameManager>($"'{existingGame.Title}' now has {existingGame.FileLocations.DiscCount} discs");
+
+        return newDiscNumber;
     }
 
     /// <summary>

--- a/source/XeniaManager.Core/Manage/GameManager.cs
+++ b/source/XeniaManager.Core/Manage/GameManager.cs
@@ -102,6 +102,20 @@ public class GameManager
                         migrated = true;
                     }
                 }
+
+                foreach (GameDisc disc in game.FileLocations.AdditionalDiscs)
+                {
+                    if (!string.IsNullOrEmpty(disc.Path) && Path.IsPathRooted(disc.Path))
+                    {
+                        string relativeDiscPath = GetRelativeGamePath(disc.Path);
+                        if (relativeDiscPath != disc.Path)
+                        {
+                            Logger.Debug<GameManager>($"Migrating additional disc path for '{game.Title}' (Disc {disc.DiscNumber}): '{disc.Path}' -> '{relativeDiscPath}'");
+                            disc.Path = relativeDiscPath;
+                            migrated = true;
+                        }
+                    }
+                }
             }
 
             // Migrate empty Config fields for games added in older versions
@@ -877,7 +891,7 @@ public class GameManager
             resolvedPath,
             StringComparison.OrdinalIgnoreCase))
             || Games.Any(game => game.FileLocations.AdditionalDiscs.Any(d => string.Equals(
-                d.Path,
+                d.ResolvedPath,
                 resolvedPath,
                 StringComparison.OrdinalIgnoreCase)));
         if (isDuplicate)
@@ -903,10 +917,14 @@ public class GameManager
             return null;
         }
 
+        string resolvedPath = Path.IsPathRooted(gamePath)
+            ? gamePath
+            : Path.Combine(AppPaths.GamesDirectory, gamePath);
+
         Game? match = Games.FirstOrDefault(game =>
             game.GameId == gameId
-            && game.FileLocations.Game != gamePath
-            && game.FileLocations.AdditionalDiscs.All(d => d.Path != gamePath));
+            && game.FileLocations.ResolvedGamePath != resolvedPath
+            && game.FileLocations.AdditionalDiscs.All(d => d.ResolvedPath != resolvedPath));
 
         if (match != null)
         {
@@ -933,7 +951,7 @@ public class GameManager
         existingGame.FileLocations.AdditionalDiscs.Add(new GameDisc
         {
             DiscNumber = newDiscNumber,
-            Path = gamePath,
+            Path = Path.IsPathRooted(gamePath) ? GetRelativeGamePath(gamePath) : gamePath,
             Label = label
         });
 

--- a/source/XeniaManager.Core/Manage/Launcher.cs
+++ b/source/XeniaManager.Core/Manage/Launcher.cs
@@ -156,10 +156,11 @@ public class Launcher
     /// <param name="outputHandler">Optional output handler to capture Xenia output</param>
     /// <param name="onGameLoadingStarted">Optional callback when game loading starts</param>
     /// <param name="configOverridesFromArgs">Optional config string when game loading starts</param>
+    /// <param name="discNumber">Which disc to launch (1-based). Defaults to Disc 1.</param>
     /// <returns>A task representing the asynchronous operation</returns>
-    public static async Task LaunchGameASync(Game game, Settings.Settings settings, XeniaOutputHandler? outputHandler = null, Action? onGameLoadingStarted = null, string? configOverridesFromArgs = null)
+    public static async Task LaunchGameASync(Game game, Settings.Settings settings, XeniaOutputHandler? outputHandler = null, Action? onGameLoadingStarted = null, string? configOverridesFromArgs = null, int discNumber = 1)
     {
-        await LaunchGameCoreAsync(game, async: true, settings, outputHandler, onGameLoadingStarted, configOverridesFromArgs);
+        await LaunchGameCoreAsync(game, async: true, settings, outputHandler, onGameLoadingStarted, configOverridesFromArgs, discNumber);
     }
 
     /// <summary>
@@ -177,9 +178,10 @@ public class Launcher
     /// <param name="settings">The settings object containing emulator configuration</param>
     /// <param name="outputHandler">Optional output handler to capture Xenia output</param>
     /// <param name="onGameLoadingStarted">Optional callback when game loading starts</param>
-    public static void LaunchGame(Game game, Settings.Settings settings, XeniaOutputHandler? outputHandler = null, Action? onGameLoadingStarted = null)
+    /// <param name="discNumber">Which disc to launch (1-based). Defaults to Disc 1.</param>
+    public static void LaunchGame(Game game, Settings.Settings settings, XeniaOutputHandler? outputHandler = null, Action? onGameLoadingStarted = null, int discNumber = 1)
     {
-        LaunchGameCoreAsync(game, async: false, settings, outputHandler, onGameLoadingStarted).GetAwaiter().GetResult();
+        LaunchGameCoreAsync(game, async: false, settings, outputHandler, onGameLoadingStarted, discNumber: discNumber).GetAwaiter().GetResult();
     }
 
     /// <summary>
@@ -191,8 +193,9 @@ public class Launcher
     /// <param name="outputHandler">Optional output handler to capture Xenia output</param>
     /// <param name="onGameLoadingStarted">Optional callback when game loading starts</param>
     /// <param name="configOverridesFromArgs">Optional config string when game loading starts</param>
+    /// <param name="discNumber">Which disc to launch (1-based). Defaults to Disc 1.</param>
     /// <returns>A task representing the asynchronous operation</returns>
-    private static async Task LaunchGameCoreAsync(Game game, bool async, Settings.Settings settings, XeniaOutputHandler? outputHandler = null, Action? onGameLoadingStarted = null, string? configOverridesFromArgs = null)
+    private static async Task LaunchGameCoreAsync(Game game, bool async, Settings.Settings settings, XeniaOutputHandler? outputHandler = null, Action? onGameLoadingStarted = null, string? configOverridesFromArgs = null, int discNumber = 1)
     {
         if (XeniaUpdating)
         {
@@ -200,13 +203,25 @@ public class Launcher
             throw new Exception("Xenia is updating, please wait for it to finish updating before launching the emulator");
         }
 
-        if (!game.FileLocations.IsGamePathValid)
+        // Resolve which disc's file path to launch. Falls back to Disc 1 if the
+        // requested disc number doesn't exist (e.g. stale LastPlayedDisc value).
+        string? discPath = game.FileLocations.GetDiscPath(discNumber);
+        if (string.IsNullOrEmpty(discPath) || !File.Exists(discPath))
         {
-            Logger.Error<Launcher>($"Invalid game path: {game.FileLocations.ResolvedGamePath}");
-            throw new Exception($"Invalid game path: {game.FileLocations.ResolvedGamePath}");
+            discNumber = 1;
+            discPath = game.FileLocations.Game;
         }
 
-        Logger.Info<Launcher>($"Launching game: {game.Title} using Xenia version: {game.XeniaVersion}");
+        if (string.IsNullOrEmpty(discPath) || !File.Exists(discPath))
+        {
+            Logger.Error<Launcher>($"Invalid game path: {discPath}");
+            throw new Exception($"Invalid game path: {discPath}");
+        }
+
+        Logger.Info<Launcher>($"Launching game: {game.Title} (Disc {discNumber}/{game.FileLocations.DiscCount}) using Xenia version: {game.XeniaVersion}");
+
+        // Remember which disc was launched so the disc-selection popup can default to it next time
+        game.LastPlayedDisc = discNumber;
 
         // Load settings to check automatic save backup configuration
         bool automaticSaveBackup = settings.Settings.Emulator.Settings.Profile.AutomaticSaveBackup;
@@ -247,13 +262,13 @@ public class Launcher
 
         if (configOverridesFromArgs == null || configOverridesFromArgs.Length == 0)
         {
-            // Set the game file path as a command-line argument
-            xenia.StartInfo.Arguments = $@"""{game.FileLocations.ResolvedGamePath}""";
+            // Set the selected disc's file path as a command-line argument
+            xenia.StartInfo.Arguments = $@"""{discPath}""";
         }
         else
         {
-            // Set the game file path as a command-line argument
-            xenia.StartInfo.Arguments = $@"""{game.FileLocations.ResolvedGamePath}"" {configOverridesFromArgs}";
+            // Set the selected disc's file path as a command-line argument
+            xenia.StartInfo.Arguments = $@"""{discPath}"" {configOverridesFromArgs}";
         }
 
         Logger.Trace<Launcher>($"Process configuration - Executable: {xenia.StartInfo.FileName}, Working Directory: {xenia.StartInfo.WorkingDirectory}, Arguments: {xenia.StartInfo.Arguments}");

--- a/source/XeniaManager.Core/Manage/Launcher.cs
+++ b/source/XeniaManager.Core/Manage/Launcher.cs
@@ -209,7 +209,7 @@ public class Launcher
         if (string.IsNullOrEmpty(discPath) || !File.Exists(discPath))
         {
             discNumber = 1;
-            discPath = game.FileLocations.Game;
+            discPath = game.FileLocations.ResolvedGamePath;
         }
 
         if (string.IsNullOrEmpty(discPath) || !File.Exists(discPath))

--- a/source/XeniaManager.Core/Models/Game/Game.cs
+++ b/source/XeniaManager.Core/Models/Game/Game.cs
@@ -60,4 +60,11 @@ public class Game
     /// </summary>
     [JsonPropertyName("file_locations")]
     public GameFiles FileLocations { get; set; } = new GameFiles();
+
+    /// <summary>
+    /// Disc number (1-based) that was last launched. Used to pre-select the
+    /// disc in the disc selection popup for multi-disc games.
+    /// </summary>
+    [JsonPropertyName("last_played_disc")]
+    public int LastPlayedDisc { get; set; } = 1;
 }

--- a/source/XeniaManager.Core/Models/Game/GameFiles.cs
+++ b/source/XeniaManager.Core/Models/Game/GameFiles.cs
@@ -9,10 +9,29 @@ namespace XeniaManager.Core.Models.Game;
 public class GameFiles
 {
     /// <summary>
-    /// Path to the game's ISO file
+    /// Path to the game's ISO file (Disc 1 when the game has multiple discs)
     /// </summary>
     [JsonPropertyName("game")]
     public string Game { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Paths to additional discs for multi-disc games (Disc 2, Disc 3, ...).
+    /// Empty for single-disc games.
+    /// </summary>
+    [JsonPropertyName("additional_discs")]
+    public List<GameDisc> AdditionalDiscs { get; set; } = [];
+
+    /// <summary>
+    /// Whether this game has more than one disc associated with it
+    /// </summary>
+    [JsonIgnore]
+    public bool IsMultiDisc => AdditionalDiscs.Count > 0;
+
+    /// <summary>
+    /// Total number of discs associated with this game (including Disc 1)
+    /// </summary>
+    [JsonIgnore]
+    public int DiscCount => 1 + AdditionalDiscs.Count;
 
     /// <summary>
     /// Path to the game's patch file
@@ -46,4 +65,56 @@ public class GameFiles
     [JsonIgnore]
     public bool IsGamePathValid => !string.IsNullOrEmpty(Game)
                                    && File.Exists(ResolvedGamePath);
+
+    /// <summary>
+    /// Returns the file path for the given disc number (1-based).
+    /// Disc 1 returns <see cref="Game"/>; Disc 2+ returns the matching entry in <see cref="AdditionalDiscs"/>.
+    /// Returns null if the disc number doesn't exist.
+    /// </summary>
+    public string? GetDiscPath(int discNumber)
+    {
+        if (discNumber <= 1)
+        {
+            return Game;
+        }
+
+        int index = discNumber - 2;
+        if (index < 0 || index >= AdditionalDiscs.Count)
+        {
+            return null;
+        }
+
+        return AdditionalDiscs[index].Path;
+    }
+}
+
+/// <summary>
+/// Represents a single additional disc belonging to a multi-disc game
+/// </summary>
+public class GameDisc
+{
+    /// <summary>
+    /// Disc number as shown to the user (2, 3, 4, ...)
+    /// </summary>
+    [JsonPropertyName("disc_number")]
+    public int DiscNumber { get; set; }
+
+    /// <summary>
+    /// Path to this disc's game file
+    /// </summary>
+    [JsonPropertyName("path")]
+    public string Path { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Optional custom label for the disc (e.g. "Disco 2 - Città di Nod").
+    /// Falls back to "Disc {DiscNumber}" when empty.
+    /// </summary>
+    [JsonPropertyName("label")]
+    public string? Label { get; set; }
+
+    /// <summary>
+    /// Whether this disc's path currently points to an existing file
+    /// </summary>
+    [JsonIgnore]
+    public bool IsPathValid => !string.IsNullOrEmpty(Path) && File.Exists(Path);
 }

--- a/source/XeniaManager.Core/Models/Game/GameFiles.cs
+++ b/source/XeniaManager.Core/Models/Game/GameFiles.cs
@@ -75,7 +75,12 @@ public class GameFiles
     /// </summary>
     public string? GetDiscPath(int discNumber)
     {
-        if (discNumber <= 1)
+        if (discNumber <= 0)
+        {
+            return null;
+        }
+
+        if (discNumber == 1)
         {
             return ResolvedGamePath;
         }

--- a/source/XeniaManager.Core/Models/Game/GameFiles.cs
+++ b/source/XeniaManager.Core/Models/Game/GameFiles.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using System.Text.Json.Serialization;
 using XeniaManager.Core.Constants;
 
@@ -67,15 +68,16 @@ public class GameFiles
                                    && File.Exists(ResolvedGamePath);
 
     /// <summary>
-    /// Returns the file path for the given disc number (1-based).
-    /// Disc 1 returns <see cref="Game"/>; Disc 2+ returns the matching entry in <see cref="AdditionalDiscs"/>.
+    /// Returns the file path for the given disc number (1-based), with relative paths
+    /// resolved to absolute using the Games directory. Disc 1 returns <see cref="ResolvedGamePath"/>;
+    /// Disc 2+ returns the matching entry's <see cref="GameDisc.ResolvedPath"/>.
     /// Returns null if the disc number doesn't exist.
     /// </summary>
     public string? GetDiscPath(int discNumber)
     {
         if (discNumber <= 1)
         {
-            return Game;
+            return ResolvedGamePath;
         }
 
         int index = discNumber - 2;
@@ -84,7 +86,7 @@ public class GameFiles
             return null;
         }
 
-        return AdditionalDiscs[index].Path;
+        return AdditionalDiscs[index].ResolvedPath;
     }
 }
 
@@ -100,7 +102,7 @@ public class GameDisc
     public int DiscNumber { get; set; }
 
     /// <summary>
-    /// Path to this disc's game file
+    /// Path to this disc's game file (may be relative for portability).
     /// </summary>
     [JsonPropertyName("path")]
     public string Path { get; set; } = string.Empty;
@@ -113,8 +115,16 @@ public class GameDisc
     public string? Label { get; set; }
 
     /// <summary>
+    /// Gets the resolved absolute path, converting relative paths to absolute using the Games directory.
+    /// </summary>
+    [JsonIgnore]
+    public string ResolvedPath => System.IO.Path.IsPathRooted(Path)
+        ? Path
+        : System.IO.Path.Combine(AppPaths.GamesDirectory, Path);
+
+    /// <summary>
     /// Whether this disc's path currently points to an existing file
     /// </summary>
     [JsonIgnore]
-    public bool IsPathValid => !string.IsNullOrEmpty(Path) && File.Exists(Path);
+    public bool IsPathValid => !string.IsNullOrEmpty(Path) && File.Exists(ResolvedPath);
 }

--- a/source/XeniaManager.Core/Settings/Sections/GeneralSettings.cs
+++ b/source/XeniaManager.Core/Settings/Sections/GeneralSettings.cs
@@ -30,4 +30,11 @@ public class GeneralSettings
     /// </summary>
     [JsonPropertyName("auto_detect_new_games")]
     public bool AutoDetectNewGames { get; set; } = true;
+
+    /// <summary>
+    /// Whether to automatically merge detected multi-disc games during library scan
+    /// instead of prompting the user for confirmation each time
+    /// </summary>
+    [JsonPropertyName("auto_merge_multi_disc")]
+    public bool AutoMergeMultiDisc { get; set; } = false;
 }

--- a/source/XeniaManager.Core/Utilities/ArgumentParser.cs
+++ b/source/XeniaManager.Core/Utilities/ArgumentParser.cs
@@ -128,7 +128,8 @@ public class ArgumentParser
             string trimmedArg = arg.Trim('"');
             if (trimmedArg.StartsWith("--") &&
                 !ArgumentFlags.Game.Any(f => trimmedArg.Equals(f, StringComparison.OrdinalIgnoreCase)) &&
-                !ArgumentFlags.XeniaArgs.Any(f => trimmedArg.Equals(f, StringComparison.OrdinalIgnoreCase)))
+                !ArgumentFlags.XeniaArgs.Any(f => trimmedArg.Equals(f, StringComparison.OrdinalIgnoreCase)) &&
+                !ArgumentFlags.Disc.Any(f => trimmedArg.Equals(f, StringComparison.OrdinalIgnoreCase)))
             {
                 configOverrideArgs += trimmedArg + " ";
             }

--- a/source/XeniaManager.Core/Utilities/ArgumentParser.cs
+++ b/source/XeniaManager.Core/Utilities/ArgumentParser.cs
@@ -144,6 +144,27 @@ public class ArgumentParser
     }
 
     /// <summary>
+    /// Checks if the desktop arguments specify a disc number to launch for a multi-disc game.
+    /// Accepts the value via the <see cref="ArgumentFlags.Disc"/> flag (e.g. "--disc 2").
+    /// </summary>
+    /// <param name="args">The array of string arguments from the desktop shortcut.</param>
+    /// <returns>The 1-based disc number if a valid value was provided, null otherwise.</returns>
+    public static int? GetDiscFromArgs(string[]? args)
+    {
+        Logger.Debug<ArgumentParser>($"Checking if desktop arguments specify a disc number");
+
+        (int discFlagIndex, string? discFlagValue) = TryGetFlagValue(args, ArgumentFlags.Disc);
+        if (!string.IsNullOrWhiteSpace(discFlagValue) && int.TryParse(discFlagValue, out int discNumber) && discNumber >= 1)
+        {
+            Logger.Debug<ArgumentParser>($"Found disc number {discNumber} via disc flag");
+            return discNumber;
+        }
+
+        Logger.Debug<ArgumentParser>("No valid disc number found in desktop arguments");
+        return null;
+    }
+
+    /// <summary>
     /// Helper to retrieve flag value
     /// </summary>
     /// <param name="args">Launch Arguments</param>

--- a/source/XeniaManager/App.axaml
+++ b/source/XeniaManager/App.axaml
@@ -16,6 +16,7 @@
             <converters:CompatibilityRatingColorConverter x:Key="CompatibilityRatingColorConverter" />
             <converters:CompatibilityRatingToStringConverter x:Key="CompatibilityRatingToStringConverter" />
             <converters:ConfigControlTypeToVisibilityConverter x:Key="ConfigControlTypeToVisibilityConverter" />
+            <converters:DiscCountConverter x:Key="DiscCountConverter" />
             <converters:DoubleFormatConverter x:Key="DoubleFormatConverter" />
             <converters:PlaytimeConverter x:Key="PlaytimeConverter" />
             <converters:ZoomScaleConverter x:Key="ZoomScaleConverter" />

--- a/source/XeniaManager/App.axaml.cs
+++ b/source/XeniaManager/App.axaml.cs
@@ -90,6 +90,7 @@ public partial class App : Application
             // Check for arguments first (before showing MainWindow)
             Game? gameFromArgs = ArgumentParser.GetGameFromArgs(desktop.Args);
             string? configOverridesFromArgs = ArgumentParser.GetConfigOverridesFromArgs(desktop.Args);
+            int? discFromArgs = ArgumentParser.GetDiscFromArgs(desktop.Args);
 
             if (gameFromArgs != null)
             {
@@ -109,7 +110,7 @@ public partial class App : Application
                 };
 
                 // Launch the game with a loading screen
-                ArgumentChecker(gameFromArgs, settings, mainWindow, configOverridesFromArgs);
+                ArgumentChecker(gameFromArgs, settings, mainWindow, configOverridesFromArgs, discFromArgs);
             }
             else
             {
@@ -256,7 +257,7 @@ public partial class App : Application
         }
     }
 
-    private async void ArgumentChecker(Game game, Settings settings, MainWindow mainWindow, string? configOverridesFromArgs = null)
+    private async void ArgumentChecker(Game game, Settings settings, MainWindow mainWindow, string? configOverridesFromArgs = null, int? discFromArgs = null)
     {
         Logger.Info<App>($"Launching game '{game.Title}' directly from desktop shortcut.");
 
@@ -287,6 +288,28 @@ public partial class App : Application
                 }
             };
 
+            // For multi-disc games, pick the disc to launch.
+            // Prefer an explicit --disc argument; otherwise default to Disc 1.
+            int discNumber = 1;
+            if (game.FileLocations.IsMultiDisc)
+            {
+                if (discFromArgs.HasValue && discFromArgs.Value >= 1 && discFromArgs.Value <= game.FileLocations.DiscCount)
+                {
+                    discNumber = discFromArgs.Value;
+                    Logger.Info<App>($"'{game.Title}' launched via --disc argument, using Disc {discNumber}");
+                }
+                else
+                {
+                    if (discFromArgs.HasValue)
+                    {
+                        Logger.Warning<App>($"--disc value {discFromArgs.Value} out of range for '{game.Title}', defaulting to Disc 1");
+                    }
+
+                    Logger.Info<App>($"'{game.Title}' has {game.FileLocations.DiscCount} discs, no --disc argument provided, defaulting to Disc 1");
+                    discNumber = 1;
+                }
+            }
+
             // Show the loading screen before launching the game
             if (loadingScreen != null)
             {
@@ -295,7 +318,7 @@ public partial class App : Application
             }
 
             // Launch the game asynchronously
-            await Launcher.LaunchGameASync(game, settings, onGameLoadingStarted: onGameLoadingStarted, configOverridesFromArgs: configOverridesFromArgs);
+            await Launcher.LaunchGameASync(game, settings, onGameLoadingStarted: onGameLoadingStarted, configOverridesFromArgs: configOverridesFromArgs, discNumber: discNumber);
             Logger.Info<App>($"Game session ended for '{game.Title}'");
         }
         catch (Exception ex)

--- a/source/XeniaManager/Controls/DiscSelectionDialog.cs
+++ b/source/XeniaManager/Controls/DiscSelectionDialog.cs
@@ -1,0 +1,112 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FluentAvalonia.UI.Controls;
+using Symbol = FluentIcons.Common.Symbol;
+using SymbolIconSource = FluentIcons.Avalonia.Fluent.SymbolIconSource;
+using XeniaManager.Core.Logging;
+using XeniaManager.Core.Models.Game;
+using XeniaManager.Core.Utilities;
+
+namespace XeniaManager.Controls;
+
+/// <summary>
+/// Provides functionality for displaying a dialog that allows users to pick which
+/// disc of a multi-disc game to launch.
+/// </summary>
+public abstract class DiscSelectionDialog
+{
+    /// <summary>
+    /// Shows a dialog letting the user pick which disc to launch.
+    /// The disc that was played last (<see cref="Game.LastPlayedDisc"/>) is highlighted as the default.
+    /// </summary>
+    /// <param name="game">The multi-disc game to show disc options for</param>
+    /// <returns>The 1-based disc number the user picked, or null if cancelled</returns>
+    public static async Task<int?> ShowAsync(Game game)
+    {
+        Logger.Info<DiscSelectionDialog>($"Showing disc selection dialog for '{game.Title}' ({game.FileLocations.DiscCount} discs)");
+
+        TaskDialog taskDialog = new TaskDialog
+        {
+            Title = game.Title,
+            Header = LocalizationHelper.GetText("DiscSelectionDialog.Header"),
+            SubHeader = LocalizationHelper.GetText("DiscSelectionDialog.SubHeader"),
+            IconSource = new SymbolIconSource { Symbol = Symbol.Games },
+            XamlRoot = App.MainWindow
+        };
+
+        List<TaskDialogCommand> commands = [];
+
+        for (int discNumber = 1; discNumber <= game.FileLocations.DiscCount; discNumber++)
+        {
+            string? path = game.FileLocations.GetDiscPath(discNumber);
+            bool isValid = !string.IsNullOrEmpty(path) && System.IO.File.Exists(path);
+            bool isLastPlayed = discNumber == game.LastPlayedDisc;
+
+            string label = discNumber == 1
+                ? LocalizationHelper.GetText("DiscSelectionDialog.Disc1")
+                : GetDiscLabel(game, discNumber);
+
+            if (isLastPlayed)
+            {
+                label = $"{label} {LocalizationHelper.GetText("DiscSelectionDialog.LastPlayedSuffix")}";
+            }
+
+            if (!isValid)
+            {
+                label = $"{label} {LocalizationHelper.GetText("DiscSelectionDialog.MissingSuffix")}";
+            }
+
+            TaskDialogCommand discCommand = new TaskDialogCommand
+            {
+                Text = label,
+                IconSource = new SymbolIconSource { Symbol = Symbol.Games },
+                ClosesOnInvoked = false,
+                IsEnabled = isValid
+            };
+
+            int capturedDiscNumber = discNumber; // avoid closure-over-loop-variable pitfall
+            discCommand.Click += (_, _) =>
+            {
+                Logger.Info<DiscSelectionDialog>($"User selected Disc {capturedDiscNumber}");
+                taskDialog.Hide(capturedDiscNumber);
+            };
+
+            commands.Add(discCommand);
+        }
+
+        taskDialog.Commands = commands;
+        taskDialog.Buttons = new List<TaskDialogButton>
+        {
+            TaskDialogButton.CloseButton
+        };
+
+        object result = await taskDialog.ShowAsync(true);
+
+        if (result is int discNumberResult)
+        {
+            Logger.Info<DiscSelectionDialog>($"User confirmed Disc {discNumberResult}");
+            return discNumberResult;
+        }
+
+        Logger.Info<DiscSelectionDialog>("User cancelled disc selection");
+        return null;
+    }
+
+    /// <summary>
+    /// Builds the display label for a disc, preferring its custom label when set.
+    /// </summary>
+    private static string GetDiscLabel(Game game, int discNumber)
+    {
+        int index = discNumber - 2; // AdditionalDiscs is 0-indexed starting at Disc 2
+        if (index >= 0 && index < game.FileLocations.AdditionalDiscs.Count)
+        {
+            GameDisc disc = game.FileLocations.AdditionalDiscs[index];
+            if (!string.IsNullOrWhiteSpace(disc.Label))
+            {
+                return disc.Label!;
+            }
+        }
+
+        return string.Format(LocalizationHelper.GetText("DiscSelectionDialog.DiscN"), discNumber);
+    }
+}

--- a/source/XeniaManager/Controls/ManageDiscsDialog.axaml
+++ b/source/XeniaManager/Controls/ManageDiscsDialog.axaml
@@ -1,0 +1,111 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:XeniaManager.ViewModels.Controls"
+             xmlns:icons="using:FluentIcons.Avalonia.Fluent"
+             xmlns:cards="using:XeniaManager.Controls.Cards"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d" d:DesignWidth="480" d:DesignHeight="440"
+             x:Class="XeniaManager.Controls.ManageDiscsDialog"
+             x:DataType="vm:ManageDiscsViewModel"
+             Margin="20"
+             Width="480">
+
+    <UserControl.Styles>
+        <Style Selector="TextBlock.discPath">
+            <Setter Property="FontSize" Value="11" />
+            <Setter Property="Foreground" Value="{DynamicResource TextFillColorSecondaryBrush}" />
+            <Setter Property="TextTrimming" Value="CharacterEllipsis" />
+        </Style>
+        <Style Selector="Border.discRow">
+            <Setter Property="Background" Value="{DynamicResource ControlFillColorSecondaryBrush}" />
+            <Setter Property="BorderBrush" Value="{DynamicResource CardStrokeColorDefaultBrush}" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="CornerRadius" Value="6" />
+            <Setter Property="Padding" Value="10,8" />
+            <Setter Property="Margin" Value="0,0,0,6" />
+        </Style>
+        <Style Selector="Border.discRow.invalid">
+            <Setter Property="BorderBrush" Value="{DynamicResource SystemFillColorCriticalBrush}" />
+        </Style>
+    </UserControl.Styles>
+
+    <StackPanel>
+        <TextBlock Text="{Binding GameTitle}"
+                   FontWeight="SemiBold"
+                   FontSize="14"
+                   Margin="0,0,0,4" />
+        <TextBlock Text="{DynamicResource ManageDiscsDialog.Subtitle}"
+                   FontSize="12"
+                   Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                   TextWrapping="Wrap"
+                   Margin="0,0,0,12" />
+
+        <cards:CustomCard>
+            <StackPanel>
+                <!-- Disc list -->
+                <ItemsControl ItemsSource="{Binding Discs}">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate x:DataType="vm:DiscRowViewModel">
+                            <Border Classes="discRow" Classes.invalid="{Binding !IsPathValid}">
+                                <Grid ColumnDefinitions="Auto,*,Auto">
+                                    <!-- Disc number badge -->
+                                    <Border Grid.Column="0"
+                                            Background="{DynamicResource AccentFillColorDefaultBrush}"
+                                            CornerRadius="4"
+                                            Padding="8,4"
+                                            VerticalAlignment="Center"
+                                            Margin="0,0,10,0">
+                                        <TextBlock Text="{Binding DiscNumber}"
+                                                   FontWeight="Bold"
+                                                   Foreground="White" />
+                                    </Border>
+
+                                    <!-- Label + path -->
+                                    <StackPanel Grid.Column="1" VerticalAlignment="Center">
+                                        <TextBox Text="{Binding Label}"
+                                                 IsEnabled="{Binding IsRemovable}"
+                                                 IsReadOnly="{Binding !IsRemovable}"
+                                                 BorderThickness="0"
+                                                 Background="Transparent"
+                                                 Padding="0"
+                                                 FontWeight="Medium"
+                                                 LostFocus="OnDiscLabelLostFocus" />
+                                        <TextBlock Classes="discPath" Text="{Binding Path}" />
+                                        <TextBlock Classes="discPath"
+                                                   Foreground="{DynamicResource SystemFillColorCriticalBrush}"
+                                                   Text="{DynamicResource ManageDiscsDialog.MissingFile}"
+                                                   IsVisible="{Binding !IsPathValid}" />
+                                    </StackPanel>
+
+                                    <!-- Remove button (Disc 1 not removable) -->
+                                    <Button Grid.Column="2"
+                                            Command="{Binding $parent[UserControl].((vm:ManageDiscsViewModel)DataContext).RemoveDiscCommand}"
+                                            CommandParameter="{Binding}"
+                                            IsVisible="{Binding IsRemovable}"
+                                            Padding="6"
+                                            VerticalAlignment="Center"
+                                            ToolTip.Tip="{DynamicResource ManageDiscsDialog.RemoveDisc.ToolTip}">
+                                        <icons:SymbolIcon Symbol="Delete" />
+                                    </Button>
+                                </Grid>
+                            </Border>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+
+                <!-- Add disc button -->
+                <Button Command="{Binding AddDiscCommand}"
+                        HorizontalAlignment="Stretch"
+                        HorizontalContentAlignment="Center"
+                        Margin="0,4,0,0"
+                        Padding="12,8">
+                    <StackPanel Orientation="Horizontal" Spacing="6">
+                        <icons:SymbolIcon Symbol="Add" />
+                        <TextBlock Text="{DynamicResource ManageDiscsDialog.AddDisc.Button}" />
+                    </StackPanel>
+                </Button>
+            </StackPanel>
+        </cards:CustomCard>
+    </StackPanel>
+</UserControl>

--- a/source/XeniaManager/Controls/ManageDiscsDialog.axaml.cs
+++ b/source/XeniaManager/Controls/ManageDiscsDialog.axaml.cs
@@ -1,0 +1,72 @@
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using FluentAvalonia.UI.Controls;
+using XeniaManager.Core.Models.Game;
+using XeniaManager.Core.Utilities;
+using XeniaManager.ViewModels.Controls;
+
+namespace XeniaManager.Controls;
+
+/// <summary>
+/// Represents a dialog that allows users to view, add, rename, and remove the discs
+/// associated with a multi-disc game (e.g. Blue Dragon's 3 discs).
+/// </summary>
+public partial class ManageDiscsDialog : UserControl
+{
+    private readonly ManageDiscsViewModel? _viewModel;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ManageDiscsDialog"/> class.
+    /// This constructor is required for the AXAML loader.
+    /// </summary>
+    public ManageDiscsDialog()
+    {
+        InitializeComponent();
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ManageDiscsDialog"/> class.
+    /// </summary>
+    /// <param name="game">The game whose discs are being managed.</param>
+    public ManageDiscsDialog(Game game)
+    {
+        InitializeComponent();
+        _viewModel = new ManageDiscsViewModel(game);
+        DataContext = _viewModel;
+    }
+
+    /// <summary>
+    /// Persists a disc's custom label when the user finishes editing it.
+    /// </summary>
+    private void OnDiscLabelLostFocus(object? sender, RoutedEventArgs e)
+    {
+        if (sender is TextBox { DataContext: DiscRowViewModel row } textBox)
+        {
+            _viewModel?.UpdateDiscLabel(row.DiscNumber, textBox.Text ?? string.Empty);
+        }
+    }
+
+    /// <summary>
+    /// Shows the Manage Discs dialog for the given game.
+    /// </summary>
+    /// <param name="game">The game whose discs are being managed.</param>
+    /// <returns>True when the dialog was closed (changes are applied live and always saved by the caller).</returns>
+    public static async Task<bool> ShowAsync(Game game)
+    {
+        ManageDiscsDialog dialogContent = new ManageDiscsDialog(game);
+
+        string dialogTitle = string.Format(LocalizationHelper.GetText("ManageDiscsDialog.Title"), game.Title);
+
+        ContentDialog contentDialog = new ContentDialog
+        {
+            Title = dialogTitle,
+            Content = dialogContent,
+            CloseButtonText = LocalizationHelper.GetText("ManageDiscsDialog.CloseButton"),
+            DefaultButton = ContentDialogButton.Close
+        };
+
+        await contentDialog.ShowAsync();
+        return true;
+    }
+}

--- a/source/XeniaManager/Resources/Language/en.axaml
+++ b/source/XeniaManager/Resources/Language/en.axaml
@@ -332,6 +332,9 @@
     <sys:String x:Key="SettingsPage.General.AutoDetectNewGames">Auto-Detect New Games</sys:String>
     <sys:String x:Key="SettingsPage.General.AutoDetectNewGames.Description">Automatically detect when new games are added to the Games folder</sys:String>
     <sys:String x:Key="SettingsPage.General.AutoDetectNewGames.ToolTip">Shows a notification when new game files are detected in the Games directory</sys:String>
+    <sys:String x:Key="SettingsPage.General.AutoMergeMultiDisc">Auto-Merge Multi-Disc Games</sys:String>
+    <sys:String x:Key="SettingsPage.General.AutoMergeMultiDisc.Description">Automatically merge detected discs of the same game during library scan</sys:String>
+    <sys:String x:Key="SettingsPage.General.AutoMergeMultiDisc.ToolTip">When enabled, additional discs matching an existing game in the library are merged automatically without prompting</sys:String>
 
     <!-- Loading Screen Window -->
     <sys:String x:Key="LoadingScreenWindow.LoadingText">Loading {0}</sys:String>

--- a/source/XeniaManager/Resources/Language/en.axaml
+++ b/source/XeniaManager/Resources/Language/en.axaml
@@ -1229,4 +1229,36 @@
     <!-- Library Page - Drag & Drop -->
     <sys:String x:Key="LibraryPage.DragDrop.Title">Drop files to add games</sys:String>
     <sys:String x:Key="LibraryPage.DragDrop.Subtitle">.iso, .xex, .zar files are supported</sys:String>
+
+    <!-- Multi-Disc Support -->
+    <sys:String x:Key="GameButton.ContextFlyout.EditGame.ManageDiscs.Header">Manage Discs</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.EditGame.ManageDiscs.ToolTip">Add, rename, or remove discs for multi-disc games</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.ManageDiscs.Error.Title">Failed to Manage Discs</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.ManageDiscs.Error.Message">An error occurred while managing discs.&#10;{0}</sys:String>
+    <sys:String x:Key="LibraryPage.GameButton.DiscCount">{0} Discs</sys:String>
+    <sys:String x:Key="LibraryPage.MultiDisc.MergePrompt.Title">Add as Additional Disc?</sys:String>
+    <sys:String x:Key="LibraryPage.MultiDisc.MergePrompt.Message">This file appears to be another disc of '{0}', which is already in your library.&#10;&#10;Would you like to add it as an additional disc of '{0}' instead of creating a separate library entry?</sys:String>
+
+    <!-- Disc Selection Dialog (shown when launching a multi-disc game) -->
+    <sys:String x:Key="DiscSelectionDialog.Header">Select Disc</sys:String>
+    <sys:String x:Key="DiscSelectionDialog.SubHeader">This game has multiple discs. Choose which one to launch.</sys:String>
+    <sys:String x:Key="DiscSelectionDialog.Disc1">Disc 1</sys:String>
+    <sys:String x:Key="DiscSelectionDialog.DiscN">Disc {0}</sys:String>
+    <sys:String x:Key="DiscSelectionDialog.LastPlayedSuffix">(Last Played)</sys:String>
+    <sys:String x:Key="DiscSelectionDialog.MissingSuffix">(File Missing)</sys:String>
+
+    <!-- Manage Discs Dialog -->
+    <sys:String x:Key="ManageDiscsDialog.Title">{0} - Manage Discs</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.Subtitle">Add, rename, or remove discs. The disc you launch will be remembered for next time.</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.CloseButton">Close</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.Disc1Label">Disc 1</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.DiscNLabel">Disc {0}</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.AddDisc.Button">Add Disc</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.RemoveDisc.ToolTip">Remove this disc</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.MissingFile">File not found</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.FilePicker.Title">Select Disc File</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.MissingStorageProvider.Title">Missing Storage Provider</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.MissingStorageProvider.Message">Storage provider is not available.</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.DuplicateDisc.Title">Disc Already Added</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.DuplicateDisc.Message">This file is already associated with this game.</sys:String>
 </ResourceDictionary>

--- a/source/XeniaManager/Resources/Language/hr.axaml
+++ b/source/XeniaManager/Resources/Language/hr.axaml
@@ -332,6 +332,9 @@
     <sys:String x:Key="SettingsPage.General.AutoDetectNewGames">Automatski otkrij nove igre</sys:String>
     <sys:String x:Key="SettingsPage.General.AutoDetectNewGames.Description">Automatski otkrij kada se nove igre dodaju u mapu Igre</sys:String>
     <sys:String x:Key="SettingsPage.General.AutoDetectNewGames.ToolTip">Prikazuje obavijest kada se u mapi Igre otkriju nove datoteke igara</sys:String>
+    <sys:String x:Key="SettingsPage.General.AutoMergeMultiDisc">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="SettingsPage.General.AutoMergeMultiDisc.Description">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="SettingsPage.General.AutoMergeMultiDisc.ToolTip">#NOTTRANSLATED#</sys:String>
 
     <!-- Loading Screen Window -->
     <sys:String x:Key="LoadingScreenWindow.LoadingText">Učitavanje {0}</sys:String>
@@ -1229,4 +1232,36 @@
     <!-- Library Page - Drag & Drop -->
     <sys:String x:Key="LibraryPage.DragDrop.Title">Ispustite datoteke za dodavanje igara</sys:String>
     <sys:String x:Key="LibraryPage.DragDrop.Subtitle">Podržane su .iso, .xex, .zar datoteke</sys:String>
+
+    <!-- Multi-Disc Support -->
+    <sys:String x:Key="GameButton.ContextFlyout.EditGame.ManageDiscs.Header">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.EditGame.ManageDiscs.ToolTip">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.ManageDiscs.Error.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.ManageDiscs.Error.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="LibraryPage.GameButton.DiscCount">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="LibraryPage.MultiDisc.MergePrompt.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="LibraryPage.MultiDisc.MergePrompt.Message">#NOTTRANSLATED#</sys:String>
+
+    <!-- Disc Selection Dialog (shown when launching a multi-disc game) -->
+    <sys:String x:Key="DiscSelectionDialog.Header">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="DiscSelectionDialog.SubHeader">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="DiscSelectionDialog.Disc1">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="DiscSelectionDialog.DiscN">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="DiscSelectionDialog.LastPlayedSuffix">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="DiscSelectionDialog.MissingSuffix">#NOTTRANSLATED#</sys:String>
+
+    <!-- Manage Discs Dialog -->
+    <sys:String x:Key="ManageDiscsDialog.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.Subtitle">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.CloseButton">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.Disc1Label">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.DiscNLabel">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.AddDisc.Button">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.RemoveDisc.ToolTip">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.MissingFile">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.FilePicker.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.MissingStorageProvider.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.MissingStorageProvider.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.DuplicateDisc.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.DuplicateDisc.Message">#NOTTRANSLATED#</sys:String>
 </ResourceDictionary>

--- a/source/XeniaManager/Resources/Language/hr.axaml
+++ b/source/XeniaManager/Resources/Language/hr.axaml
@@ -332,9 +332,9 @@
     <sys:String x:Key="SettingsPage.General.AutoDetectNewGames">Automatski otkrij nove igre</sys:String>
     <sys:String x:Key="SettingsPage.General.AutoDetectNewGames.Description">Automatski otkrij kada se nove igre dodaju u mapu Igre</sys:String>
     <sys:String x:Key="SettingsPage.General.AutoDetectNewGames.ToolTip">Prikazuje obavijest kada se u mapi Igre otkriju nove datoteke igara</sys:String>
-    <sys:String x:Key="SettingsPage.General.AutoMergeMultiDisc">#NOTTRANSLATED#</sys:String>
-    <sys:String x:Key="SettingsPage.General.AutoMergeMultiDisc.Description">#NOTTRANSLATED#</sys:String>
-    <sys:String x:Key="SettingsPage.General.AutoMergeMultiDisc.ToolTip">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="SettingsPage.General.AutoMergeMultiDisc">Automatski spoji igre s više diskova</sys:String>
+    <sys:String x:Key="SettingsPage.General.AutoMergeMultiDisc.Description">Tijekom skeniranja biblioteke automatski spoji prepoznate diskove iste igre</sys:String>
+    <sys:String x:Key="SettingsPage.General.AutoMergeMultiDisc.ToolTip">Kada je omogućeno, dodatni diskovi koji odgovaraju postojećoj igri u biblioteci automatski se spajaju bez traženja potvrde</sys:String>
 
     <!-- Loading Screen Window -->
     <sys:String x:Key="LoadingScreenWindow.LoadingText">Učitavanje {0}</sys:String>
@@ -1234,34 +1234,34 @@
     <sys:String x:Key="LibraryPage.DragDrop.Subtitle">Podržane su .iso, .xex, .zar datoteke</sys:String>
 
     <!-- Multi-Disc Support -->
-    <sys:String x:Key="GameButton.ContextFlyout.EditGame.ManageDiscs.Header">#NOTTRANSLATED#</sys:String>
-    <sys:String x:Key="GameButton.ContextFlyout.EditGame.ManageDiscs.ToolTip">#NOTTRANSLATED#</sys:String>
-    <sys:String x:Key="GameButton.ContextFlyout.ManageDiscs.Error.Title">#NOTTRANSLATED#</sys:String>
-    <sys:String x:Key="GameButton.ContextFlyout.ManageDiscs.Error.Message">#NOTTRANSLATED#</sys:String>
-    <sys:String x:Key="LibraryPage.GameButton.DiscCount">#NOTTRANSLATED#</sys:String>
-    <sys:String x:Key="LibraryPage.MultiDisc.MergePrompt.Title">#NOTTRANSLATED#</sys:String>
-    <sys:String x:Key="LibraryPage.MultiDisc.MergePrompt.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.EditGame.ManageDiscs.Header">Upravljanje diskovima</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.EditGame.ManageDiscs.ToolTip">Dodajte, preimenujte ili uklonite diskove za igre s više diskova</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.ManageDiscs.Error.Title">Upravljanje diskovima nije uspjelo</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.ManageDiscs.Error.Message">Došlo je do pogreške tijekom upravljanja diskovima.&#10;{0}</sys:String>
+    <sys:String x:Key="LibraryPage.GameButton.DiscCount">{0} diskova</sys:String>
+    <sys:String x:Key="LibraryPage.MultiDisc.MergePrompt.Title">Dodati kao dodatni disk?</sys:String>
+    <sys:String x:Key="LibraryPage.MultiDisc.MergePrompt.Message">Čini se da je ova datoteka još jedan disk igre „{0}”, koja se već nalazi u vašoj biblioteci.&#10;&#10;Želite li je dodati kao dodatni disk igre „{0}” umjesto stvaranja zasebnog unosa u biblioteci?</sys:String>
 
     <!-- Disc Selection Dialog (shown when launching a multi-disc game) -->
-    <sys:String x:Key="DiscSelectionDialog.Header">#NOTTRANSLATED#</sys:String>
-    <sys:String x:Key="DiscSelectionDialog.SubHeader">#NOTTRANSLATED#</sys:String>
-    <sys:String x:Key="DiscSelectionDialog.Disc1">#NOTTRANSLATED#</sys:String>
-    <sys:String x:Key="DiscSelectionDialog.DiscN">#NOTTRANSLATED#</sys:String>
-    <sys:String x:Key="DiscSelectionDialog.LastPlayedSuffix">#NOTTRANSLATED#</sys:String>
-    <sys:String x:Key="DiscSelectionDialog.MissingSuffix">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="DiscSelectionDialog.Header">Odaberite disk</sys:String>
+    <sys:String x:Key="DiscSelectionDialog.SubHeader">Ova igra ima više diskova. Odaberite koji želite pokrenuti.</sys:String>
+    <sys:String x:Key="DiscSelectionDialog.Disc1">Disk 1</sys:String>
+    <sys:String x:Key="DiscSelectionDialog.DiscN">Disk {0}</sys:String>
+    <sys:String x:Key="DiscSelectionDialog.LastPlayedSuffix">(Zadnji korišten)</sys:String>
+    <sys:String x:Key="DiscSelectionDialog.MissingSuffix">(Datoteka nedostaje)</sys:String>
 
     <!-- Manage Discs Dialog -->
-    <sys:String x:Key="ManageDiscsDialog.Title">#NOTTRANSLATED#</sys:String>
-    <sys:String x:Key="ManageDiscsDialog.Subtitle">#NOTTRANSLATED#</sys:String>
-    <sys:String x:Key="ManageDiscsDialog.CloseButton">#NOTTRANSLATED#</sys:String>
-    <sys:String x:Key="ManageDiscsDialog.Disc1Label">#NOTTRANSLATED#</sys:String>
-    <sys:String x:Key="ManageDiscsDialog.DiscNLabel">#NOTTRANSLATED#</sys:String>
-    <sys:String x:Key="ManageDiscsDialog.AddDisc.Button">#NOTTRANSLATED#</sys:String>
-    <sys:String x:Key="ManageDiscsDialog.RemoveDisc.ToolTip">#NOTTRANSLATED#</sys:String>
-    <sys:String x:Key="ManageDiscsDialog.MissingFile">#NOTTRANSLATED#</sys:String>
-    <sys:String x:Key="ManageDiscsDialog.FilePicker.Title">#NOTTRANSLATED#</sys:String>
-    <sys:String x:Key="ManageDiscsDialog.MissingStorageProvider.Title">#NOTTRANSLATED#</sys:String>
-    <sys:String x:Key="ManageDiscsDialog.MissingStorageProvider.Message">#NOTTRANSLATED#</sys:String>
-    <sys:String x:Key="ManageDiscsDialog.DuplicateDisc.Title">#NOTTRANSLATED#</sys:String>
-    <sys:String x:Key="ManageDiscsDialog.DuplicateDisc.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.Title">{0} – Upravljanje diskovima</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.Subtitle">Dodajte, preimenujte ili uklonite diskove. Disk koji pokrenete bit će zapamćen za sljedeći put.</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.CloseButton">Zatvori</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.Disc1Label">Disk 1</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.DiscNLabel">Disk {0}</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.AddDisc.Button">Dodaj disk</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.RemoveDisc.ToolTip">Ukloni ovaj disk</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.MissingFile">Datoteka nije pronađena</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.FilePicker.Title">Odaberite datoteku diska</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.MissingStorageProvider.Title">Nedostaje pružatelj pohrane</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.MissingStorageProvider.Message">Pružatelj pohrane nije dostupan.</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.DuplicateDisc.Title">Disk je već dodan</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.DuplicateDisc.Message">Ova je datoteka već povezana s ovom igrom.</sys:String>
 </ResourceDictionary>

--- a/source/XeniaManager/Resources/Language/it.axaml
+++ b/source/XeniaManager/Resources/Language/it.axaml
@@ -46,11 +46,11 @@
     <sys:String x:Key="LibraryPage.Options.ScanDirectory.Error.Title">Scansione Fallita</sys:String>
     <sys:String x:Key="LibraryPage.Options.ScanDirectory.Error.Message">Si è verificato un errore durante la scansione della cartella:&#10;&#10;{0}</sys:String>
     <sys:String x:Key="LibraryPage.Options.ScanDirectory.ScanError.Title">Errore di Scansione</sys:String>
-    <sys:String x:Key="LibraryPage.Options.ScanDirectory.ScanChoice.Title">#NOTTRANSLATED#</sys:String>
-    <sys:String x:Key="LibraryPage.Options.ScanDirectory.ScanChoice.Message">#NOTTRANSLATED#</sys:String>
-    <sys:String x:Key="LibraryPage.Options.ScanDirectory.ScanChoice.GamesFolder">#NOTTRANSLATED#</sys:String>
-    <sys:String x:Key="LibraryPage.Options.ScanDirectory.ScanChoice.CustomFolder">#NOTTRANSLATED#</sys:String>
-    <sys:String x:Key="LibraryPage.Options.ScanDirectory.ScanChoice.Cancel">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="LibraryPage.Options.ScanDirectory.ScanChoice.Title">Scansiona Cartella</sys:String>
+    <sys:String x:Key="LibraryPage.Options.ScanDirectory.ScanChoice.Message">Seleziona la sorgente per la scansione:</sys:String>
+    <sys:String x:Key="LibraryPage.Options.ScanDirectory.ScanChoice.GamesFolder">Scansiona la cartella Games</sys:String>
+    <sys:String x:Key="LibraryPage.Options.ScanDirectory.ScanChoice.CustomFolder">Scansiona una cartella personalizzata</sys:String>
+    <sys:String x:Key="LibraryPage.Options.ScanDirectory.ScanChoice.Cancel">Annulla</sys:String>
 
     <!-- Folder Scan Progress Dialog -->
     <sys:String x:Key="FolderScanProgressDialog.Title">Scansione in Corso</sys:String>
@@ -329,12 +329,12 @@
     <sys:String x:Key="SettingsPage.General.CheckForUpdatesOnStartup">Controlla Aggiornamenti all'Avvio</sys:String>
     <sys:String x:Key="SettingsPage.General.CheckForUpdatesOnStartup.Description">Controlla automaticamente gli aggiornamenti di Xenia e Xenia Manager all'avvio</sys:String>
     <sys:String x:Key="SettingsPage.General.CheckForUpdatesOnStartup.ToolTip">Disabilita per saltare il controllo aggiornamenti all'avvio</sys:String>
-    <sys:String x:Key="SettingsPage.General.AutoDetectNewGames">#NOTTRANSLATED#</sys:String>
-    <sys:String x:Key="SettingsPage.General.AutoDetectNewGames.Description">#NOTTRANSLATED#</sys:String>
-    <sys:String x:Key="SettingsPage.General.AutoDetectNewGames.ToolTip">#NOTTRANSLATED#</sys:String>
-    <sys:String x:Key="SettingsPage.General.AutoMergeMultiDisc">#NOTTRANSLATED#</sys:String>
-    <sys:String x:Key="SettingsPage.General.AutoMergeMultiDisc.Description">#NOTTRANSLATED#</sys:String>
-    <sys:String x:Key="SettingsPage.General.AutoMergeMultiDisc.ToolTip">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="SettingsPage.General.AutoDetectNewGames">Rileva Automaticamente Nuovi Giochi</sys:String>
+    <sys:String x:Key="SettingsPage.General.AutoDetectNewGames.Description">Rileva automaticamente quando nuovi giochi vengono aggiunti alla cartella Games</sys:String>
+    <sys:String x:Key="SettingsPage.General.AutoDetectNewGames.ToolTip">Mostra una notifica quando vengono rilevati nuovi file di gioco nella cartella Games</sys:String>
+    <sys:String x:Key="SettingsPage.General.AutoMergeMultiDisc">Unisci Automaticamente Giochi Multi-Disco</sys:String>
+    <sys:String x:Key="SettingsPage.General.AutoMergeMultiDisc.Description">Unisce automaticamente i dischi rilevati dello stesso gioco durante la scansione della libreria</sys:String>
+    <sys:String x:Key="SettingsPage.General.AutoMergeMultiDisc.ToolTip">Se abilitato, i dischi aggiuntivi che corrispondono a un gioco già presente in libreria vengono uniti automaticamente senza chiedere conferma</sys:String>
 
     <!-- Loading Screen Window -->
     <sys:String x:Key="LoadingScreenWindow.LoadingText">Caricamento {0}</sys:String>
@@ -724,8 +724,8 @@
     <!-- InfoBar Messages -->
     <sys:String x:Key="InfoBar.UpdatesAvailable">Aggiornamenti disponibili: {0}</sys:String>
     <sys:String x:Key="InfoBar.XeniaManagerUpdateAvailable">Aggiornamenti disponibili per Xenia Manager</sys:String>
-    <sys:String x:Key="InfoBar.NewGamesDetected.Message">#NOTTRANSLATED#</sys:String>
-    <sys:String x:Key="InfoBar.NewGamesDetected.Action">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="InfoBar.NewGamesDetected.Message">Nuovi giochi rilevati. Riscansiona la cartella giochi per aggiornare la tua libreria.</sys:String>
+    <sys:String x:Key="InfoBar.NewGamesDetected.Action">Riscansiona</sys:String>
 
     <!-- Config Editor Dialog -->
     <sys:String x:Key="ConfigEditorDialog.ContentDialog.Title">Editor di Configurazione</sys:String>
@@ -971,12 +971,12 @@
     <sys:String x:Key="ConfigUiSettings.GPU.anisotropic_override.option.5">16x</sys:String>
     <sys:String x:Key="ConfigUiSettings.GPU.async_shader_compilation.Title">Compilazione Shader Asincrona</sys:String>
     <sys:String x:Key="ConfigUiSettings.GPU.async_shader_compilation.Comment">Compila shader in background eliminando gli stutter&#10;Può causare brevi artefatti visivi durante la creazione delle pipeline</sys:String>
-    <sys:String x:Key="ConfigUiSettings.GPU.occlusion_query.Title">#NOTTRANSLATED#</sys:String>
-    <sys:String x:Key="ConfigUiSettings.GPU.occlusion_query.Comment">#NOTTRANSLATED#</sys:String>
-    <sys:String x:Key="ConfigUiSettings.GPU.occlusion_query.option.fake">#NOTTRANSLATED#</sys:String>
-    <sys:String x:Key="ConfigUiSettings.GPU.occlusion_query.option.fast">#NOTTRANSLATED#</sys:String>
-    <sys:String x:Key="ConfigUiSettings.GPU.occlusion_query.option.fast-alt">#NOTTRANSLATED#</sys:String>
-    <sys:String x:Key="ConfigUiSettings.GPU.occlusion_query.option.strict">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ConfigUiSettings.GPU.occlusion_query.Title">Occlusion Query</sys:String>
+    <sys:String x:Key="ConfigUiSettings.GPU.occlusion_query.Comment">Controlla il comportamento dell'occlusion query hardware per EVENT_WRITE_ZPD&#10;Usato per effetti come lens flare, culling degli oggetti e auto-esposizione&#10;fake: Scrive un risultato fittizio senza interpellare la GPU. Sicuro per la maggior parte dei giochi&#10;fast: Interpella la GPU ma non attende. Scrive il risultato in cache, aggiornandolo quando la GPU è pronta. (Predefinito)&#10;fast-alt: Come fast ma mantiene risultati zero in cache per i report non risolti&#10;strict: Interpella la GPU e attende il risultato reale. Più accurato, meno performante</sys:String>
+    <sys:String x:Key="ConfigUiSettings.GPU.occlusion_query.option.fake">Fake</sys:String>
+    <sys:String x:Key="ConfigUiSettings.GPU.occlusion_query.option.fast">Fast (Predefinito)</sys:String>
+    <sys:String x:Key="ConfigUiSettings.GPU.occlusion_query.option.fast-alt">Fast-Alt</sys:String>
+    <sys:String x:Key="ConfigUiSettings.GPU.occlusion_query.option.strict">Strict</sys:String>
 
     <!-- Config UI Settings - HID Options -->
     <sys:String x:Key="ConfigUiSettings.HID.hid.Title">Sistema di Input</sys:String>
@@ -1234,34 +1234,34 @@
     <sys:String x:Key="LibraryPage.DragDrop.Subtitle">Sono supportati i file .iso, .xex, .zar</sys:String>
 
     <!-- Multi-Disc Support -->
-    <sys:String x:Key="GameButton.ContextFlyout.EditGame.ManageDiscs.Header">#NOTTRANSLATED#</sys:String>
-    <sys:String x:Key="GameButton.ContextFlyout.EditGame.ManageDiscs.ToolTip">#NOTTRANSLATED#</sys:String>
-    <sys:String x:Key="GameButton.ContextFlyout.ManageDiscs.Error.Title">#NOTTRANSLATED#</sys:String>
-    <sys:String x:Key="GameButton.ContextFlyout.ManageDiscs.Error.Message">#NOTTRANSLATED#</sys:String>
-    <sys:String x:Key="LibraryPage.GameButton.DiscCount">#NOTTRANSLATED#</sys:String>
-    <sys:String x:Key="LibraryPage.MultiDisc.MergePrompt.Title">#NOTTRANSLATED#</sys:String>
-    <sys:String x:Key="LibraryPage.MultiDisc.MergePrompt.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.EditGame.ManageDiscs.Header">Gestisci Dischi</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.EditGame.ManageDiscs.ToolTip">Aggiungi, rinomina o rimuovi dischi per i giochi multi-disco</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.ManageDiscs.Error.Title">Gestione Dischi Fallita</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.ManageDiscs.Error.Message">Si è verificato un errore durante la gestione dei dischi.&#10;{0}</sys:String>
+    <sys:String x:Key="LibraryPage.GameButton.DiscCount">{0} Dischi</sys:String>
+    <sys:String x:Key="LibraryPage.MultiDisc.MergePrompt.Title">Aggiungere come Disco Aggiuntivo?</sys:String>
+    <sys:String x:Key="LibraryPage.MultiDisc.MergePrompt.Message">Questo file sembra essere un altro disco di '{0}', già presente nella tua libreria.&#10;&#10;Vuoi aggiungerlo come disco aggiuntivo di '{0}' invece di creare una voce separata in libreria?</sys:String>
 
     <!-- Disc Selection Dialog (shown when launching a multi-disc game) -->
-    <sys:String x:Key="DiscSelectionDialog.Header">#NOTTRANSLATED#</sys:String>
-    <sys:String x:Key="DiscSelectionDialog.SubHeader">#NOTTRANSLATED#</sys:String>
-    <sys:String x:Key="DiscSelectionDialog.Disc1">#NOTTRANSLATED#</sys:String>
-    <sys:String x:Key="DiscSelectionDialog.DiscN">#NOTTRANSLATED#</sys:String>
-    <sys:String x:Key="DiscSelectionDialog.LastPlayedSuffix">#NOTTRANSLATED#</sys:String>
-    <sys:String x:Key="DiscSelectionDialog.MissingSuffix">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="DiscSelectionDialog.Header">Seleziona Disco</sys:String>
+    <sys:String x:Key="DiscSelectionDialog.SubHeader">Questo gioco ha più dischi. Scegli quale avviare.</sys:String>
+    <sys:String x:Key="DiscSelectionDialog.Disc1">Disco 1</sys:String>
+    <sys:String x:Key="DiscSelectionDialog.DiscN">Disco {0}</sys:String>
+    <sys:String x:Key="DiscSelectionDialog.LastPlayedSuffix">(Ultimo Giocato)</sys:String>
+    <sys:String x:Key="DiscSelectionDialog.MissingSuffix">(File Mancante)</sys:String>
 
     <!-- Manage Discs Dialog -->
-    <sys:String x:Key="ManageDiscsDialog.Title">#NOTTRANSLATED#</sys:String>
-    <sys:String x:Key="ManageDiscsDialog.Subtitle">#NOTTRANSLATED#</sys:String>
-    <sys:String x:Key="ManageDiscsDialog.CloseButton">#NOTTRANSLATED#</sys:String>
-    <sys:String x:Key="ManageDiscsDialog.Disc1Label">#NOTTRANSLATED#</sys:String>
-    <sys:String x:Key="ManageDiscsDialog.DiscNLabel">#NOTTRANSLATED#</sys:String>
-    <sys:String x:Key="ManageDiscsDialog.AddDisc.Button">#NOTTRANSLATED#</sys:String>
-    <sys:String x:Key="ManageDiscsDialog.RemoveDisc.ToolTip">#NOTTRANSLATED#</sys:String>
-    <sys:String x:Key="ManageDiscsDialog.MissingFile">#NOTTRANSLATED#</sys:String>
-    <sys:String x:Key="ManageDiscsDialog.FilePicker.Title">#NOTTRANSLATED#</sys:String>
-    <sys:String x:Key="ManageDiscsDialog.MissingStorageProvider.Title">#NOTTRANSLATED#</sys:String>
-    <sys:String x:Key="ManageDiscsDialog.MissingStorageProvider.Message">#NOTTRANSLATED#</sys:String>
-    <sys:String x:Key="ManageDiscsDialog.DuplicateDisc.Title">#NOTTRANSLATED#</sys:String>
-    <sys:String x:Key="ManageDiscsDialog.DuplicateDisc.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.Title">{0} - Gestisci Dischi</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.Subtitle">Aggiungi, rinomina o rimuovi dischi. Il disco che avvii verrà ricordato per la prossima volta.</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.CloseButton">Chiudi</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.Disc1Label">Disco 1</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.DiscNLabel">Disco {0}</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.AddDisc.Button">Aggiungi Disco</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.RemoveDisc.ToolTip">Rimuovi questo disco</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.MissingFile">File non trovato</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.FilePicker.Title">Seleziona File Disco</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.MissingStorageProvider.Title">Provider di Archiviazione Mancante</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.MissingStorageProvider.Message">Il provider di archiviazione non è disponibile.</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.DuplicateDisc.Title">Disco Già Aggiunto</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.DuplicateDisc.Message">Questo file è già associato a questo gioco.</sys:String>
 </ResourceDictionary>

--- a/source/XeniaManager/Resources/Language/it.axaml
+++ b/source/XeniaManager/Resources/Language/it.axaml
@@ -46,6 +46,11 @@
     <sys:String x:Key="LibraryPage.Options.ScanDirectory.Error.Title">Scansione Fallita</sys:String>
     <sys:String x:Key="LibraryPage.Options.ScanDirectory.Error.Message">Si è verificato un errore durante la scansione della cartella:&#10;&#10;{0}</sys:String>
     <sys:String x:Key="LibraryPage.Options.ScanDirectory.ScanError.Title">Errore di Scansione</sys:String>
+    <sys:String x:Key="LibraryPage.Options.ScanDirectory.ScanChoice.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="LibraryPage.Options.ScanDirectory.ScanChoice.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="LibraryPage.Options.ScanDirectory.ScanChoice.GamesFolder">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="LibraryPage.Options.ScanDirectory.ScanChoice.CustomFolder">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="LibraryPage.Options.ScanDirectory.ScanChoice.Cancel">#NOTTRANSLATED#</sys:String>
 
     <!-- Folder Scan Progress Dialog -->
     <sys:String x:Key="FolderScanProgressDialog.Title">Scansione in Corso</sys:String>
@@ -226,9 +231,11 @@
     <sys:String x:Key="ManagePage.Content.ManageProfiles.Title">Gestisci Profili</sys:String>
     <sys:String x:Key="ManagePage.Content.ManageProfiles.Description">Consente all'utente di modificare i Profili Xenia</sys:String>
     <sys:String x:Key="ManagePage.ManageProfiles.Button">Gestisci</sys:String>
+
     <sys:String x:Key="ManagePage.Content.EditXConfig.Title">Modifica Impostazioni XConfig</sys:String>
     <sys:String x:Key="ManagePage.Content.EditXConfig.Description">Modifica le impostazioni della dashboard Xbox 360 (risoluzione, lingua, paese, profilo predefinito)</sys:String>
     <sys:String x:Key="ManagePage.EditXConfig.Button">Modifica</sys:String>
+
     <sys:String x:Key="ManagePage.Content.Install.Title">Installa Contenuti</sys:String>
     <sys:String x:Key="ManagePage.Content.Install.Description">Installa DLC, aggiornamenti e altri contenuti per Xenia</sys:String>
     <sys:String x:Key="ManagePage.Content.Install.Button">Installa Contenuti</sys:String>
@@ -322,6 +329,12 @@
     <sys:String x:Key="SettingsPage.General.CheckForUpdatesOnStartup">Controlla Aggiornamenti all'Avvio</sys:String>
     <sys:String x:Key="SettingsPage.General.CheckForUpdatesOnStartup.Description">Controlla automaticamente gli aggiornamenti di Xenia e Xenia Manager all'avvio</sys:String>
     <sys:String x:Key="SettingsPage.General.CheckForUpdatesOnStartup.ToolTip">Disabilita per saltare il controllo aggiornamenti all'avvio</sys:String>
+    <sys:String x:Key="SettingsPage.General.AutoDetectNewGames">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="SettingsPage.General.AutoDetectNewGames.Description">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="SettingsPage.General.AutoDetectNewGames.ToolTip">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="SettingsPage.General.AutoMergeMultiDisc">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="SettingsPage.General.AutoMergeMultiDisc.Description">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="SettingsPage.General.AutoMergeMultiDisc.ToolTip">#NOTTRANSLATED#</sys:String>
 
     <!-- Loading Screen Window -->
     <sys:String x:Key="LoadingScreenWindow.LoadingText">Caricamento {0}</sys:String>
@@ -659,6 +672,7 @@
     <sys:String x:Key="InstalledContentDialog.OpenDirectory.Failed.Title">Apertura Cartella Fallita</sys:String>
     <sys:String x:Key="InstalledContentDialog.OpenDirectory.Failed.Message">Impossibile aprire la cartella dei contenuti.&#10;Errore: {0}</sys:String>
     <sys:String x:Key="InstalledContentDialog.Achievements">Obiettivi</sys:String>
+
     <sys:String x:Key="InstalledContentDialog.SelectAll">Seleziona Tutto</sys:String>
     <sys:String x:Key="InstalledContentDialog.UnselectAll">Deseleziona Tutto</sys:String>
     <sys:String x:Key="InstalledContentDialog.UnlockSelected">Sblocca Selezionati</sys:String>
@@ -710,6 +724,8 @@
     <!-- InfoBar Messages -->
     <sys:String x:Key="InfoBar.UpdatesAvailable">Aggiornamenti disponibili: {0}</sys:String>
     <sys:String x:Key="InfoBar.XeniaManagerUpdateAvailable">Aggiornamenti disponibili per Xenia Manager</sys:String>
+    <sys:String x:Key="InfoBar.NewGamesDetected.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="InfoBar.NewGamesDetected.Action">#NOTTRANSLATED#</sys:String>
 
     <!-- Config Editor Dialog -->
     <sys:String x:Key="ConfigEditorDialog.ContentDialog.Title">Editor di Configurazione</sys:String>
@@ -1213,7 +1229,39 @@
     <sys:String x:Key="AboutPage.InfoBar.XeniaManagerUpdateAvailable.Message">È disponibile una versione più recente di Xenia Manager.</sys:String>
     <sys:String x:Key="AboutPage.InfoBar.NoXeniaManagerUpdateAvailable.Message">Stai attualmente usando l'ultima versione di Xenia Manager.</sys:String>
 
-    <!-- Library Page - Drag and Drop -->
+    <!-- Library Page - Drag & Drop -->
     <sys:String x:Key="LibraryPage.DragDrop.Title">Trascina i file per aggiungere giochi</sys:String>
     <sys:String x:Key="LibraryPage.DragDrop.Subtitle">Sono supportati i file .iso, .xex, .zar</sys:String>
+
+    <!-- Multi-Disc Support -->
+    <sys:String x:Key="GameButton.ContextFlyout.EditGame.ManageDiscs.Header">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.EditGame.ManageDiscs.ToolTip">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.ManageDiscs.Error.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.ManageDiscs.Error.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="LibraryPage.GameButton.DiscCount">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="LibraryPage.MultiDisc.MergePrompt.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="LibraryPage.MultiDisc.MergePrompt.Message">#NOTTRANSLATED#</sys:String>
+
+    <!-- Disc Selection Dialog (shown when launching a multi-disc game) -->
+    <sys:String x:Key="DiscSelectionDialog.Header">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="DiscSelectionDialog.SubHeader">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="DiscSelectionDialog.Disc1">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="DiscSelectionDialog.DiscN">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="DiscSelectionDialog.LastPlayedSuffix">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="DiscSelectionDialog.MissingSuffix">#NOTTRANSLATED#</sys:String>
+
+    <!-- Manage Discs Dialog -->
+    <sys:String x:Key="ManageDiscsDialog.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.Subtitle">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.CloseButton">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.Disc1Label">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.DiscNLabel">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.AddDisc.Button">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.RemoveDisc.ToolTip">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.MissingFile">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.FilePicker.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.MissingStorageProvider.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.MissingStorageProvider.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.DuplicateDisc.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.DuplicateDisc.Message">#NOTTRANSLATED#</sys:String>
 </ResourceDictionary>

--- a/source/XeniaManager/Resources/Language/it.axaml
+++ b/source/XeniaManager/Resources/Language/it.axaml
@@ -48,8 +48,8 @@
     <sys:String x:Key="LibraryPage.Options.ScanDirectory.ScanError.Title">Errore di Scansione</sys:String>
     <sys:String x:Key="LibraryPage.Options.ScanDirectory.ScanChoice.Title">Scansiona Cartella</sys:String>
     <sys:String x:Key="LibraryPage.Options.ScanDirectory.ScanChoice.Message">Seleziona la sorgente per la scansione:</sys:String>
-    <sys:String x:Key="LibraryPage.Options.ScanDirectory.ScanChoice.GamesFolder">Scansiona la cartella Games</sys:String>
-    <sys:String x:Key="LibraryPage.Options.ScanDirectory.ScanChoice.CustomFolder">Scansiona una cartella personalizzata</sys:String>
+    <sys:String x:Key="LibraryPage.Options.ScanDirectory.ScanChoice.GamesFolder">Cartella Games</sys:String>
+    <sys:String x:Key="LibraryPage.Options.ScanDirectory.ScanChoice.CustomFolder">Cartella Personalizzata</sys:String>
     <sys:String x:Key="LibraryPage.Options.ScanDirectory.ScanChoice.Cancel">Annulla</sys:String>
 
     <!-- Folder Scan Progress Dialog -->

--- a/source/XeniaManager/Resources/Language/pt-BR.axaml
+++ b/source/XeniaManager/Resources/Language/pt-BR.axaml
@@ -332,6 +332,9 @@
     <sys:String x:Key="SettingsPage.General.AutoDetectNewGames">#NOTTRANSLATED#</sys:String>
     <sys:String x:Key="SettingsPage.General.AutoDetectNewGames.Description">#NOTTRANSLATED#</sys:String>
     <sys:String x:Key="SettingsPage.General.AutoDetectNewGames.ToolTip">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="SettingsPage.General.AutoMergeMultiDisc">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="SettingsPage.General.AutoMergeMultiDisc.Description">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="SettingsPage.General.AutoMergeMultiDisc.ToolTip">#NOTTRANSLATED#</sys:String>
 
     <!-- Loading Screen Window -->
     <sys:String x:Key="LoadingScreenWindow.LoadingText">Carregando {0}</sys:String>
@@ -1229,4 +1232,36 @@
     <!-- Library Page - Drag & Drop -->
     <sys:String x:Key="LibraryPage.DragDrop.Title">#NOTTRANSLATED#</sys:String>
     <sys:String x:Key="LibraryPage.DragDrop.Subtitle">#NOTTRANSLATED#</sys:String>
+
+    <!-- Multi-Disc Support -->
+    <sys:String x:Key="GameButton.ContextFlyout.EditGame.ManageDiscs.Header">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.EditGame.ManageDiscs.ToolTip">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.ManageDiscs.Error.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.ManageDiscs.Error.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="LibraryPage.GameButton.DiscCount">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="LibraryPage.MultiDisc.MergePrompt.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="LibraryPage.MultiDisc.MergePrompt.Message">#NOTTRANSLATED#</sys:String>
+
+    <!-- Disc Selection Dialog (shown when launching a multi-disc game) -->
+    <sys:String x:Key="DiscSelectionDialog.Header">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="DiscSelectionDialog.SubHeader">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="DiscSelectionDialog.Disc1">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="DiscSelectionDialog.DiscN">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="DiscSelectionDialog.LastPlayedSuffix">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="DiscSelectionDialog.MissingSuffix">#NOTTRANSLATED#</sys:String>
+
+    <!-- Manage Discs Dialog -->
+    <sys:String x:Key="ManageDiscsDialog.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.Subtitle">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.CloseButton">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.Disc1Label">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.DiscNLabel">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.AddDisc.Button">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.RemoveDisc.ToolTip">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.MissingFile">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.FilePicker.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.MissingStorageProvider.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.MissingStorageProvider.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.DuplicateDisc.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.DuplicateDisc.Message">#NOTTRANSLATED#</sys:String>
 </ResourceDictionary>

--- a/source/XeniaManager/Resources/Language/ru.axaml
+++ b/source/XeniaManager/Resources/Language/ru.axaml
@@ -332,6 +332,9 @@
     <sys:String x:Key="SettingsPage.General.AutoDetectNewGames">#NOTTRANSLATED#</sys:String>
     <sys:String x:Key="SettingsPage.General.AutoDetectNewGames.Description">#NOTTRANSLATED#</sys:String>
     <sys:String x:Key="SettingsPage.General.AutoDetectNewGames.ToolTip">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="SettingsPage.General.AutoMergeMultiDisc">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="SettingsPage.General.AutoMergeMultiDisc.Description">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="SettingsPage.General.AutoMergeMultiDisc.ToolTip">#NOTTRANSLATED#</sys:String>
 
     <!-- Loading Screen Window -->
     <sys:String x:Key="LoadingScreenWindow.LoadingText">Загрузка {0}</sys:String>
@@ -1229,4 +1232,36 @@
     <!-- Library Page - Drag & Drop -->
     <sys:String x:Key="LibraryPage.DragDrop.Title">#NOTTRANSLATED#</sys:String>
     <sys:String x:Key="LibraryPage.DragDrop.Subtitle">#NOTTRANSLATED#</sys:String>
+
+    <!-- Multi-Disc Support -->
+    <sys:String x:Key="GameButton.ContextFlyout.EditGame.ManageDiscs.Header">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.EditGame.ManageDiscs.ToolTip">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.ManageDiscs.Error.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.ManageDiscs.Error.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="LibraryPage.GameButton.DiscCount">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="LibraryPage.MultiDisc.MergePrompt.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="LibraryPage.MultiDisc.MergePrompt.Message">#NOTTRANSLATED#</sys:String>
+
+    <!-- Disc Selection Dialog (shown when launching a multi-disc game) -->
+    <sys:String x:Key="DiscSelectionDialog.Header">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="DiscSelectionDialog.SubHeader">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="DiscSelectionDialog.Disc1">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="DiscSelectionDialog.DiscN">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="DiscSelectionDialog.LastPlayedSuffix">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="DiscSelectionDialog.MissingSuffix">#NOTTRANSLATED#</sys:String>
+
+    <!-- Manage Discs Dialog -->
+    <sys:String x:Key="ManageDiscsDialog.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.Subtitle">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.CloseButton">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.Disc1Label">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.DiscNLabel">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.AddDisc.Button">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.RemoveDisc.ToolTip">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.MissingFile">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.FilePicker.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.MissingStorageProvider.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.MissingStorageProvider.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.DuplicateDisc.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.DuplicateDisc.Message">#NOTTRANSLATED#</sys:String>
 </ResourceDictionary>

--- a/source/XeniaManager/Resources/Language/tr.axaml
+++ b/source/XeniaManager/Resources/Language/tr.axaml
@@ -332,6 +332,9 @@
     <sys:String x:Key="SettingsPage.General.AutoDetectNewGames">#NOTTRANSLATED#</sys:String>
     <sys:String x:Key="SettingsPage.General.AutoDetectNewGames.Description">#NOTTRANSLATED#</sys:String>
     <sys:String x:Key="SettingsPage.General.AutoDetectNewGames.ToolTip">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="SettingsPage.General.AutoMergeMultiDisc">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="SettingsPage.General.AutoMergeMultiDisc.Description">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="SettingsPage.General.AutoMergeMultiDisc.ToolTip">#NOTTRANSLATED#</sys:String>
 
     <!-- Loading Screen Window -->
     <sys:String x:Key="LoadingScreenWindow.LoadingText">{0} yükleniyor</sys:String>
@@ -1229,4 +1232,36 @@
     <!-- Library Page - Drag & Drop -->
     <sys:String x:Key="LibraryPage.DragDrop.Title">#NOTTRANSLATED#</sys:String>
     <sys:String x:Key="LibraryPage.DragDrop.Subtitle">#NOTTRANSLATED#</sys:String>
+
+    <!-- Multi-Disc Support -->
+    <sys:String x:Key="GameButton.ContextFlyout.EditGame.ManageDiscs.Header">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.EditGame.ManageDiscs.ToolTip">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.ManageDiscs.Error.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.ManageDiscs.Error.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="LibraryPage.GameButton.DiscCount">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="LibraryPage.MultiDisc.MergePrompt.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="LibraryPage.MultiDisc.MergePrompt.Message">#NOTTRANSLATED#</sys:String>
+
+    <!-- Disc Selection Dialog (shown when launching a multi-disc game) -->
+    <sys:String x:Key="DiscSelectionDialog.Header">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="DiscSelectionDialog.SubHeader">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="DiscSelectionDialog.Disc1">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="DiscSelectionDialog.DiscN">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="DiscSelectionDialog.LastPlayedSuffix">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="DiscSelectionDialog.MissingSuffix">#NOTTRANSLATED#</sys:String>
+
+    <!-- Manage Discs Dialog -->
+    <sys:String x:Key="ManageDiscsDialog.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.Subtitle">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.CloseButton">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.Disc1Label">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.DiscNLabel">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.AddDisc.Button">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.RemoveDisc.ToolTip">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.MissingFile">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.FilePicker.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.MissingStorageProvider.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.MissingStorageProvider.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.DuplicateDisc.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.DuplicateDisc.Message">#NOTTRANSLATED#</sys:String>
 </ResourceDictionary>

--- a/source/XeniaManager/Resources/Language/zh-CN.axaml
+++ b/source/XeniaManager/Resources/Language/zh-CN.axaml
@@ -332,6 +332,9 @@
     <sys:String x:Key="SettingsPage.General.AutoDetectNewGames">#NOTTRANSLATED#</sys:String>
     <sys:String x:Key="SettingsPage.General.AutoDetectNewGames.Description">#NOTTRANSLATED#</sys:String>
     <sys:String x:Key="SettingsPage.General.AutoDetectNewGames.ToolTip">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="SettingsPage.General.AutoMergeMultiDisc">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="SettingsPage.General.AutoMergeMultiDisc.Description">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="SettingsPage.General.AutoMergeMultiDisc.ToolTip">#NOTTRANSLATED#</sys:String>
 
     <!-- Loading Screen Window -->
     <sys:String x:Key="LoadingScreenWindow.LoadingText">正在加载 {0}</sys:String>
@@ -1229,4 +1232,36 @@
     <!-- Library Page - Drag & Drop -->
     <sys:String x:Key="LibraryPage.DragDrop.Title">将文件拖放至此处来添加游戏</sys:String>
     <sys:String x:Key="LibraryPage.DragDrop.Subtitle">支持 .iso、.xex、.zar 文件</sys:String>
+
+    <!-- Multi-Disc Support -->
+    <sys:String x:Key="GameButton.ContextFlyout.EditGame.ManageDiscs.Header">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.EditGame.ManageDiscs.ToolTip">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.ManageDiscs.Error.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.ManageDiscs.Error.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="LibraryPage.GameButton.DiscCount">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="LibraryPage.MultiDisc.MergePrompt.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="LibraryPage.MultiDisc.MergePrompt.Message">#NOTTRANSLATED#</sys:String>
+
+    <!-- Disc Selection Dialog (shown when launching a multi-disc game) -->
+    <sys:String x:Key="DiscSelectionDialog.Header">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="DiscSelectionDialog.SubHeader">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="DiscSelectionDialog.Disc1">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="DiscSelectionDialog.DiscN">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="DiscSelectionDialog.LastPlayedSuffix">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="DiscSelectionDialog.MissingSuffix">#NOTTRANSLATED#</sys:String>
+
+    <!-- Manage Discs Dialog -->
+    <sys:String x:Key="ManageDiscsDialog.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.Subtitle">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.CloseButton">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.Disc1Label">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.DiscNLabel">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.AddDisc.Button">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.RemoveDisc.ToolTip">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.MissingFile">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.FilePicker.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.MissingStorageProvider.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.MissingStorageProvider.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.DuplicateDisc.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="ManageDiscsDialog.DuplicateDisc.Message">#NOTTRANSLATED#</sys:String>
 </ResourceDictionary>

--- a/source/XeniaManager/ViewModels/Controls/ManageDiscsViewModel.cs
+++ b/source/XeniaManager/ViewModels/Controls/ManageDiscsViewModel.cs
@@ -7,6 +7,7 @@ using Avalonia.Platform.Storage;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Microsoft.Extensions.DependencyInjection;
+using XeniaManager.Core.Constants;
 using XeniaManager.Core.Logging;
 using XeniaManager.Core.Models.Game;
 using XeniaManager.Core.Utilities;
@@ -68,7 +69,7 @@ public partial class ManageDiscsViewModel : ObservableObject
         {
             DiscNumber = 1,
             Label = LocalizationHelper.GetText("ManageDiscsDialog.Disc1Label"),
-            Path = _game.FileLocations.Game,
+            Path = _game.FileLocations.ResolvedGamePath,
             IsPathValid = _game.FileLocations.IsGamePathValid
         });
 
@@ -80,7 +81,7 @@ public partial class ManageDiscsViewModel : ObservableObject
                 Label = string.IsNullOrWhiteSpace(disc.Label)
                     ? string.Format(LocalizationHelper.GetText("ManageDiscsDialog.DiscNLabel"), disc.DiscNumber)
                     : disc.Label!,
-                Path = disc.Path,
+                Path = disc.ResolvedPath,
                 IsPathValid = disc.IsPathValid
             });
         }
@@ -127,10 +128,13 @@ public partial class ManageDiscsViewModel : ObservableObject
         }
 
         string selectedPath = files[0].Path.LocalPath;
+        string resolvedSelectedPath = Path.IsPathRooted(selectedPath)
+            ? selectedPath
+            : Path.Combine(AppPaths.GamesDirectory, selectedPath);
 
         // Avoid adding the same file twice (as Disc 1 or as an existing additional disc)
-        bool alreadyAdded = _game.FileLocations.Game == selectedPath
-                            || _game.FileLocations.AdditionalDiscs.Exists(d => d.Path == selectedPath);
+        bool alreadyAdded = _game.FileLocations.ResolvedGamePath == resolvedSelectedPath
+                            || _game.FileLocations.AdditionalDiscs.Exists(d => d.ResolvedPath == resolvedSelectedPath);
         if (alreadyAdded)
         {
             Logger.Warning<ManageDiscsViewModel>($"'{selectedPath}' is already associated with '{_game.Title}'");
@@ -146,7 +150,7 @@ public partial class ManageDiscsViewModel : ObservableObject
         _game.FileLocations.AdditionalDiscs.Add(new GameDisc
         {
             DiscNumber = newDiscNumber,
-            Path = selectedPath
+            Path = Core.Manage.GameManager.GetRelativeGamePath(selectedPath)
         });
 
         LoadDiscs();
@@ -167,7 +171,7 @@ public partial class ManageDiscsViewModel : ObservableObject
 
         Logger.Info<ManageDiscsViewModel>($"Removing Disc {disc.DiscNumber} from '{_game.Title}'");
 
-        _game.FileLocations.AdditionalDiscs.RemoveAll(d => d.Path == disc.Path);
+        _game.FileLocations.AdditionalDiscs.RemoveAll(d => d.DiscNumber == disc.DiscNumber);
 
         // Renumber remaining additional discs so they stay contiguous
         for (int i = 0; i < _game.FileLocations.AdditionalDiscs.Count; i++)

--- a/source/XeniaManager/ViewModels/Controls/ManageDiscsViewModel.cs
+++ b/source/XeniaManager/ViewModels/Controls/ManageDiscsViewModel.cs
@@ -1,0 +1,207 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Avalonia.Platform.Storage;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Microsoft.Extensions.DependencyInjection;
+using XeniaManager.Core.Logging;
+using XeniaManager.Core.Models.Game;
+using XeniaManager.Core.Utilities;
+using XeniaManager.Services;
+
+namespace XeniaManager.ViewModels.Controls;
+
+/// <summary>
+/// Represents a single disc row shown in the Manage Discs dialog.
+/// Disc 1 (the main game file) is shown read-only alongside the editable additional discs.
+/// </summary>
+public partial class DiscRowViewModel : ObservableObject
+{
+    /// <summary>1-based disc number.</summary>
+    [ObservableProperty] private int _discNumber;
+
+    /// <summary>Display label (custom label if set, otherwise "Disc N").</summary>
+    [ObservableProperty] private string _label = string.Empty;
+
+    /// <summary>Full path to this disc's game file.</summary>
+    [ObservableProperty] private string _path = string.Empty;
+
+    /// <summary>Whether the file this disc points to currently exists.</summary>
+    [ObservableProperty] private bool _isPathValid;
+
+    /// <summary>Disc 1 is the main game file and can't be removed or relabeled from this dialog.</summary>
+    public bool IsRemovable => DiscNumber > 1;
+}
+
+/// <summary>
+/// ViewModel for the Manage Discs dialog, which lets users view, add, rename, and remove
+/// the discs associated with a multi-disc game.
+/// </summary>
+public partial class ManageDiscsViewModel : ObservableObject
+{
+    private readonly Game _game;
+    private readonly IMessageBoxService _messageBoxService;
+
+    /// <summary>The discs currently shown in the dialog (Disc 1 + all additional discs).</summary>
+    [ObservableProperty] private ObservableCollection<DiscRowViewModel> _discs = [];
+
+    public string GameTitle => _game.Title;
+
+    public ManageDiscsViewModel(Game game)
+    {
+        _game = game;
+        _messageBoxService = App.Services.GetRequiredService<IMessageBoxService>();
+        LoadDiscs();
+    }
+
+    /// <summary>
+    /// Rebuilds the <see cref="Discs"/> collection from the current state of the game's file locations.
+    /// </summary>
+    private void LoadDiscs()
+    {
+        Discs.Clear();
+
+        Discs.Add(new DiscRowViewModel
+        {
+            DiscNumber = 1,
+            Label = LocalizationHelper.GetText("ManageDiscsDialog.Disc1Label"),
+            Path = _game.FileLocations.Game,
+            IsPathValid = _game.FileLocations.IsGamePathValid
+        });
+
+        foreach (GameDisc disc in _game.FileLocations.AdditionalDiscs)
+        {
+            Discs.Add(new DiscRowViewModel
+            {
+                DiscNumber = disc.DiscNumber,
+                Label = string.IsNullOrWhiteSpace(disc.Label)
+                    ? string.Format(LocalizationHelper.GetText("ManageDiscsDialog.DiscNLabel"), disc.DiscNumber)
+                    : disc.Label!,
+                Path = disc.Path,
+                IsPathValid = disc.IsPathValid
+            });
+        }
+    }
+
+    /// <summary>
+    /// Opens a file picker and adds the selected file as a new additional disc.
+    /// </summary>
+    [RelayCommand]
+    private async Task AddDiscAsync()
+    {
+        IStorageProvider? storageProvider = App.MainWindow?.StorageProvider;
+        if (storageProvider == null)
+        {
+            Logger.Warning<ManageDiscsViewModel>("Storage provider is not available");
+            await _messageBoxService.ShowErrorAsync(
+                LocalizationHelper.GetText("ManageDiscsDialog.MissingStorageProvider.Title"),
+                LocalizationHelper.GetText("ManageDiscsDialog.MissingStorageProvider.Message"));
+            return;
+        }
+
+        FilePickerOpenOptions options = new FilePickerOpenOptions
+        {
+            Title = LocalizationHelper.GetText("ManageDiscsDialog.FilePicker.Title"),
+            AllowMultiple = false,
+            FileTypeFilter = new List<FilePickerFileType>
+            {
+                new FilePickerFileType("Game Files")
+                {
+                    Patterns = ["*.iso", "*.xex", "*.zar"]
+                },
+                new FilePickerFileType("All Files")
+                {
+                    Patterns = ["*.*"]
+                }
+            }
+        };
+
+        IReadOnlyList<IStorageFile> files = await storageProvider.OpenFilePickerAsync(options);
+        if (files.Count == 0)
+        {
+            Logger.Debug<ManageDiscsViewModel>("Add disc selection canceled by user");
+            return;
+        }
+
+        string selectedPath = files[0].Path.LocalPath;
+
+        // Avoid adding the same file twice (as Disc 1 or as an existing additional disc)
+        bool alreadyAdded = _game.FileLocations.Game == selectedPath
+                            || _game.FileLocations.AdditionalDiscs.Exists(d => d.Path == selectedPath);
+        if (alreadyAdded)
+        {
+            Logger.Warning<ManageDiscsViewModel>($"'{selectedPath}' is already associated with '{_game.Title}'");
+            await _messageBoxService.ShowWarningAsync(
+                LocalizationHelper.GetText("ManageDiscsDialog.DuplicateDisc.Title"),
+                LocalizationHelper.GetText("ManageDiscsDialog.DuplicateDisc.Message"));
+            return;
+        }
+
+        int newDiscNumber = _game.FileLocations.DiscCount + 1;
+        Logger.Info<ManageDiscsViewModel>($"Adding Disc {newDiscNumber} for '{_game.Title}': {selectedPath}");
+
+        _game.FileLocations.AdditionalDiscs.Add(new GameDisc
+        {
+            DiscNumber = newDiscNumber,
+            Path = selectedPath
+        });
+
+        LoadDiscs();
+    }
+
+    /// <summary>
+    /// Removes the given disc from the game. Disc 1 can't be removed this way.
+    /// Renumbers the remaining additional discs to stay contiguous (2, 3, 4, ...).
+    /// </summary>
+    [RelayCommand]
+    private void RemoveDisc(DiscRowViewModel disc)
+    {
+        if (disc.DiscNumber <= 1)
+        {
+            Logger.Warning<ManageDiscsViewModel>("Attempted to remove Disc 1, which is not allowed");
+            return;
+        }
+
+        Logger.Info<ManageDiscsViewModel>($"Removing Disc {disc.DiscNumber} from '{_game.Title}'");
+
+        _game.FileLocations.AdditionalDiscs.RemoveAll(d => d.Path == disc.Path);
+
+        // Renumber remaining additional discs so they stay contiguous
+        for (int i = 0; i < _game.FileLocations.AdditionalDiscs.Count; i++)
+        {
+            _game.FileLocations.AdditionalDiscs[i].DiscNumber = i + 2;
+        }
+
+        // Reset LastPlayedDisc if it no longer exists
+        if (_game.LastPlayedDisc > _game.FileLocations.DiscCount)
+        {
+            _game.LastPlayedDisc = 1;
+        }
+
+        LoadDiscs();
+    }
+
+    /// <summary>
+    /// Updates the custom label for an additional disc (Disc 2+).
+    /// </summary>
+    /// <param name="discNumber">1-based disc number being relabeled.</param>
+    /// <param name="newLabel">The new label text.</param>
+    public void UpdateDiscLabel(int discNumber, string newLabel)
+    {
+        if (discNumber <= 1)
+        {
+            return;
+        }
+
+        int index = discNumber - 2;
+        if (index < 0 || index >= _game.FileLocations.AdditionalDiscs.Count)
+        {
+            return;
+        }
+
+        _game.FileLocations.AdditionalDiscs[index].Label = string.IsNullOrWhiteSpace(newLabel) ? null : newLabel;
+    }
+}

--- a/source/XeniaManager/ViewModels/Items/GameItemViewModel.cs
+++ b/source/XeniaManager/ViewModels/Items/GameItemViewModel.cs
@@ -46,6 +46,8 @@ public partial class GameItemViewModel : ViewModelBase
     public bool IsXeniaMousehook => Game.XeniaVersion == XeniaVersion.Mousehook;
 
     public bool InstalledPatches => !string.IsNullOrEmpty(Game.FileLocations.Patch);
+    public bool IsMultiDisc => Game.FileLocations.IsMultiDisc;
+    public int DiscCount => Game.FileLocations.DiscCount;
 
     // Cached result to avoid repeated platform checks
     private static readonly bool _supportsShortcuts = PlatformUtilities.IsNativeWindows();
@@ -72,10 +74,25 @@ public partial class GameItemViewModel : ViewModelBase
             return;
         }
 
+        // For multi-disc games, ask the user which disc to launch before proceeding
+        int discNumber = 1;
+        if (Game.FileLocations.IsMultiDisc)
+        {
+            Logger.Info<GameItemViewModel>($"{Game.Title} has {Game.FileLocations.DiscCount} discs, showing disc selection dialog");
+            int? selectedDisc = await DiscSelectionDialog.ShowAsync(Game);
+            if (selectedDisc == null)
+            {
+                Logger.Info<GameItemViewModel>("Disc selection cancelled, aborting launch");
+                return;
+            }
+
+            discNumber = selectedDisc.Value;
+        }
+
         LoadingScreenWindow? loadingScreen = null;
         try
         {
-            Logger.Info<GameItemViewModel>($"Launching {Game.Title}...");
+            Logger.Info<GameItemViewModel>($"Launching {Game.Title} (Disc {discNumber}/{Game.FileLocations.DiscCount})...");
 
             // Check if the loading screen should be shown
             bool showLoadingScreen = _settings.Settings.Ui.Window.LoadingScreen;
@@ -108,7 +125,7 @@ public partial class GameItemViewModel : ViewModelBase
             }
 
             EventManager.Instance.DisableWindow();
-            await Launcher.LaunchGameASync(Game, _settings, onGameLoadingStarted: onGameLoadingStarted);
+            await Launcher.LaunchGameASync(Game, _settings, onGameLoadingStarted: onGameLoadingStarted, discNumber: discNumber);
             EventManager.Instance.EnableWindow();
         }
         catch (Exception ex)
@@ -738,6 +755,35 @@ public partial class GameItemViewModel : ViewModelBase
             await _messageBoxService.ShowErrorAsync(
                 LocalizationHelper.GetText("GameButton.ContextFlyout.EditGame.Information.Error.Title"),
                 string.Format(LocalizationHelper.GetText("GameButton.ContextFlyout.EditGame.Information.Error.Message"), ex.Message));
+        }
+    }
+
+    [RelayCommand]
+    private async Task ManageDiscs()
+    {
+        Logger.Info<GameItemViewModel>($"Opening Manage Discs dialog for: '{Game.Title}'");
+
+        try
+        {
+            await ManageDiscsDialog.ShowAsync(Game);
+
+            // Persist any disc additions/removals/relabeling made in the dialog
+            GameManager.SaveLibrary();
+
+            // Refresh derived properties (IsMultiDisc, DiscCount) and the library UI
+            OnPropertyChanged(nameof(IsMultiDisc));
+            OnPropertyChanged(nameof(DiscCount));
+            _library.RefreshLibrary();
+
+            Logger.Info<GameItemViewModel>($"Manage Discs dialog closed for: '{Game.Title}', now has {Game.FileLocations.DiscCount} disc(s)");
+        }
+        catch (Exception ex)
+        {
+            Logger.Error<GameItemViewModel>($"Failed to manage discs for: '{Game.Title}'");
+            Logger.LogExceptionDetails<GameItemViewModel>(ex);
+            await _messageBoxService.ShowErrorAsync(
+                LocalizationHelper.GetText("GameButton.ContextFlyout.ManageDiscs.Error.Title"),
+                string.Format(LocalizationHelper.GetText("GameButton.ContextFlyout.ManageDiscs.Error.Message"), ex.Message));
         }
     }
 

--- a/source/XeniaManager/ViewModels/Pages/LibraryPageViewModel.cs
+++ b/source/XeniaManager/ViewModels/Pages/LibraryPageViewModel.cs
@@ -444,7 +444,9 @@ public partial class LibraryPageViewModel : ViewModelBase
                                 GameInfo gameInfo = XboxDatabase.FilteredDatabase[0];
                                 await GameManager.AddGame(xeniaVersion, gameInfo, gameFile, details,
                                     _settings.Settings.General.UseMediaIdForTitle,
-                                    confirmMultiDiscMerge: _ => Task.FromResult(true));
+                                    confirmMultiDiscMerge: _settings.Settings.General.AutoMergeMultiDisc
+                                        ? _ => Task.FromResult(true)
+                                        : ConfirmMultiDiscMergeAsync);
                             }
                             else
                             {
@@ -721,7 +723,9 @@ public partial class LibraryPageViewModel : ViewModelBase
                         {
                             // Add the game using fetched GameInfo
                             GameInfo gameInfo = XboxDatabase.FilteredDatabase[0];
-                            await GameManager.AddGame(xeniaVersion, gameInfo, gameFile, details, _settings.Settings.General.UseMediaIdForTitle, confirmMultiDiscMerge: ConfirmMultiDiscMergeAsync);
+                            await GameManager.AddGame(xeniaVersion, gameInfo, gameFile, details, _settings.Settings.General.UseMediaIdForTitle, confirmMultiDiscMerge: _settings.Settings.General.AutoMergeMultiDisc
+                                ? _ => Task.FromResult(true)
+                                : ConfirmMultiDiscMergeAsync);
                         }
                         else
                         {

--- a/source/XeniaManager/ViewModels/Pages/LibraryPageViewModel.cs
+++ b/source/XeniaManager/ViewModels/Pages/LibraryPageViewModel.cs
@@ -444,7 +444,7 @@ public partial class LibraryPageViewModel : ViewModelBase
                                 GameInfo gameInfo = XboxDatabase.FilteredDatabase[0];
                                 await GameManager.AddGame(xeniaVersion, gameInfo, gameFile, details,
                                     _settings.Settings.General.UseMediaIdForTitle,
-                                    confirmMultiDiscMerge: _ => Task.FromResult(true));
+                                    confirmMultiDiscMerge: ConfirmMultiDiscMergeAsync);
                             }
                             else
                             {

--- a/source/XeniaManager/ViewModels/Pages/LibraryPageViewModel.cs
+++ b/source/XeniaManager/ViewModels/Pages/LibraryPageViewModel.cs
@@ -442,7 +442,9 @@ public partial class LibraryPageViewModel : ViewModelBase
                             if (XboxDatabase.FilteredDatabase.Count == 1)
                             {
                                 GameInfo gameInfo = XboxDatabase.FilteredDatabase[0];
-                                await GameManager.AddGame(xeniaVersion, gameInfo, gameFile, details, _settings.Settings.General.UseMediaIdForTitle);
+                                await GameManager.AddGame(xeniaVersion, gameInfo, gameFile, details,
+                                    _settings.Settings.General.UseMediaIdForTitle,
+                                    confirmMultiDiscMerge: _ => Task.FromResult(true));
                             }
                             else
                             {
@@ -888,11 +890,11 @@ public partial class LibraryPageViewModel : ViewModelBase
     private async Task<bool> ConfirmMultiDiscMergeAsync(Game existingGame)
     {
         Logger.Info<LibraryPageViewModel>($"Prompting user to confirm multi-disc merge into '{existingGame.Title}'");
-
+        EventManager.Instance.EnableWindow();
         bool confirmed = await _messageBoxService.ShowConfirmationAsync(
             LocalizationHelper.GetText("LibraryPage.MultiDisc.MergePrompt.Title"),
             string.Format(LocalizationHelper.GetText("LibraryPage.MultiDisc.MergePrompt.Message"), existingGame.Title));
-
+        EventManager.Instance.DisableWindow();
         Logger.Info<LibraryPageViewModel>(confirmed
             ? $"User confirmed merging into '{existingGame.Title}'"
             : $"User declined merging into '{existingGame.Title}', will add as separate entry");

--- a/source/XeniaManager/ViewModels/Pages/LibraryPageViewModel.cs
+++ b/source/XeniaManager/ViewModels/Pages/LibraryPageViewModel.cs
@@ -719,7 +719,7 @@ public partial class LibraryPageViewModel : ViewModelBase
                         {
                             // Add the game using fetched GameInfo
                             GameInfo gameInfo = XboxDatabase.FilteredDatabase[0];
-                            await GameManager.AddGame(xeniaVersion, gameInfo, gameFile, details, _settings.Settings.General.UseMediaIdForTitle);
+                            await GameManager.AddGame(xeniaVersion, gameInfo, gameFile, details, _settings.Settings.General.UseMediaIdForTitle, confirmMultiDiscMerge: ConfirmMultiDiscMergeAsync);
                         }
                         else
                         {
@@ -879,6 +879,28 @@ public partial class LibraryPageViewModel : ViewModelBase
     }
 
     /// <summary>
+    /// Asks the user whether a newly detected game file should be merged into an existing
+    /// library entry as an additional disc, since it shares the same Title ID (e.g. Disc 2 of a
+    /// multi-disc game like Blue Dragon).
+    /// </summary>
+    /// <param name="existingGame">The existing library entry the new file could be merged into.</param>
+    /// <returns>True if the user confirmed the merge, false to add it as a separate entry instead.</returns>
+    private async Task<bool> ConfirmMultiDiscMergeAsync(Game existingGame)
+    {
+        Logger.Info<LibraryPageViewModel>($"Prompting user to confirm multi-disc merge into '{existingGame.Title}'");
+
+        bool confirmed = await _messageBoxService.ShowConfirmationAsync(
+            LocalizationHelper.GetText("LibraryPage.MultiDisc.MergePrompt.Title"),
+            string.Format(LocalizationHelper.GetText("LibraryPage.MultiDisc.MergePrompt.Message"), existingGame.Title));
+
+        Logger.Info<LibraryPageViewModel>(confirmed
+            ? $"User confirmed merging into '{existingGame.Title}'"
+            : $"User declined merging into '{existingGame.Title}', will add as separate entry");
+
+        return confirmed;
+    }
+
+    /// <summary>
     /// Processes a list of file paths and adds them as games to the library.
     /// </summary>
     private async Task ProcessAndAddGamesAsync(List<string> filePaths, XeniaVersion xeniaVersion)
@@ -932,7 +954,7 @@ public partial class LibraryPageViewModel : ViewModelBase
                     if (XboxDatabase.FilteredDatabase.Count == 1)
                     {
                         GameInfo gameInfo = XboxDatabase.FilteredDatabase[0];
-                        await GameManager.AddGame(xeniaVersion, gameInfo, filePath, details, _settings.Settings.General.UseMediaIdForTitle);
+                        await GameManager.AddGame(xeniaVersion, gameInfo, filePath, details, _settings.Settings.General.UseMediaIdForTitle, confirmMultiDiscMerge: ConfirmMultiDiscMergeAsync);
                     }
                     else
                     {

--- a/source/XeniaManager/ViewModels/Pages/LibraryPageViewModel.cs
+++ b/source/XeniaManager/ViewModels/Pages/LibraryPageViewModel.cs
@@ -444,7 +444,7 @@ public partial class LibraryPageViewModel : ViewModelBase
                                 GameInfo gameInfo = XboxDatabase.FilteredDatabase[0];
                                 await GameManager.AddGame(xeniaVersion, gameInfo, gameFile, details,
                                     _settings.Settings.General.UseMediaIdForTitle,
-                                    confirmMultiDiscMerge: ConfirmMultiDiscMergeAsync);
+                                    confirmMultiDiscMerge: _ => Task.FromResult(true));
                             }
                             else
                             {
@@ -755,7 +755,7 @@ public partial class LibraryPageViewModel : ViewModelBase
 
             // Refresh the library to update the UI with newly added games
             RefreshLibrary();
-
+            EventManager.Instance.EnableWindow();
             // Show results
             if (gamesAdded > 0)
             {

--- a/source/XeniaManager/ViewModels/Pages/SettingsPageViewModel.cs
+++ b/source/XeniaManager/ViewModels/Pages/SettingsPageViewModel.cs
@@ -83,6 +83,18 @@ public partial class SettingsPageViewModel : ViewModelBase
         }
     }
 
+    [ObservableProperty] private bool autoMergeMultiDisc;
+    partial void OnAutoMergeMultiDiscChanged(bool oldValue, bool newValue)
+    {
+        if (oldValue == newValue)
+        {
+            return;
+        }
+        Logger.Info<SettingsPageViewModel>($"Auto Merge Multi-Disc changed from '{oldValue}' to '{newValue}'");
+        _settings.Settings.General.AutoMergeMultiDisc = newValue;
+        _settings.SaveSettings();
+    }
+
     // UI Settings
     // Language settings
     public ObservableCollection<LanguageItem> AppLanguages { get; set; } = [];
@@ -253,6 +265,7 @@ public partial class SettingsPageViewModel : ViewModelBase
         CheckForUpdatesOnStartup = _settings.Settings.UpdateChecks.CheckForUpdatesOnStartup;
         UseMediaIdForTitle = _settings.Settings.General.UseMediaIdForTitle;
         AutoDetectNewGames = _settings.Settings.General.AutoDetectNewGames;
+        AutoMergeMultiDisc = _settings.Settings.General.AutoMergeMultiDisc;
 
         // Load supported languages & selected language
         CultureInfo[] supportedCultures = LocalizationHelper.GetSupportedLanguages();

--- a/source/XeniaManager/Views/Pages/LibraryPage.axaml
+++ b/source/XeniaManager/Views/Pages/LibraryPage.axaml
@@ -264,6 +264,20 @@
                                                        FontWeight="Bold"
                                                        Margin="4,0,0,0" />
                                         </StackPanel>
+
+                                        <!-- Multi-Disc Indicator -->
+                                        <StackPanel Orientation="Horizontal"
+                                                    HorizontalAlignment="Center"
+                                                    Margin="0,4,0,0"
+                                                    IsVisible="{Binding IsMultiDisc}">
+                                            <icons:SymbolIcon Symbol="Games"
+                                                               FontSize="14"
+                                                               VerticalAlignment="Center" />
+                                            <TextBlock Text="{Binding DiscCount, Converter={StaticResource DiscCountConverter}}"
+                                                       FontWeight="Bold"
+                                                       VerticalAlignment="Center"
+                                                       Margin="4,0,0,0" />
+                                        </StackPanel>
                                     </StackPanel>
                                 </ToolTip>
                             </ToolTip.Tip>
@@ -443,6 +457,16 @@
                                             </MenuItem.Icon>
                                             <ToolTip.Tip>
                                                 <TextBlock Text="{DynamicResource GameButton.ContextFlyout.EditGame.Settings.ToolTip}" />
+                                            </ToolTip.Tip>
+                                        </MenuItem>
+                                        <!-- Manage Discs -->
+                                        <MenuItem Header="{DynamicResource GameButton.ContextFlyout.EditGame.ManageDiscs.Header}"
+                                                  Command="{Binding ManageDiscsCommand}">
+                                            <MenuItem.Icon>
+                                                <icons:SymbolIcon Symbol="Games" />
+                                            </MenuItem.Icon>
+                                            <ToolTip.Tip>
+                                                <TextBlock Text="{DynamicResource GameButton.ContextFlyout.EditGame.ManageDiscs.ToolTip}" />
                                             </ToolTip.Tip>
                                         </MenuItem>
                                     </MenuItem>

--- a/source/XeniaManager/Views/Pages/SettingsPage.axaml
+++ b/source/XeniaManager/Views/Pages/SettingsPage.axaml
@@ -47,6 +47,12 @@
                                             ToolTip.Tip="{DynamicResource SettingsPage.General.AutoDetectNewGames.ToolTip}"
                                             Icon="Scan"
                                             IsChecked="{Binding AutoDetectNewGames, Mode=TwoWay}" />
+                    <!-- Auto Merge Multi-Disc -->
+                    <cards:ToggleSwitchCard Title="{DynamicResource SettingsPage.General.AutoMergeMultiDisc}"
+                                            Description="{DynamicResource SettingsPage.General.AutoMergeMultiDisc.Description}"
+                                            ToolTip.Tip="{DynamicResource SettingsPage.General.AutoMergeMultiDisc.ToolTip}"
+                                            Icon="Games"
+                                            IsChecked="{Binding AutoMergeMultiDisc, Mode=TwoWay}" />
                 </StackPanel>
             </Expander>
             <!-- UI Settings -->

--- a/source/XeniaManager/XeniaManager.csproj
+++ b/source/XeniaManager/XeniaManager.csproj
@@ -28,5 +28,8 @@
       <Compile Update="Controls\EditXConfigDialog.axaml.cs">
         <DependentUpon>EditXConfigDialog.axaml</DependentUpon>
       </Compile>
+      <Compile Update="Controls\ManageDiscsDialog.axaml.cs">
+        <DependentUpon>ManageDiscsDialog.axaml</DependentUpon>
+      </Compile>
     </ItemGroup>
 </Project>

--- a/tests/XeniaManager.Tests/ArgumentParserTests.cs
+++ b/tests/XeniaManager.Tests/ArgumentParserTests.cs
@@ -71,4 +71,46 @@ public class ArgumentParserTests
         // Result may have trailing space; trim for assertion
         Assert.AreEqual("--fullscreen --debug", result!.Trim());
     }
+
+    [Test]
+    public void GetDiscFromArgs_Flag_ReturnsDiscNumber()
+    {
+        string[] args = ["--game", "\"TestGame\"", "--disc", "2"];
+        int? result = ArgumentParser.GetDiscFromArgs(args);
+        Assert.IsNotNull(result);
+        Assert.AreEqual(2, result);
+    }
+
+    [Test]
+    public void GetDiscFromArgs_ShortAlias_ReturnsDiscNumber()
+    {
+        string[] args = ["-d", "3"];
+        int? result = ArgumentParser.GetDiscFromArgs(args);
+        Assert.IsNotNull(result);
+        Assert.AreEqual(3, result);
+    }
+
+    [Test]
+    public void GetDiscFromArgs_Missing_ReturnsNull()
+    {
+        string[] args = ["--game", "\"TestGame\""];
+        int? result = ArgumentParser.GetDiscFromArgs(args);
+        Assert.IsNull(result);
+    }
+
+    [Test]
+    public void GetDiscFromArgs_InvalidValue_ReturnsNull()
+    {
+        string[] args = ["--disc", "notanumber"];
+        int? result = ArgumentParser.GetDiscFromArgs(args);
+        Assert.IsNull(result);
+    }
+
+    [Test]
+    public void GetDiscFromArgs_ZeroOrNegative_ReturnsNull()
+    {
+        string[] args = ["--disc", "0"];
+        int? result = ArgumentParser.GetDiscFromArgs(args);
+        Assert.IsNull(result);
+    }
 }


### PR DESCRIPTION
## Summary
Adds support for multi-disc games (e.g. Blue Dragon's 3 discs), which
today show up as separate, unrelated library entries with no way to
group them or remember which disc to launch.

## Changes
- **Model**: extended `GameFiles` with `AdditionalDiscs`/`GameDisc` to
  hold extra discs, keeping the existing `Game` field as Disc 1 for
  backward compatibility with existing `library.json` files. Added
  `LastPlayedDisc` to `Game` to remember the last disc launched.
- **Launcher**: `LaunchGameASync`/`LaunchGame` now accept an optional
  `discNumber` parameter to launch a specific disc.
- **Automatic detection**: `GameManager.AddGame` now checks for an
  existing library entry with the same Title ID before creating a new
  one, and (via an optional confirmation callback) offers to merge the
  new file as an additional disc instead.
- **Disc selection on launch**: new `DiscSelectionDialog` (same
  TaskDialog style as the existing Xenia version selector) shown when
  pressing Play on a multi-disc game. Highlights the last disc played
  and flags any disc whose file is missing.
- **Manual management**: new "Manage Discs" option in the game's
  right-click context menu, opening a `ManageDiscsDialog` to add,
  rename, or remove discs at any time.
- **Library UI**: multi-disc games show a "N Discs" indicator in the
  card tooltip.
- Full English localization for all new strings (Italian translation
  will follow separately once PR #541 is merged, to avoid touching
  `it.axaml` in two places at once).

## Testing
Compiled and tested locally with `dotnet run`:
- Added Blue Dragon's 3 discs — the 2nd and 3rd were correctly detected
  and merged into the same library entry after confirmation.
- Disc selection popup on Play shows all 3 discs correctly.
- Manage Discs dialog correctly adds/removes/relabels discs and persists
  changes.
- Verified existing single-disc games are unaffected (Disc 1 path is
  used exactly as before when no additional discs are present).

Screenshots attached showing the merged library entry, the automatic
merge prompt, the disc selection popup, and the Manage Discs dialog.

Open to feedback on the approach/UX — happy to adjust based on review.

<img width="887" height="876" alt="Screenshot 2026-07-04 165029" src="https://github.com/user-attachments/assets/3869fd72-b2a4-4fa3-ab3a-cac84061a50b" />
<img width="887" height="845" alt="Screenshot 2026-07-04 162937" src="https://github.com/user-attachments/assets/fda14a5c-7f9e-4042-93c5-90ff03b2da47" />
<img width="887" height="845" alt="Screenshot 2026-07-04 163003" src="https://github.com/user-attachments/assets/e4ceddf6-9c4c-44b4-9360-31d0c6befe94" />
<img width="887" height="845" alt="Screenshot 2026-07-04 163020" src="https://github.com/user-attachments/assets/51068544-a688-4ee3-b9e9-5ca30b0d0014" />
<img width="887" height="876" alt="Screenshot 2026-07-04 164950" src="https://github.com/user-attachments/assets/5575e795-2851-44c5-83e9-f6fa278264e2" />
