### PR TITLE
fix(theme): Use SystemAccentColorBrush in Card Header

### DIFF
--- a/source/XeniaManager/Controls/Cards/CardHeader.axaml
+++ b/source/XeniaManager/Controls/Cards/CardHeader.axaml
@@ -13,7 +13,7 @@
                             Margin="0,0,12,0"
                             Padding="6"
                             CornerRadius="6"
-                            Background="{DynamicResource SystemAccentColor}"
+                            Background="{DynamicResource SystemAccentColorBrush}"
                             VerticalAlignment="Center"
                             IsVisible="{TemplateBinding Icon, Converter={StaticResource NotNullConverter}}">
                         <fluent:SymbolIcon Symbol="{TemplateBinding Icon}" />


### PR DESCRIPTION
Small thing found playing around with themes.

Icons in both Manage Xenia and About were hard stuck on xbox green, this makes them use the theme file colouring.

<img width="1280" height="800" alt="XeniaManager_DKi59z1L3h" src="https://github.com/user-attachments/assets/a9173af9-a4f8-4310-ab89-ae923a68ee4f" />
<img width="1280" height="800" alt="XeniaManager_FCMQpQALLC" src="https://github.com/user-attachments/assets/86f8bd2c-519b-4a4c-a7eb-dcf20c599b66" />
