### PR TITLE
feat(library): Open Game Location

### DIFF
--- a/source/XeniaManager/Resources/Language/en.axaml
+++ b/source/XeniaManager/Resources/Language/en.axaml
@@ -405,6 +405,12 @@
     <sys:String x:Key="GameButton.ContextFlyout.Content.Screenshots.NoScreenshots.Message">No screenshots found for {0}.</sys:String>
     <sys:String x:Key="GameButton.ContextFlyout.Content.Screenshots.Error.Title">Failed to Open Folder</sys:String>
     <sys:String x:Key="GameButton.ContextFlyout.Content.Screenshots.Error.Message">There was an error while opening the screenshots folder.&#10;{0}</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.Content.GameLocation.Header">Open Game Location</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.Content.GameLocation.ToolTip">Opens the folder containing the game file</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.Content.GameLocation.NoGameDir.Title">Game File Not Found</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.Content.GameLocation.NoGameDir.Message">The game file directory could not be found.</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.Content.GameLocation.Error.Title">Failed to Open Folder</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.Content.GameLocation.Error.Message">There was an error while opening the game location.&#10;{0}</sys:String>
     <sys:String x:Key="GameButton.ContextFlyout.Patches.Header">Patches</sys:String>
     <sys:String x:Key="GameButton.ContextFlyout.Patches.Download.Header">Download</sys:String>
     <sys:String x:Key="GameButton.ContextFlyout.Patches.Download.ToolTip">Download patches from repository</sys:String>

--- a/source/XeniaManager/Resources/Language/en.axaml
+++ b/source/XeniaManager/Resources/Language/en.axaml
@@ -411,6 +411,10 @@
     <sys:String x:Key="GameButton.ContextFlyout.Content.GameLocation.NoGameDir.Message">The game file directory could not be found.</sys:String>
     <sys:String x:Key="GameButton.ContextFlyout.Content.GameLocation.Error.Title">Failed to Open Folder</sys:String>
     <sys:String x:Key="GameButton.ContextFlyout.Content.GameLocation.Error.Message">There was an error while opening the game location.&#10;{0}</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.Content.CopyGameId.Header">Copy Game ID</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.Content.CopyGameId.ToolTip">Copies the game's Game ID to the clipboard</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.Content.CopyGameId.Success.Message">Game ID {0} copied to clipboard</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.Content.CopyGameId.Error.Message">Failed to copy Game ID for {0}</sys:String>
     <sys:String x:Key="GameButton.ContextFlyout.Patches.Header">Patches</sys:String>
     <sys:String x:Key="GameButton.ContextFlyout.Patches.Download.Header">Download</sys:String>
     <sys:String x:Key="GameButton.ContextFlyout.Patches.Download.ToolTip">Download patches from repository</sys:String>

--- a/source/XeniaManager/Resources/Language/en.axaml
+++ b/source/XeniaManager/Resources/Language/en.axaml
@@ -411,10 +411,6 @@
     <sys:String x:Key="GameButton.ContextFlyout.Content.GameLocation.NoGameDir.Message">The game file directory could not be found.</sys:String>
     <sys:String x:Key="GameButton.ContextFlyout.Content.GameLocation.Error.Title">Failed to Open Folder</sys:String>
     <sys:String x:Key="GameButton.ContextFlyout.Content.GameLocation.Error.Message">There was an error while opening the game location.&#10;{0}</sys:String>
-    <sys:String x:Key="GameButton.ContextFlyout.Content.CopyGameId.Header">Copy Game ID</sys:String>
-    <sys:String x:Key="GameButton.ContextFlyout.Content.CopyGameId.ToolTip">Copies the game's Game ID to the clipboard</sys:String>
-    <sys:String x:Key="GameButton.ContextFlyout.Content.CopyGameId.Success.Message">Game ID {0} copied to clipboard</sys:String>
-    <sys:String x:Key="GameButton.ContextFlyout.Content.CopyGameId.Error.Message">Failed to copy Game ID for {0}</sys:String>
     <sys:String x:Key="GameButton.ContextFlyout.Patches.Header">Patches</sys:String>
     <sys:String x:Key="GameButton.ContextFlyout.Patches.Download.Header">Download</sys:String>
     <sys:String x:Key="GameButton.ContextFlyout.Patches.Download.ToolTip">Download patches from repository</sys:String>

--- a/source/XeniaManager/ViewModels/Items/GameItemViewModel.cs
+++ b/source/XeniaManager/ViewModels/Items/GameItemViewModel.cs
@@ -1016,37 +1016,4 @@ public partial class GameItemViewModel : ViewModelBase
                     ex.Message));
         }
     }
-
-    [RelayCommand]
-    private async Task CopyGameId()
-    {
-        try
-        {
-            Window? mainWindow = App.MainWindow;
-            if (mainWindow?.Clipboard is null)
-            {
-                _notificationService.ShowError(string.Format(
-                    LocalizationHelper.GetText("GameButton.ContextFlyout.Content.CopyGameId.Error.Message"),
-                    Game.Title));
-                Logger.Warning<GameItemViewModel>("Clipboard is not available; cannot copy Game ID.");
-                return;
-            }
-
-            await mainWindow.Clipboard.SetTextAsync(Game.GameId);
-            _notificationService.ShowSuccess(
-                string.Format(LocalizationHelper.GetText("GameButton.ContextFlyout.Content.CopyGameId.Success.Message"),
-                Game.GameId));
-            
-            Logger.Info<GameItemViewModel>($"Copied Game ID '{Game.GameId}' for Game '{Game.Title}' to clipboard.");
-        }
-        catch (Exception ex)
-        {
-            _notificationService.ShowError(
-                string.Format(LocalizationHelper.GetText("GameButton.ContextFlyout.Content.CopyGameId.Error.Message"),
-                    Game.Title));
-            
-            Logger.Error<GameItemViewModel>($"Failed to copy Game ID for '{Game.Title}'");
-            Logger.LogExceptionDetails<GameItemViewModel>(ex);
-        }
-    }
 }

--- a/source/XeniaManager/ViewModels/Items/GameItemViewModel.cs
+++ b/source/XeniaManager/ViewModels/Items/GameItemViewModel.cs
@@ -991,7 +991,7 @@ public partial class GameItemViewModel : ViewModelBase
         try
         {
             string? directory = Path.GetDirectoryName(Game.FileLocations.ResolvedGamePath);
-            if (!Directory.Exists(directory))
+            if (string.IsNullOrWhiteSpace(directory) || !Directory.Exists(directory))
             {
                 await _messageBoxService.ShowInfoAsync(
                     LocalizationHelper.GetText("GameButton.ContextFlyout.Content.GameLocation.NoGameDir.Title"),
@@ -1012,7 +1012,8 @@ public partial class GameItemViewModel : ViewModelBase
             Logger.LogExceptionDetails<GameItemViewModel>(ex);
             await _messageBoxService.ShowErrorAsync(
                 LocalizationHelper.GetText("GameButton.ContextFlyout.Content.GameLocation.Error.Title"),
-                string.Format(LocalizationHelper.GetText("GameButton.ContextFlyout.Content.GameLocation.Error.Message")));
+                string.Format(LocalizationHelper.GetText("GameButton.ContextFlyout.Content.GameLocation.Error.Message"), 
+                    ex.Message));
         }
     }
 
@@ -1022,7 +1023,14 @@ public partial class GameItemViewModel : ViewModelBase
         try
         {
             Window? mainWindow = App.MainWindow;
-            if(mainWindow?.Clipboard is null) return;
+            if (mainWindow?.Clipboard is null)
+            {
+                _notificationService.ShowError(string.Format(
+                    LocalizationHelper.GetText("GameButton.ContextFlyout.Content.CopyGameId.Error.Message"),
+                    Game.Title));
+                Logger.Warning<GameItemViewModel>("Clipboard is not available; cannot copy Game ID.");
+                return;
+            }
 
             await mainWindow.Clipboard.SetTextAsync(Game.GameId);
             _notificationService.ShowSuccess(

--- a/source/XeniaManager/ViewModels/Items/GameItemViewModel.cs
+++ b/source/XeniaManager/ViewModels/Items/GameItemViewModel.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Avalonia.Controls;
+using Avalonia.Input.Platform;
 using Avalonia.Platform.Storage;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -38,6 +39,7 @@ public partial class GameItemViewModel : ViewModelBase
     [ObservableProperty] private bool _isSelected;
     private readonly LibraryPageViewModel _library;
     private IMessageBoxService _messageBoxService { get; set; }
+    private INotificationService _notificationService;
     private Core.Settings.Settings _settings { get; set; }
     public string Title => Game.Title;
     public GameArtwork Artwork => Game.Artwork;
@@ -64,6 +66,7 @@ public partial class GameItemViewModel : ViewModelBase
         Game = game;
         _library = library;
         _messageBoxService = App.Services.GetRequiredService<IMessageBoxService>();
+        _notificationService = App.Services.GetRequiredService<INotificationService>();
         _settings = App.Services.GetRequiredService<Core.Settings.Settings>();
     }
 
@@ -1010,6 +1013,32 @@ public partial class GameItemViewModel : ViewModelBase
             await _messageBoxService.ShowErrorAsync(
                 LocalizationHelper.GetText("GameButton.ContextFlyout.Content.GameLocation.Error.Title"),
                 string.Format(LocalizationHelper.GetText("GameButton.ContextFlyout.Content.GameLocation.Error.Message")));
+        }
+    }
+
+    [RelayCommand]
+    private async Task CopyGameId()
+    {
+        try
+        {
+            Window? mainWindow = App.MainWindow;
+            if(mainWindow?.Clipboard is null) return;
+
+            await mainWindow.Clipboard.SetTextAsync(Game.GameId);
+            _notificationService.ShowSuccess(
+                string.Format(LocalizationHelper.GetText("GameButton.ContextFlyout.Content.CopyGameId.Success.Message"),
+                Game.GameId));
+            
+            Logger.Info<GameItemViewModel>($"Copied Game ID '{Game.GameId}' for Game '{Game.Title}' to clipboard.");
+        }
+        catch (Exception ex)
+        {
+            _notificationService.ShowError(
+                string.Format(LocalizationHelper.GetText("GameButton.ContextFlyout.Content.CopyGameId.Error.Message"),
+                    Game.Title));
+            
+            Logger.Error<GameItemViewModel>($"Failed to copy Game ID for '{Game.Title}'");
+            Logger.LogExceptionDetails<GameItemViewModel>(ex);
         }
     }
 }

--- a/source/XeniaManager/ViewModels/Items/GameItemViewModel.cs
+++ b/source/XeniaManager/ViewModels/Items/GameItemViewModel.cs
@@ -981,4 +981,35 @@ public partial class GameItemViewModel : ViewModelBase
             }
         }
     }
+
+    [RelayCommand]
+    private async Task OpenGameLocation()
+    {
+        try
+        {
+            string? directory = Path.GetDirectoryName(Game.FileLocations.ResolvedGamePath);
+            if (!Directory.Exists(directory))
+            {
+                await _messageBoxService.ShowInfoAsync(
+                    LocalizationHelper.GetText("GameButton.ContextFlyout.Content.GameLocation.NoGameDir.Title"),
+                LocalizationHelper.GetText("GameButton.ContextFlyout.Content.GameLocation.NoGameDir.Message"));   
+                return;
+            }
+
+            Process.Start(new ProcessStartInfo
+            {
+                FileName = directory,
+                UseShellExecute = true,
+                Verb = "open"
+            });
+        }
+        catch (Exception ex)
+        {
+            Logger.Error<GameItemViewModel>($"Failed to open game location for: {Game.Title}");
+            Logger.LogExceptionDetails<GameItemViewModel>(ex);
+            await _messageBoxService.ShowErrorAsync(
+                LocalizationHelper.GetText("GameButton.ContextFlyout.Content.GameLocation.Error.Title"),
+                string.Format(LocalizationHelper.GetText("GameButton.ContextFlyout.Content.GameLocation.Error.Message")));
+        }
+    }
 }

--- a/source/XeniaManager/Views/Pages/LibraryPage.axaml
+++ b/source/XeniaManager/Views/Pages/LibraryPage.axaml
@@ -895,6 +895,26 @@
                                                 <TextBlock Text="{DynamicResource GameButton.ContextFlyout.Content.SaveBackup.ToolTip}" />
                                             </ToolTip.Tip>
                                         </MenuItem>
+                                        <!-- Open Save Backup -->
+                                        <MenuItem Header="{DynamicResource GameButton.ContextFlyout.Content.SaveBackup.Header}"
+                                                  Command="{Binding OpenSaveBackupFolderCommand}">
+                                            <MenuItem.Icon>
+                                                <icons:SymbolIcon Symbol="SaveArrowRight" />
+                                            </MenuItem.Icon>
+                                            <ToolTip.Tip>
+                                                <TextBlock Text="{DynamicResource GameButton.ContextFlyout.Content.SaveBackup.ToolTip}" />
+                                            </ToolTip.Tip>
+                                        </MenuItem>
+                                        <!-- Open Game Location -->
+                                        <MenuItem Header="{DynamicResource GameButton.ContextFlyout.Content.GameLocation.Header}"
+                                                  Command="{Binding OpenGameLocationCommand}">
+                                            <MenuItem.Icon>
+                                                <icons:SymbolIcon Symbol="Folder" />
+                                            </MenuItem.Icon>
+                                            <ToolTip.Tip>
+                                                <TextBlock Text="{DynamicResource GameButton.ContextFlyout.Content.GameLocation.ToolTip}" />
+                                            </ToolTip.Tip>
+                                        </MenuItem>
                                     </MenuItem>
                                     <!-- Patches -->
                                     <MenuItem Header="{DynamicResource GameButton.ContextFlyout.Patches.Header}"

--- a/source/XeniaManager/Views/Pages/LibraryPage.axaml
+++ b/source/XeniaManager/Views/Pages/LibraryPage.axaml
@@ -548,6 +548,16 @@
                                                 <TextBlock Text="{DynamicResource GameButton.ContextFlyout.Content.SaveBackup.ToolTip}" />
                                             </ToolTip.Tip>
                                         </MenuItem>
+                                        <!-- Open Game Location -->
+                                        <MenuItem Header="{DynamicResource GameButton.ContextFlyout.Content.GameLocation.Header}"
+                                                  Command="{Binding OpenGameLocationCommand}">
+                                            <MenuItem.Icon>
+                                                <icons:SymbolIcon Symbol="Folder" />
+                                            </MenuItem.Icon>
+                                            <ToolTip.Tip>
+                                                <TextBlock Text="{DynamicResource GameButton.ContextFlyout.Content.GameLocation.ToolTip}" />
+                                            </ToolTip.Tip>
+                                        </MenuItem>
                                     </MenuItem>
                                     <!-- Patches -->
                                     <MenuItem Header="{DynamicResource GameButton.ContextFlyout.Patches.Header}"

--- a/source/XeniaManager/Views/Pages/LibraryPage.axaml
+++ b/source/XeniaManager/Views/Pages/LibraryPage.axaml
@@ -558,16 +558,6 @@
                                                 <TextBlock Text="{DynamicResource GameButton.ContextFlyout.Content.GameLocation.ToolTip}" />
                                             </ToolTip.Tip>
                                         </MenuItem>
-                                        <!-- Copy Game ID -->
-                                        <MenuItem Header="{DynamicResource GameButton.ContextFlyout.Content.CopyGameId.Header}"
-                                                  Command="{Binding CopyGameIdCommand}">
-                                            <MenuItem.Icon>
-                                                <icons:SymbolIcon Symbol="Note" />
-                                            </MenuItem.Icon>
-                                            <ToolTip.Tip>
-                                                <TextBlock Text="{DynamicResource GameButton.ContextFlyout.Content.CopyGameId.ToolTip}" />
-                                            </ToolTip.Tip>
-                                        </MenuItem>
                                     </MenuItem>
                                     <!-- Patches -->
                                     <MenuItem Header="{DynamicResource GameButton.ContextFlyout.Patches.Header}"
@@ -883,16 +873,6 @@
                                             </MenuItem.Icon>
                                             <ToolTip.Tip>
                                                 <TextBlock Text="{DynamicResource GameButton.ContextFlyout.Content.Screenshots.ToolTip}" />
-                                            </ToolTip.Tip>
-                                        </MenuItem>
-                                        <!-- Open Save Backup -->
-                                        <MenuItem Header="{DynamicResource GameButton.ContextFlyout.Content.SaveBackup.Header}"
-                                                  Command="{Binding OpenSaveBackupFolderCommand}">
-                                            <MenuItem.Icon>
-                                                <icons:SymbolIcon Symbol="SaveArrowRight" />
-                                            </MenuItem.Icon>
-                                            <ToolTip.Tip>
-                                                <TextBlock Text="{DynamicResource GameButton.ContextFlyout.Content.SaveBackup.ToolTip}" />
                                             </ToolTip.Tip>
                                         </MenuItem>
                                         <!-- Open Save Backup -->

--- a/source/XeniaManager/Views/Pages/LibraryPage.axaml
+++ b/source/XeniaManager/Views/Pages/LibraryPage.axaml
@@ -558,6 +558,16 @@
                                                 <TextBlock Text="{DynamicResource GameButton.ContextFlyout.Content.GameLocation.ToolTip}" />
                                             </ToolTip.Tip>
                                         </MenuItem>
+                                        <!-- Copy Game ID -->
+                                        <MenuItem Header="{DynamicResource GameButton.ContextFlyout.Content.CopyGameId.Header}"
+                                                  Command="{Binding CopyGameIdCommand}">
+                                            <MenuItem.Icon>
+                                                <icons:SymbolIcon Symbol="Note" />
+                                            </MenuItem.Icon>
+                                            <ToolTip.Tip>
+                                                <TextBlock Text="{DynamicResource GameButton.ContextFlyout.Content.CopyGameId.ToolTip}" />
+                                            </ToolTip.Tip>
+                                        </MenuItem>
                                     </MenuItem>
                                     <!-- Patches -->
                                     <MenuItem Header="{DynamicResource GameButton.ContextFlyout.Patches.Header}"


### PR DESCRIPTION
Added Two Options under Content when you right click on a game in your library.

Open Game Location opens the folder in explorer containing the game.
Copy Game ID does what it says, helpful when needing to search online. 

Added Notification Service to Game Item View Model for Copy Confirmation or Error.

<img width="1280" height="800" alt="XeniaManager_R6S0be4N9K" src="https://github.com/user-attachments/assets/5369a530-2261-4d31-80a6-441e0b3dbcc3" />
<img width="1280" height="800" alt="XeniaManager_U5S95lIJy5" src="https://github.com/user-attachments/assets/53d23a6c-e9e7-4fed-b41b-346150c89ce1" />
