### PR TITLE
refactor(themes): Deduplicated code for `ThemeDisplayItem` option

### DIFF
--- a/source/XeniaManager/Controls/WelcomeDialog.axaml
+++ b/source/XeniaManager/Controls/WelcomeDialog.axaml
@@ -1,21 +1,26 @@
-<UserControl xmlns="https://github.com/avaloniaui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:vm="using:XeniaManager.ViewModels.Controls"
-             xmlns:cards="using:XeniaManager.Controls.Cards"
-             mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="150"
-             x:Class="XeniaManager.Controls.WelcomeDialog"
-             x:DataType="vm:WelcomeDialogViewModel"
-             Width="400">
+<UserControl
+    Width="400"
+    d:DesignHeight="150"
+    d:DesignWidth="400"
+    mc:Ignorable="d"
+    x:Class="XeniaManager.Controls.WelcomeDialog"
+    x:DataType="vm:WelcomeDialogViewModel"
+    xmlns="https://github.com/avaloniaui"
+    xmlns:cards="using:XeniaManager.Controls.Cards"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:vm="using:XeniaManager.ViewModels.Controls"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <cards:CustomCard>
         <StackPanel Spacing="16">
-            <TextBlock Text="{DynamicResource WelcomeDialog.Description}"
-                       TextWrapping="Wrap"
-                       FontSize="14" />
-            <ComboBox ItemsSource="{Binding ThemeOptions}"
-                      SelectedIndex="{Binding SelectedThemeIndex, Mode=TwoWay}"
-                      HorizontalAlignment="Stretch" />
+            <TextBlock
+                FontSize="14"
+                Text="{DynamicResource WelcomeDialog.Description}"
+                TextWrapping="Wrap" />
+            <ComboBox
+                HorizontalAlignment="Stretch"
+                ItemsSource="{Binding AppThemeOptions}"
+                SelectedIndex="{Binding SelectedThemeIndex, Mode=TwoWay}" />
         </StackPanel>
     </cards:CustomCard>
 </UserControl>

--- a/source/XeniaManager/Controls/WelcomeDialog.axaml
+++ b/source/XeniaManager/Controls/WelcomeDialog.axaml
@@ -1,16 +1,13 @@
-<UserControl
-    Width="400"
-    d:DesignHeight="150"
-    d:DesignWidth="400"
-    mc:Ignorable="d"
-    x:Class="XeniaManager.Controls.WelcomeDialog"
-    x:DataType="vm:WelcomeDialogViewModel"
-    xmlns="https://github.com/avaloniaui"
-    xmlns:cards="using:XeniaManager.Controls.Cards"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:vm="using:XeniaManager.ViewModels.Controls"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:XeniaManager.ViewModels.Controls"
+             xmlns:cards="using:XeniaManager.Controls.Cards"
+             mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="150"
+             x:Class="XeniaManager.Controls.WelcomeDialog"
+             x:DataType="vm:WelcomeDialogViewModel"
+             Width="400">
     <cards:CustomCard>
         <StackPanel Spacing="16">
             <TextBlock Text="{DynamicResource WelcomeDialog.Description}"

--- a/source/XeniaManager/Controls/WelcomeDialog.axaml
+++ b/source/XeniaManager/Controls/WelcomeDialog.axaml
@@ -13,14 +13,12 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <cards:CustomCard>
         <StackPanel Spacing="16">
-            <TextBlock
-                FontSize="14"
-                Text="{DynamicResource WelcomeDialog.Description}"
-                TextWrapping="Wrap" />
-            <ComboBox
-                HorizontalAlignment="Stretch"
-                ItemsSource="{Binding AppThemeOptions}"
-                SelectedIndex="{Binding SelectedThemeIndex, Mode=TwoWay}" />
+            <TextBlock Text="{DynamicResource WelcomeDialog.Description}"
+                       TextWrapping="Wrap"
+                       FontSize="14" />
+            <ComboBox ItemsSource="{Binding AppThemeOptions}"
+                      SelectedIndex="{Binding SelectedThemeIndex, Mode=TwoWay}"
+                      HorizontalAlignment="Stretch" />
         </StackPanel>
     </cards:CustomCard>
 </UserControl>

--- a/source/XeniaManager/Services/ThemeService.cs
+++ b/source/XeniaManager/Services/ThemeService.cs
@@ -1,11 +1,14 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using Avalonia;
 using Avalonia.Markup.Xaml.Styling;
 using Avalonia.Styling;
 using FluentAvalonia.Styling;
 using XeniaManager.Core.Logging;
 using XeniaManager.Core.Models;
+using XeniaManager.Core.Models.Items;
+using XeniaManager.Core.Utilities;
 
 namespace XeniaManager.Services;
 
@@ -16,6 +19,7 @@ public class ThemeService
 {
     private Theme _currentTheme = Theme.Dark;
     private FluentAvaloniaTheme? _faTheme;
+    private ObservableCollection<ThemeDisplayItem>? _themeDisplayItems;
     private readonly Dictionary<Theme, ResourceInclude?> _themeResources = new Dictionary<Theme, ResourceInclude?>();
 
     private readonly Dictionary<Theme, ThemeConfiguration> _themeConfigs = new Dictionary<Theme, ThemeConfiguration>
@@ -31,9 +35,10 @@ public class ThemeService
             BaseTheme = ThemeVariant.Dark,
             ResourcePath = "avares://XeniaManager/Resources/Themes/Dark.axaml",
             FallbackTheme = null
-        }
+        },
         // New themes need to be added here
     };
+    public ObservableCollection<ThemeDisplayItem> ThemeDisplayItems => _themeDisplayItems ??= CreateThemeDisplayItems();
 
     private class ThemeConfiguration
     {
@@ -62,6 +67,24 @@ public class ThemeService
             _faTheme = faTheme;
             break;
         }
+    }
+    
+    /// <summary>
+    /// Create the observable collection accessed by dropdown menus for theme selection in the application
+    /// </summary>
+    /// <returns>Observable List of all available Theme Display Items</returns>
+    private ObservableCollection<ThemeDisplayItem> CreateThemeDisplayItems()
+    {
+        var items = new ObservableCollection<ThemeDisplayItem>();
+        foreach (var theme in _themeConfigs.Keys)
+        {
+            items.Add(new ThemeDisplayItem
+            {
+                DisplayName = LocalizationHelper.GetText($"SettingsPage.Ui.Theme.Option.{theme}"),
+                ThemeValue = theme
+            });
+        }
+        return items;
     }
 
     /// <summary>

--- a/source/XeniaManager/Services/ThemeService.cs
+++ b/source/XeniaManager/Services/ThemeService.cs
@@ -19,7 +19,7 @@ public class ThemeService
 {
     private Theme _currentTheme = Theme.Dark;
     private FluentAvaloniaTheme? _faTheme;
-    private ObservableCollection<ThemeDisplayItem>? _themeDisplayItems;
+    private ReadOnlyObservableCollection<ThemeDisplayItem>? _themeDisplayItems;
     private readonly Dictionary<Theme, ResourceInclude?> _themeResources = new Dictionary<Theme, ResourceInclude?>();
 
     private readonly Dictionary<Theme, ThemeConfiguration> _themeConfigs = new Dictionary<Theme, ThemeConfiguration>
@@ -35,10 +35,12 @@ public class ThemeService
             BaseTheme = ThemeVariant.Dark,
             ResourcePath = "avares://XeniaManager/Resources/Themes/Dark.axaml",
             FallbackTheme = null
-        },
+        }
         // New themes need to be added here
     };
-    public ObservableCollection<ThemeDisplayItem> ThemeDisplayItems => _themeDisplayItems ??= CreateThemeDisplayItems();
+    
+    public ReadOnlyObservableCollection<ThemeDisplayItem> ThemeDisplayItems => _themeDisplayItems ??= CreateThemeDisplayItems();
+
 
     private class ThemeConfiguration
     {
@@ -72,11 +74,14 @@ public class ThemeService
     /// <summary>
     /// Create the observable collection accessed by dropdown menus for theme selection in the application
     /// </summary>
-    /// <returns>Observable List of all available Theme Display Items</returns>
-    private ObservableCollection<ThemeDisplayItem> CreateThemeDisplayItems()
+    /// <returns>Read Only Observable List of all available Theme Display Items</returns>
+    private ReadOnlyObservableCollection<ThemeDisplayItem> CreateThemeDisplayItems()
     {
-        var items = new ObservableCollection<ThemeDisplayItem>();
-        foreach (var theme in _themeConfigs.Keys)
+        ObservableCollection<ThemeDisplayItem> items = new ObservableCollection<ThemeDisplayItem>();
+        List<Theme> themes = new List<Theme>(_themeConfigs.Keys);
+        themes.Sort();
+        
+        foreach (Theme theme in themes)
         {
             items.Add(new ThemeDisplayItem
             {
@@ -84,7 +89,8 @@ public class ThemeService
                 ThemeValue = theme
             });
         }
-        return items;
+        _themeDisplayItems = new ReadOnlyObservableCollection<ThemeDisplayItem>(items);    
+        return _themeDisplayItems;
     }
 
     /// <summary>

--- a/source/XeniaManager/ViewModels/Controls/WelcomeDialogViewModel.cs
+++ b/source/XeniaManager/ViewModels/Controls/WelcomeDialogViewModel.cs
@@ -29,19 +29,7 @@ public partial class WelcomeDialogViewModel : ViewModelBase
     /// <summary>
     /// The list of available themes for selection.
     /// </summary>
-    public ObservableCollection<ThemeDisplayItem> ThemeOptions { get; set; } =
-    [
-        new ThemeDisplayItem
-        {
-            DisplayName = LocalizationHelper.GetText("SettingsPage.Ui.Theme.Option.Light"),
-            ThemeValue = Theme.Light
-        },
-        new ThemeDisplayItem
-        {
-            DisplayName = LocalizationHelper.GetText("SettingsPage.Ui.Theme.Option.Dark"),
-            ThemeValue = Theme.Dark
-        }
-    ];
+    public ObservableCollection<ThemeDisplayItem> AppThemeOptions { get; private set; }
 
     /// <summary>
     /// The currently selected theme.
@@ -55,12 +43,12 @@ public partial class WelcomeDialogViewModel : ViewModelBase
 
     partial void OnSelectedThemeIndexChanged(int oldValue, int newValue)
     {
-        if (newValue < 0 || newValue >= ThemeOptions.Count || newValue == oldValue)
+        if (newValue < 0 || newValue >= AppThemeOptions.Count || newValue == oldValue)
         {
             return;
         }
 
-        SelectedTheme = ThemeOptions[newValue].ThemeValue;
+        SelectedTheme = AppThemeOptions[newValue].ThemeValue;
         _themeService.SetTheme(SelectedTheme);
         Logger.Info<WelcomeDialogViewModel>($"Theme preview changed to {SelectedTheme}");
     }
@@ -73,10 +61,12 @@ public partial class WelcomeDialogViewModel : ViewModelBase
         _themeService = App.Services.GetRequiredService<ThemeService>();
         _settings = App.Services.GetRequiredService<Settings>();
 
+        AppThemeOptions = _themeService.ThemeDisplayItems;
+
         SelectedTheme = _settings.Settings.Ui.Theme;
-        for (int i = 0; i < ThemeOptions.Count; i++)
+        for (int i = 0; i < AppThemeOptions.Count; i++)
         {
-            if (ThemeOptions[i].ThemeValue == SelectedTheme)
+            if (AppThemeOptions[i].ThemeValue == SelectedTheme)
             {
                 SelectedThemeIndex = i;
                 break;

--- a/source/XeniaManager/ViewModels/Controls/WelcomeDialogViewModel.cs
+++ b/source/XeniaManager/ViewModels/Controls/WelcomeDialogViewModel.cs
@@ -29,7 +29,7 @@ public partial class WelcomeDialogViewModel : ViewModelBase
     /// <summary>
     /// The list of available themes for selection.
     /// </summary>
-    public ObservableCollection<ThemeDisplayItem> AppThemeOptions { get; private set; }
+    public ReadOnlyObservableCollection<ThemeDisplayItem> AppThemeOptions { get; private set; }
 
     /// <summary>
     /// The currently selected theme.

--- a/source/XeniaManager/ViewModels/Pages/SettingsPageViewModel.cs
+++ b/source/XeniaManager/ViewModels/Pages/SettingsPageViewModel.cs
@@ -125,20 +125,7 @@ public partial class SettingsPageViewModel : ViewModelBase
     }
 
     // Theme Settings
-    public ObservableCollection<ThemeDisplayItem> AppThemeOptions { get; set; } =
-    [
-        new ThemeDisplayItem
-        {
-            DisplayName = LocalizationHelper.GetText("SettingsPage.Ui.Theme.Option.Light"),
-            ThemeValue = Theme.Light
-        },
-
-        new ThemeDisplayItem
-        {
-            DisplayName = LocalizationHelper.GetText("SettingsPage.Ui.Theme.Option.Dark"),
-            ThemeValue = Theme.Dark
-        }
-    ];
+    public ObservableCollection<ThemeDisplayItem> AppThemeOptions { get; private set; }
 
     [ObservableProperty] private Theme selectedTheme;
     partial void OnSelectedThemeChanged(Theme oldValue, Theme newValue)
@@ -252,6 +239,7 @@ public partial class SettingsPageViewModel : ViewModelBase
     {
         _settings = App.Services.GetRequiredService<Settings>();
         _themeService = App.Services.GetRequiredService<ThemeService>();
+        AppThemeOptions = _themeService.ThemeDisplayItems;
         LoadUISettings();
     }
 

--- a/source/XeniaManager/ViewModels/Pages/SettingsPageViewModel.cs
+++ b/source/XeniaManager/ViewModels/Pages/SettingsPageViewModel.cs
@@ -90,20 +90,7 @@ public partial class SettingsPageViewModel : ViewModelBase
     }
 
     // Theme Settings
-    public ObservableCollection<ThemeDisplayItem> AppThemeOptions { get; set; } =
-    [
-        new ThemeDisplayItem
-        {
-            DisplayName = LocalizationHelper.GetText("SettingsPage.Ui.Theme.Option.Light"),
-            ThemeValue = Theme.Light
-        },
-
-        new ThemeDisplayItem
-        {
-            DisplayName = LocalizationHelper.GetText("SettingsPage.Ui.Theme.Option.Dark"),
-            ThemeValue = Theme.Dark
-        }
-    ];
+    public ObservableCollection<ThemeDisplayItem> AppThemeOptions { get; private set; }
 
     [ObservableProperty] private Theme selectedTheme;
     partial void OnSelectedThemeChanged(Theme oldValue, Theme newValue)
@@ -217,6 +204,7 @@ public partial class SettingsPageViewModel : ViewModelBase
     {
         _settings = App.Services.GetRequiredService<Settings>();
         _themeService = App.Services.GetRequiredService<ThemeService>();
+        AppThemeOptions = _themeService.ThemeDisplayItems;
         LoadUISettings();
     }
 

--- a/source/XeniaManager/ViewModels/Pages/SettingsPageViewModel.cs
+++ b/source/XeniaManager/ViewModels/Pages/SettingsPageViewModel.cs
@@ -125,7 +125,7 @@ public partial class SettingsPageViewModel : ViewModelBase
     }
 
     // Theme Settings
-    public ObservableCollection<ThemeDisplayItem> AppThemeOptions { get; private set; }
+    public ReadOnlyObservableCollection<ThemeDisplayItem> AppThemeOptions { get; private set; }
 
     [ObservableProperty] private Theme selectedTheme;
     partial void OnSelectedThemeChanged(Theme oldValue, Theme newValue)


### PR DESCRIPTION
Went to add a theme and realised both the welcome dialog and settings page were creating the same code locally.

Added a property and function to Theme Service that does this instead that adjusts dynamically to include any created themes.

Removes the two hidden hard coded steps from new theme creation.

<img width="1275" height="799" alt="Screenshot_2" src="https://github.com/user-attachments/assets/be4c0e67-4b05-4d8c-a000-75846f5ad104" />
