### PR TITLE
[Feature] Add user-defined game groups

### DIFF
--- a/source/XeniaManager.Core/Constants/AppPaths.cs
+++ b/source/XeniaManager.Core/Constants/AppPaths.cs
@@ -24,7 +24,6 @@ public class AppPaths
     public static readonly string GameLibraryPath = Path.Combine(ConfigDirectory, "games.json");
     public static readonly string GameGroupsPath = Path.Combine(ConfigDirectory, "groups.json");
 
-
     // Downloads
     public static readonly string DownloadsDirectory = AppPathResolver.GetFullPath("Downloads");
 

--- a/source/XeniaManager.Core/Constants/AppPaths.cs
+++ b/source/XeniaManager.Core/Constants/AppPaths.cs
@@ -22,6 +22,8 @@ public class AppPaths
     public static readonly string ConfigFile = Path.Combine(ConfigDirectory, "config.json");
     public static readonly string ConfigFileBackup = Path.Combine(ConfigDirectory, "config.json.backup");
     public static readonly string GameLibraryPath = Path.Combine(ConfigDirectory, "games.json");
+    public static readonly string GameGroupsPath = Path.Combine(ConfigDirectory, "groups.json");
+
 
     // Downloads
     public static readonly string DownloadsDirectory = AppPathResolver.GetFullPath("Downloads");

--- a/source/XeniaManager.Core/Manage/GroupManager.cs
+++ b/source/XeniaManager.Core/Manage/GroupManager.cs
@@ -1,0 +1,318 @@
+using System.Text.Json;
+using XeniaManager.Core.Constants;
+using XeniaManager.Core.Logging;
+using XeniaManager.Core.Models.Game;
+using XeniaManager.Core.Services;
+
+namespace XeniaManager.Core.Manage;
+
+/// <summary>
+/// Manages user-defined game groups by loading from and saving to a local file.
+/// </summary>
+public class GroupManager
+{
+    /// <summary>
+    /// Gets or sets the list of game groups.
+    /// </summary>
+    public static List<GameGroup> Groups { get; set; } = [];
+
+    /// <summary>
+    /// Currently active group filter for the library. Null means show all games.
+    /// </summary>
+    public static Guid? ActiveFilterGroupId { get; private set; }
+
+    /// <summary>
+    /// Builds a stable key used to associate a game with groups.
+    /// </summary>
+    public static string GetGameKey(Game game)
+    {
+        string path = game.FileLocations.ResolvedGamePath;
+        if (!string.IsNullOrWhiteSpace(path))
+        {
+            return path.ToLowerInvariant();
+        }
+
+        return $"{game.GameId}|{game.MediaId}|{game.Title}".ToLowerInvariant();
+    }
+
+    /// <summary>
+    /// Loads game groups from the local file.
+    /// </summary>
+    public static void LoadGroups()
+    {
+        string path = AppPaths.GameGroupsPath;
+        string backupPath = path + ".backup";
+
+        try
+        {
+            if (!File.Exists(path))
+            {
+                Logger.Info<GroupManager>($"Game groups file not found at {path}, creating a new empty list");
+                Groups = [];
+                SaveGroups();
+                return;
+            }
+
+            Logger.Info<GroupManager>($"Loading game groups from {path}");
+            string content = File.ReadAllText(path);
+
+            if (string.IsNullOrWhiteSpace(content))
+            {
+                throw new JsonException("Game groups file is empty");
+            }
+
+            List<GameGroup>? deserialized = JsonSerializer.Deserialize<List<GameGroup>>(content);
+            if (deserialized == null)
+            {
+                throw new JsonException("Deserialization resulted in null");
+            }
+
+            Groups = [];
+            foreach (GameGroup group in deserialized)
+            {
+                if (string.IsNullOrWhiteSpace(group.Name))
+                {
+                    Logger.Warning<GroupManager>("Skipping group with missing name");
+                    continue;
+                }
+
+                if (group.Id == Guid.Empty)
+                {
+                    group.Id = Guid.NewGuid();
+                }
+
+                group.GameKeys ??= [];
+                Groups.Add(group);
+            }
+
+            Logger.Info<GroupManager>($"Successfully loaded {Groups.Count} game groups");
+        }
+        catch (JsonException jsonEx)
+        {
+            Logger.Error<GroupManager>($"JSON error while loading game groups: {jsonEx.Message}");
+            Logger.LogExceptionDetails<GroupManager>(jsonEx);
+            TryRecoverFromBackup(backupPath);
+        }
+        catch (Exception ex)
+        {
+            Logger.Error<GroupManager>($"Unexpected error while loading game groups: {ex.Message}");
+            Logger.LogExceptionDetails<GroupManager>(ex);
+            TryRecoverFromBackup(backupPath);
+        }
+    }
+
+    /// <summary>
+    /// Saves game groups to the local file using an atomic write.
+    /// </summary>
+    public static void SaveGroups()
+    {
+        string path = AppPaths.GameGroupsPath;
+        string tempPath = path + ".tmp";
+        string backupPath = path + ".backup";
+
+        try
+        {
+            Directory.CreateDirectory(AppPaths.ConfigDirectory);
+
+            string json = JsonSerializer.Serialize(Groups, new JsonSerializerOptions
+            {
+                WriteIndented = true
+            });
+
+            if (string.IsNullOrWhiteSpace(json))
+            {
+                throw new InvalidOperationException("Serialization produced empty or null JSON");
+            }
+
+            File.WriteAllText(tempPath, json);
+
+            if (!File.Exists(tempPath) || string.IsNullOrWhiteSpace(File.ReadAllText(tempPath)))
+            {
+                throw new IOException("Temporary groups file was not written correctly");
+            }
+
+            if (File.Exists(path))
+            {
+                File.Copy(path, backupPath, overwrite: true);
+            }
+
+            File.Move(tempPath, path, overwrite: true);
+            Logger.Info<GroupManager>($"Game groups successfully saved to {path}");
+        }
+        catch (Exception ex)
+        {
+            Logger.Error<GroupManager>($"Failed to save game groups: {ex.Message}");
+            Logger.LogExceptionDetails<GroupManager>(ex);
+            CleanupTempFile(tempPath);
+        }
+    }
+
+    /// <summary>
+    /// Creates a new group with the given name and persists it.
+    /// </summary>
+    public static GameGroup CreateGroup(string name)
+    {
+        string trimmedName = name.Trim();
+        if (string.IsNullOrWhiteSpace(trimmedName))
+        {
+            throw new ArgumentException("Group name cannot be empty", nameof(name));
+        }
+
+        GameGroup group = new GameGroup
+        {
+            Id = Guid.NewGuid(),
+            Name = trimmedName,
+            GameKeys = []
+        };
+
+        Groups.Add(group);
+        SaveGroups();
+        EventManager.Instance.OnGameGroupsChanged();
+        Logger.Info<GroupManager>($"Created game group '{group.Name}' ({group.Id})");
+        return group;
+    }
+
+    /// <summary>
+    /// Adds a game to the specified group and persists the change.
+    /// </summary>
+    public static bool AddGameToGroup(Guid groupId, Game game)
+    {
+        return AddGamesToGroup(groupId, [game]) > 0;
+    }
+
+    /// <summary>
+    /// Adds multiple games to the specified group and persists once.
+    /// </summary>
+    /// <returns>Number of games newly added (already-present games are skipped).</returns>
+    public static int AddGamesToGroup(Guid groupId, IEnumerable<Game> games)
+    {
+        GameGroup? group = Groups.FirstOrDefault(g => g.Id == groupId);
+        if (group == null)
+        {
+            Logger.Warning<GroupManager>($"Cannot add games to group: group {groupId} not found");
+            return 0;
+        }
+
+        int addedCount = 0;
+        foreach (Game game in games)
+        {
+            string key = GetGameKey(game);
+            if (group.GameKeys.Contains(key, StringComparer.OrdinalIgnoreCase))
+            {
+                Logger.Debug<GroupManager>($"Game '{game.Title}' is already in group '{group.Name}'");
+                continue;
+            }
+
+            group.GameKeys.Add(key);
+            addedCount++;
+            Logger.Info<GroupManager>($"Added '{game.Title}' to group '{group.Name}'");
+        }
+
+        if (addedCount > 0)
+        {
+            SaveGroups();
+            EventManager.Instance.OnGameGroupsChanged();
+        }
+
+        return addedCount;
+    }
+
+    /// <summary>
+    /// Removes a game from the specified group and persists the change.
+    /// </summary>
+    public static bool RemoveGameFromGroup(Guid groupId, Game game)
+    {
+        GameGroup? group = Groups.FirstOrDefault(g => g.Id == groupId);
+        if (group == null)
+        {
+            return false;
+        }
+
+        string key = GetGameKey(game);
+        int removed = group.GameKeys.RemoveAll(k => string.Equals(k, key, StringComparison.OrdinalIgnoreCase));
+        if (removed == 0)
+        {
+            return false;
+        }
+
+        SaveGroups();
+        EventManager.Instance.OnGameGroupsChanged();
+        Logger.Info<GroupManager>($"Removed '{game.Title}' from group '{group.Name}'");
+        return true;
+    }
+
+    /// <summary>
+    /// Returns whether the game belongs to the given group.
+    /// </summary>
+    public static bool IsInGroup(Guid groupId, Game game)
+    {
+        GameGroup? group = Groups.FirstOrDefault(g => g.Id == groupId);
+        if (group == null)
+        {
+            return false;
+        }
+
+        string key = GetGameKey(game);
+        return group.GameKeys.Contains(key, StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Sets the active library group filter and notifies listeners.
+    /// Pass null to clear the filter and show all games.
+    /// </summary>
+    public static void SetActiveFilter(Guid? groupId)
+    {
+        if (ActiveFilterGroupId == groupId)
+        {
+            return;
+        }
+
+        ActiveFilterGroupId = groupId;
+        Logger.Info<GroupManager>(groupId.HasValue
+            ? $"Active group filter set to {groupId}"
+            : "Active group filter cleared");
+        EventManager.Instance.OnGroupFilterChanged(groupId);
+    }
+
+    private static void TryRecoverFromBackup(string backupPath)
+    {
+        try
+        {
+            if (!File.Exists(backupPath))
+            {
+                Logger.Warning<GroupManager>("No groups backup available, starting with empty list");
+                Groups = [];
+                SaveGroups();
+                return;
+            }
+
+            Logger.Info<GroupManager>($"Attempting to recover game groups from backup: {backupPath}");
+            string content = File.ReadAllText(backupPath);
+            List<GameGroup>? deserialized = JsonSerializer.Deserialize<List<GameGroup>>(content);
+            Groups = deserialized ?? [];
+            SaveGroups();
+            Logger.Info<GroupManager>($"Recovered {Groups.Count} groups from backup");
+        }
+        catch (Exception ex)
+        {
+            Logger.Error<GroupManager>($"Failed to recover groups from backup: {ex.Message}");
+            Logger.LogExceptionDetails<GroupManager>(ex);
+            Groups = [];
+        }
+    }
+
+    private static void CleanupTempFile(string tempPath)
+    {
+        try
+        {
+            if (File.Exists(tempPath))
+            {
+                File.Delete(tempPath);
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.Debug<GroupManager>($"Failed to clean up temporary groups file: {ex.Message}");
+        }
+    }
+}

--- a/source/XeniaManager.Core/Manage/GroupManager.cs
+++ b/source/XeniaManager.Core/Manage/GroupManager.cs
@@ -17,11 +17,6 @@ public class GroupManager
     public static List<GameGroup> Groups { get; set; } = [];
 
     /// <summary>
-    /// Currently active group filter for the library. Null means show all games.
-    /// </summary>
-    public static Guid? ActiveFilterGroupId { get; private set; }
-
-    /// <summary>
     /// Builds a stable key used to associate a game with groups.
     /// </summary>
     public static string GetGameKey(Game game)
@@ -218,9 +213,50 @@ public class GroupManager
     }
 
     /// <summary>
+    /// Removes multiple games from the specified group and persists once.
+    /// </summary>
+    /// <returns>Number of games removed.</returns>
+    public static int RemoveGamesFromGroup(Guid groupId, IEnumerable<Game> games)
+    {
+        GameGroup? group = Groups.FirstOrDefault(g => g.Id == groupId);
+        if (group == null)
+        {
+            return 0;
+        }
+
+        int removedCount = 0;
+        foreach (Game game in games)
+        {
+            string key = GetGameKey(game);
+            int removed = group.GameKeys.RemoveAll(k => string.Equals(k, key, StringComparison.OrdinalIgnoreCase));
+            if (removed > 0)
+            {
+                removedCount++;
+                Logger.Info<GroupManager>($"Removed '{game.Title}' from group '{group.Name}'");
+            }
+        }
+
+        if (removedCount > 0)
+        {
+            SaveGroups();
+            EventManager.Instance.OnGameGroupsChanged();
+        }
+
+        return removedCount;
+    }
+
+    /// <summary>
     /// Removes a game from the specified group and persists the change.
     /// </summary>
     public static bool RemoveGameFromGroup(Guid groupId, Game game)
+    {
+        return RemoveGamesFromGroup(groupId, [game]) > 0;
+    }
+
+    /// <summary>
+    /// Deletes a group and persists the change.
+    /// </summary>
+    public static bool DeleteGroup(Guid groupId)
     {
         GameGroup? group = Groups.FirstOrDefault(g => g.Id == groupId);
         if (group == null)
@@ -228,17 +264,23 @@ public class GroupManager
             return false;
         }
 
-        string key = GetGameKey(game);
-        int removed = group.GameKeys.RemoveAll(k => string.Equals(k, key, StringComparison.OrdinalIgnoreCase));
-        if (removed == 0)
-        {
-            return false;
-        }
-
+        Groups.Remove(group);
         SaveGroups();
         EventManager.Instance.OnGameGroupsChanged();
-        Logger.Info<GroupManager>($"Removed '{game.Title}' from group '{group.Name}'");
+        Logger.Info<GroupManager>($"Deleted game group '{group.Name}' ({group.Id})");
         return true;
+    }
+
+    /// <summary>
+    /// Returns all groups that contain the given game.
+    /// </summary>
+    public static List<GameGroup> GetGroupsContaining(Game game)
+    {
+        string key = GetGameKey(game);
+        return Groups
+            .Where(g => g.GameKeys.Contains(key, StringComparer.OrdinalIgnoreCase))
+            .OrderBy(g => g.Name, StringComparer.CurrentCultureIgnoreCase)
+            .ToList();
     }
 
     /// <summary>
@@ -257,21 +299,12 @@ public class GroupManager
     }
 
     /// <summary>
-    /// Sets the active library group filter and notifies listeners.
-    /// Pass null to clear the filter and show all games.
+    /// Returns whether the game belongs to any group.
     /// </summary>
-    public static void SetActiveFilter(Guid? groupId)
+    public static bool IsInAnyGroup(Game game)
     {
-        if (ActiveFilterGroupId == groupId)
-        {
-            return;
-        }
-
-        ActiveFilterGroupId = groupId;
-        Logger.Info<GroupManager>(groupId.HasValue
-            ? $"Active group filter set to {groupId}"
-            : "Active group filter cleared");
-        EventManager.Instance.OnGroupFilterChanged(groupId);
+        string key = GetGameKey(game);
+        return Groups.Any(g => g.GameKeys.Contains(key, StringComparer.OrdinalIgnoreCase));
     }
 
     private static void TryRecoverFromBackup(string backupPath)

--- a/source/XeniaManager.Core/Models/Game/GameGroup.cs
+++ b/source/XeniaManager.Core/Models/Game/GameGroup.cs
@@ -1,0 +1,28 @@
+using System.Text.Json.Serialization;
+
+namespace XeniaManager.Core.Models.Game;
+
+/// <summary>
+/// User-defined collection of games for filtering the library.
+/// </summary>
+public class GameGroup
+{
+    /// <summary>
+    /// Unique identifier for the group.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    /// <summary>
+    /// Display name of the group.
+    /// </summary>
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Keys of games that belong to this group.
+    /// Keys are produced by <see cref="Manage.GroupManager.GetGameKey"/>.
+    /// </summary>
+    [JsonPropertyName("game_keys")]
+    public List<string> GameKeys { get; set; } = [];
+}

--- a/source/XeniaManager.Core/Services/EventManager.cs
+++ b/source/XeniaManager.Core/Services/EventManager.cs
@@ -18,6 +18,10 @@ public class EventManager
     // Game library events
     public event Action? GameLibraryChanged;
 
+    // Game groups events
+    public event Action? GameGroupsChanged;
+    public event Action<Guid?>? GroupFilterChanged;
+
     /// <summary>
     /// Triggers the window disable/enable event on the UI thread.
     /// </summary>
@@ -63,5 +67,22 @@ public class EventManager
     public void OnGameLibraryChanged()
     {
         GameLibraryChanged?.Invoke();
+    }
+
+    /// <summary>
+    /// Triggers the game groups changed event (create/rename/membership updates).
+    /// </summary>
+    public void OnGameGroupsChanged()
+    {
+        GameGroupsChanged?.Invoke();
+    }
+
+    /// <summary>
+    /// Triggers the active group filter changed event.
+    /// </summary>
+    /// <param name="groupId">Selected group id, or null to show all games.</param>
+    public void OnGroupFilterChanged(Guid? groupId)
+    {
+        GroupFilterChanged?.Invoke(groupId);
     }
 }

--- a/source/XeniaManager.Core/Services/EventManager.cs
+++ b/source/XeniaManager.Core/Services/EventManager.cs
@@ -20,7 +20,6 @@ public class EventManager
 
     // Game groups events
     public event Action? GameGroupsChanged;
-    public event Action<Guid?>? GroupFilterChanged;
 
     /// <summary>
     /// Triggers the window disable/enable event on the UI thread.
@@ -75,14 +74,5 @@ public class EventManager
     public void OnGameGroupsChanged()
     {
         GameGroupsChanged?.Invoke();
-    }
-
-    /// <summary>
-    /// Triggers the active group filter changed event.
-    /// </summary>
-    /// <param name="groupId">Selected group id, or null to show all games.</param>
-    public void OnGroupFilterChanged(Guid? groupId)
-    {
-        GroupFilterChanged?.Invoke(groupId);
     }
 }

--- a/source/XeniaManager/App.axaml.cs
+++ b/source/XeniaManager/App.axaml.cs
@@ -75,8 +75,9 @@ public partial class App : Application
             Logger.SetLogLevel(settings.Settings.Debug.LogLevel);
             settings.SaveSettings();
 
-            // Load the library
+            // Load the library and game groups
             GameManager.LoadLibrary();
+            GroupManager.LoadGroups();
 
             // Localization initialization
             LocalizationHelper.Initialize("avares://XeniaManager/Resources/Language/");

--- a/source/XeniaManager/Controls/GroupNameDialog.cs
+++ b/source/XeniaManager/Controls/GroupNameDialog.cs
@@ -1,0 +1,68 @@
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using FluentAvalonia.UI.Controls;
+using XeniaManager.Core.Logging;
+using XeniaManager.Core.Utilities;
+
+namespace XeniaManager.Controls;
+
+/// <summary>
+/// Dialog for entering a new game group name.
+/// </summary>
+public abstract class GroupNameDialog
+{
+    /// <summary>
+    /// Shows a dialog prompting the user for a group name.
+    /// </summary>
+    /// <param name="initialName">Optional prefilled name.</param>
+    /// <returns>The trimmed group name, or null if cancelled / empty.</returns>
+    public static async Task<string?> ShowAsync(string? initialName = null)
+    {
+        Logger.Info<GroupNameDialog>("Showing group name dialog");
+
+        TextBox nameBox = new TextBox
+        {
+            PlaceholderText = LocalizationHelper.GetText("GroupNameDialog.Watermark"),
+            Text = initialName ?? string.Empty,
+            MinWidth = 320
+        };
+
+        FAContentDialog dialog = new FAContentDialog
+        {
+            Title = LocalizationHelper.GetText("GroupNameDialog.Title"),
+            Content = new StackPanel
+            {
+                Spacing = 8,
+                Children =
+                {
+                    new TextBlock
+                    {
+                        Text = LocalizationHelper.GetText("GroupNameDialog.Message"),
+                        TextWrapping = Avalonia.Media.TextWrapping.Wrap
+                    },
+                    nameBox
+                }
+            },
+            PrimaryButtonText = LocalizationHelper.GetText("GroupNameDialog.Save"),
+            CloseButtonText = LocalizationHelper.GetText("MessageBox.Cancel"),
+            DefaultButton = FAContentDialogButton.Primary
+        };
+
+        FAContentDialogResult result = await dialog.ShowAsync();
+        if (result != FAContentDialogResult.Primary)
+        {
+            Logger.Info<GroupNameDialog>("Group name dialog cancelled");
+            return null;
+        }
+
+        string name = nameBox.Text?.Trim() ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            Logger.Info<GroupNameDialog>("Group name dialog returned empty name");
+            return null;
+        }
+
+        Logger.Info<GroupNameDialog>($"User entered group name: '{name}'");
+        return name;
+    }
+}

--- a/source/XeniaManager/Controls/GroupSelectionDialog.cs
+++ b/source/XeniaManager/Controls/GroupSelectionDialog.cs
@@ -1,8 +1,12 @@
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
 using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Controls.Templates;
+using Avalonia.Layout;
+using Avalonia.Media;
 using FluentAvalonia.UI.Controls;
-using Symbol = FluentIcons.Common.Symbol;
-using SymbolIconSource = FluentIcons.Avalonia.Fluent.SymbolIconSource;
 using XeniaManager.Core.Logging;
 using XeniaManager.Core.Models.Game;
 using XeniaManager.Core.Utilities;
@@ -10,16 +14,22 @@ using XeniaManager.Core.Utilities;
 namespace XeniaManager.Controls;
 
 /// <summary>
-/// Dialog for selecting a game group to add a game into.
+/// Dialog for selecting one or more game groups (checklist).
 /// </summary>
 public abstract class GroupSelectionDialog
 {
     /// <summary>
-    /// Shows a dialog listing available groups.
+    /// Shows a checklist dialog of available groups.
     /// </summary>
     /// <param name="groups">Groups the user can choose from.</param>
-    /// <returns>The selected group, or null if cancelled.</returns>
-    public static async Task<GameGroup?> ShowAsync(List<GameGroup> groups)
+    /// <param name="title">Optional dialog title override.</param>
+    /// <param name="message">Optional message override.</param>
+    /// <returns>Selected groups, or null if cancelled / none selected.</returns>
+    public static async Task<List<GameGroup>?> ShowAsync(
+        List<GameGroup> groups,
+        string? title = null,
+        string? message = null,
+        string? confirmButtonText = null)
     {
         Logger.Info<GroupSelectionDialog>($"Showing group selection dialog with {groups.Count} groups");
 
@@ -29,47 +39,74 @@ public abstract class GroupSelectionDialog
             return null;
         }
 
-        FATaskDialog taskDialog = new FATaskDialog
+        ObservableCollection<GroupSelectableItem> items = new(
+            groups.Select(g => new GroupSelectableItem(g)));
+
+        ListBox listBox = new ListBox
         {
-            Title = LocalizationHelper.GetText("GroupSelectionDialog.Title"),
-            Header = LocalizationHelper.GetText("GroupSelectionDialog.Header"),
-            SubHeader = LocalizationHelper.GetText("GroupSelectionDialog.SubHeader"),
-            IconSource = new SymbolIconSource { Symbol = Symbol.Folder },
-            XamlRoot = App.MainWindow
+            ItemsSource = items,
+            MinWidth = 320,
+            MaxHeight = 360,
+            SelectionMode = SelectionMode.Multiple
         };
 
-        List<FATaskDialogCommand> commands = [];
-        foreach (GameGroup group in groups)
+        listBox.ItemTemplate = new FuncDataTemplate<GroupSelectableItem>((item, _) =>
         {
-            FATaskDialogCommand command = new FATaskDialogCommand
+            CheckBox checkBox = new CheckBox
             {
-                Text = group.Name,
-                IconSource = new SymbolIconSource { Symbol = Symbol.Folder },
-                ClosesOnInvoked = false
+                Content = item.Group.Name,
+                IsChecked = item.IsSelected,
+                Margin = new Avalonia.Thickness(4, 2)
             };
+            checkBox.IsCheckedChanged += (_, _) =>
+            {
+                item.IsSelected = checkBox.IsChecked == true;
+            };
+            return checkBox;
+        }, true);
 
-            GameGroup capturedGroup = group;
-            command.Click += (_, _) =>
+        FAContentDialog dialog = new FAContentDialog
+        {
+            Title = title ?? LocalizationHelper.GetText("GroupSelectionDialog.Title"),
+            Content = new StackPanel
             {
-                Logger.Info<GroupSelectionDialog>($"User selected group '{capturedGroup.Name}'");
-                taskDialog.Hide(capturedGroup);
-            };
-            commands.Add(command);
+                Spacing = 8,
+                Children =
+                {
+                    new TextBlock
+                    {
+                        Text = message ?? LocalizationHelper.GetText("GroupSelectionDialog.Message"),
+                        TextWrapping = TextWrapping.Wrap
+                    },
+                    listBox
+                }
+            },
+            PrimaryButtonText = confirmButtonText ?? LocalizationHelper.GetText("GroupSelectionDialog.Confirm"),
+            CloseButtonText = LocalizationHelper.GetText("MessageBox.Cancel"),
+            DefaultButton = FAContentDialogButton.Primary
+        };
+
+        FAContentDialogResult result = await dialog.ShowAsync();
+        if (result != FAContentDialogResult.Primary)
+        {
+            Logger.Info<GroupSelectionDialog>("Group selection cancelled");
+            return null;
         }
 
-        taskDialog.Commands = commands;
-        taskDialog.Buttons =
-        [
-            FATaskDialogButton.CloseButton
-        ];
-
-        object result = await taskDialog.ShowAsync(true);
-        if (result is GameGroup selected)
+        List<GameGroup> selected = items.Where(i => i.IsSelected).Select(i => i.Group).ToList();
+        if (selected.Count == 0)
         {
-            return selected;
+            Logger.Info<GroupSelectionDialog>("No groups selected");
+            return null;
         }
 
-        Logger.Info<GroupSelectionDialog>("User cancelled group selection");
-        return null;
+        Logger.Info<GroupSelectionDialog>($"User selected {selected.Count} group(s)");
+        return selected;
+    }
+
+    private sealed class GroupSelectableItem(GameGroup group)
+    {
+        public GameGroup Group { get; } = group;
+        public bool IsSelected { get; set; }
     }
 }

--- a/source/XeniaManager/Controls/GroupSelectionDialog.cs
+++ b/source/XeniaManager/Controls/GroupSelectionDialog.cs
@@ -1,0 +1,75 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FluentAvalonia.UI.Controls;
+using Symbol = FluentIcons.Common.Symbol;
+using SymbolIconSource = FluentIcons.Avalonia.Fluent.SymbolIconSource;
+using XeniaManager.Core.Logging;
+using XeniaManager.Core.Models.Game;
+using XeniaManager.Core.Utilities;
+
+namespace XeniaManager.Controls;
+
+/// <summary>
+/// Dialog for selecting a game group to add a game into.
+/// </summary>
+public abstract class GroupSelectionDialog
+{
+    /// <summary>
+    /// Shows a dialog listing available groups.
+    /// </summary>
+    /// <param name="groups">Groups the user can choose from.</param>
+    /// <returns>The selected group, or null if cancelled.</returns>
+    public static async Task<GameGroup?> ShowAsync(List<GameGroup> groups)
+    {
+        Logger.Info<GroupSelectionDialog>($"Showing group selection dialog with {groups.Count} groups");
+
+        if (groups.Count == 0)
+        {
+            Logger.Warning<GroupSelectionDialog>("No groups available for selection");
+            return null;
+        }
+
+        FATaskDialog taskDialog = new FATaskDialog
+        {
+            Title = LocalizationHelper.GetText("GroupSelectionDialog.Title"),
+            Header = LocalizationHelper.GetText("GroupSelectionDialog.Header"),
+            SubHeader = LocalizationHelper.GetText("GroupSelectionDialog.SubHeader"),
+            IconSource = new SymbolIconSource { Symbol = Symbol.Folder },
+            XamlRoot = App.MainWindow
+        };
+
+        List<FATaskDialogCommand> commands = [];
+        foreach (GameGroup group in groups)
+        {
+            FATaskDialogCommand command = new FATaskDialogCommand
+            {
+                Text = group.Name,
+                IconSource = new SymbolIconSource { Symbol = Symbol.Folder },
+                ClosesOnInvoked = false
+            };
+
+            GameGroup capturedGroup = group;
+            command.Click += (_, _) =>
+            {
+                Logger.Info<GroupSelectionDialog>($"User selected group '{capturedGroup.Name}'");
+                taskDialog.Hide(capturedGroup);
+            };
+            commands.Add(command);
+        }
+
+        taskDialog.Commands = commands;
+        taskDialog.Buttons =
+        [
+            FATaskDialogButton.CloseButton
+        ];
+
+        object result = await taskDialog.ShowAsync(true);
+        if (result is GameGroup selected)
+        {
+            return selected;
+        }
+
+        Logger.Info<GroupSelectionDialog>("User cancelled group selection");
+        return null;
+    }
+}

--- a/source/XeniaManager/Resources/Language/en.axaml
+++ b/source/XeniaManager/Resources/Language/en.axaml
@@ -12,12 +12,37 @@
     <!-- Main View -->
     <sys:String x:Key="MainView.Navigation.OpenXenia">Open Xenia</sys:String>
     <sys:String x:Key="MainView.Navigation.Library">Game Library</sys:String>
+    <sys:String x:Key="MainView.Navigation.AddGroup">New Group</sys:String>
     <sys:String x:Key="MainView.Navigation.XeniaSettings">Xenia Settings</sys:String>
     <sys:String x:Key="MainView.Navigation.ManagePage">Manage Xenia</sys:String>
     <sys:String x:Key="MainView.Navigation.About">About</sys:String>
     <sys:String x:Key="MainView.Navigation.Settings">Settings</sys:String>
     <sys:String x:Key="MainView.Navigation.Error.Title">Error Navigating</sys:String>
     <sys:String x:Key="MainView.Navigation.Error.Message">Failed to navigate to designated page.&#10;{0}</sys:String>
+
+    <!-- Game Groups -->
+    <sys:String x:Key="GroupNameDialog.Title">New Group</sys:String>
+    <sys:String x:Key="GroupNameDialog.Message">Enter a name for this group:</sys:String>
+    <sys:String x:Key="GroupNameDialog.Watermark">Group name</sys:String>
+    <sys:String x:Key="GroupNameDialog.Save">Save</sys:String>
+    <sys:String x:Key="GroupNameDialog.EmptyName.Title">Invalid Group Name</sys:String>
+    <sys:String x:Key="GroupNameDialog.EmptyName.Message">Please enter a name for the group.</sys:String>
+    <sys:String x:Key="GroupSelectionDialog.Title">Add to Group</sys:String>
+    <sys:String x:Key="GroupSelectionDialog.Header">Select a group</sys:String>
+    <sys:String x:Key="GroupSelectionDialog.SubHeader">Choose which group to add this game to</sys:String>
+    <sys:String x:Key="GroupSelectionDialog.NoGroups.Title">No Groups</sys:String>
+    <sys:String x:Key="GroupSelectionDialog.NoGroups.Message">You don't have any groups yet. Create one now?</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.Header">Add to Group</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.ToolTip">Add this game (or all selected games) to a group</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.Success.Title">Added to Group</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.Success.Message">'{0}' was added to '{1}'.</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.AlreadyExists.Title">Already in Group</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.AlreadyExists.Message">'{0}' is already in '{1}'.</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.Multiple.Success.Title">Added to Group</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.Multiple.Success.Message">Added {0} game(s) to '{1}'.&#10;{2} were already in the group.</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.Error.Title">Failed to Add to Group</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.Error.Message">Failed to add '{0}' to a group: {1}</sys:String>
+    <sys:String x:Key="LibraryPage.AddSelectedToGroup.Button">Add to Group</sys:String>
 
     <!-- Library Page -->
     <sys:String x:Key="LibraryPage.Search.PlaceholderText">Search...</sys:String>

--- a/source/XeniaManager/Resources/Language/en.axaml
+++ b/source/XeniaManager/Resources/Language/en.axaml
@@ -12,7 +12,6 @@
     <!-- Main View -->
     <sys:String x:Key="MainView.Navigation.OpenXenia">Open Xenia</sys:String>
     <sys:String x:Key="MainView.Navigation.Library">Game Library</sys:String>
-    <sys:String x:Key="MainView.Navigation.AddGroup">New Group</sys:String>
     <sys:String x:Key="MainView.Navigation.XeniaSettings">Xenia Settings</sys:String>
     <sys:String x:Key="MainView.Navigation.ManagePage">Manage Xenia</sys:String>
     <sys:String x:Key="MainView.Navigation.About">About</sys:String>
@@ -25,24 +24,41 @@
     <sys:String x:Key="GroupNameDialog.Message">Enter a name for this group:</sys:String>
     <sys:String x:Key="GroupNameDialog.Watermark">Group name</sys:String>
     <sys:String x:Key="GroupNameDialog.Save">Save</sys:String>
-    <sys:String x:Key="GroupNameDialog.EmptyName.Title">Invalid Group Name</sys:String>
-    <sys:String x:Key="GroupNameDialog.EmptyName.Message">Please enter a name for the group.</sys:String>
     <sys:String x:Key="GroupSelectionDialog.Title">Add to Group</sys:String>
     <sys:String x:Key="GroupSelectionDialog.Header">Select a group</sys:String>
     <sys:String x:Key="GroupSelectionDialog.SubHeader">Choose which group to add this game to</sys:String>
+    <sys:String x:Key="GroupSelectionDialog.Message">Select one or more groups:</sys:String>
+    <sys:String x:Key="GroupSelectionDialog.Confirm">Add</sys:String>
     <sys:String x:Key="GroupSelectionDialog.NoGroups.Title">No Groups</sys:String>
     <sys:String x:Key="GroupSelectionDialog.NoGroups.Message">You don't have any groups yet. Create one now?</sys:String>
     <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.Header">Add to Group</sys:String>
-    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.ToolTip">Add this game (or all selected games) to a group</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.ToolTip">Add this game (or all selected games) to one or more groups</sys:String>
     <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.Success.Title">Added to Group</sys:String>
     <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.Success.Message">'{0}' was added to '{1}'.</sys:String>
     <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.AlreadyExists.Title">Already in Group</sys:String>
     <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.AlreadyExists.Message">'{0}' is already in '{1}'.</sys:String>
     <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.Multiple.Success.Title">Added to Group</sys:String>
     <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.Multiple.Success.Message">Added {0} game(s) to '{1}'.&#10;{2} were already in the group.</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.MultipleGroups.Success.Message">Added {0} game membership(s) across: {1}</sys:String>
     <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.Error.Title">Failed to Add to Group</sys:String>
     <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.Error.Message">Failed to add '{0}' to a group: {1}</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.RemoveFromGroup.Header">Remove from Group</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.RemoveFromGroup.ToolTip">Remove this game (or all selected games) from one or more groups</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.RemoveFromGroup.Message">Select the groups to remove from:</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.RemoveFromGroup.None.Title">Not in a Group</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.RemoveFromGroup.None.Message">The selected game(s) are not in any group.</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.RemoveFromGroup.Success.Title">Removed from Group</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.RemoveFromGroup.Success.Message">Removed {0} membership(s) from: {1}</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.RemoveFromGroup.Error.Title">Failed to Remove from Group</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.RemoveFromGroup.Error.Message">Failed to remove from group: {0}</sys:String>
     <sys:String x:Key="LibraryPage.AddSelectedToGroup.Button">Add to Group</sys:String>
+    <sys:String x:Key="LibraryPage.Groups.ToolTip">Game groups</sys:String>
+    <sys:String x:Key="LibraryPage.Groups.New.Header">New Group</sys:String>
+    <sys:String x:Key="LibraryPage.Groups.Ungrouped">Ungrouped</sys:String>
+    <sys:String x:Key="LibraryPage.Groups.Delete.ToolTip">Delete group</sys:String>
+    <sys:String x:Key="LibraryPage.Groups.Delete.Confirmation.Title">Delete Group</sys:String>
+    <sys:String x:Key="LibraryPage.Groups.Delete.Confirmation.Message">Delete group '{0}'? Games will not be removed from your library.</sys:String>
+
 
     <!-- Library Page -->
     <sys:String x:Key="LibraryPage.Search.PlaceholderText">Search...</sys:String>

--- a/source/XeniaManager/Resources/Language/hr.axaml
+++ b/source/XeniaManager/Resources/Language/hr.axaml
@@ -19,6 +19,47 @@
     <sys:String x:Key="MainView.Navigation.Error.Title">Greška pri navigaciji</sys:String>
     <sys:String x:Key="MainView.Navigation.Error.Message">Nije moguće navigirati na odredišnu stranicu.&#10;{0}</sys:String>
 
+    <!-- Game Groups -->
+    <sys:String x:Key="GroupNameDialog.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GroupNameDialog.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GroupNameDialog.Watermark">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GroupNameDialog.Save">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GroupSelectionDialog.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GroupSelectionDialog.Header">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GroupSelectionDialog.SubHeader">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GroupSelectionDialog.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GroupSelectionDialog.Confirm">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GroupSelectionDialog.NoGroups.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GroupSelectionDialog.NoGroups.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.Header">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.ToolTip">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.Success.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.Success.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.AlreadyExists.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.AlreadyExists.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.Multiple.Success.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.Multiple.Success.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.MultipleGroups.Success.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.Error.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.Error.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.RemoveFromGroup.Header">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.RemoveFromGroup.ToolTip">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.RemoveFromGroup.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.RemoveFromGroup.None.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.RemoveFromGroup.None.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.RemoveFromGroup.Success.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.RemoveFromGroup.Success.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.RemoveFromGroup.Error.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.RemoveFromGroup.Error.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="LibraryPage.AddSelectedToGroup.Button">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="LibraryPage.Groups.ToolTip">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="LibraryPage.Groups.New.Header">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="LibraryPage.Groups.Ungrouped">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="LibraryPage.Groups.Delete.ToolTip">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="LibraryPage.Groups.Delete.Confirmation.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="LibraryPage.Groups.Delete.Confirmation.Message">#NOTTRANSLATED#</sys:String>
+
+
     <!-- Library Page -->
     <sys:String x:Key="LibraryPage.Search.PlaceholderText">Pretraži...</sys:String>
     <sys:String x:Key="LibraryPage.Refresh.ToolTip">Ponovno učitava biblioteku igara</sys:String>
@@ -405,6 +446,12 @@
     <sys:String x:Key="GameButton.ContextFlyout.Content.Screenshots.NoScreenshots.Message">Nema pronađenih snimaka zaslona za {0}.</sys:String>
     <sys:String x:Key="GameButton.ContextFlyout.Content.Screenshots.Error.Title">Otvaranje mape nije uspjelo</sys:String>
     <sys:String x:Key="GameButton.ContextFlyout.Content.Screenshots.Error.Message">Došlo je do greške prilikom otvaranja mape sa snimkama zaslona.&#10;{0}</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.Content.GameLocation.Header">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.Content.GameLocation.ToolTip">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.Content.GameLocation.NoGameDir.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.Content.GameLocation.NoGameDir.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.Content.GameLocation.Error.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.Content.GameLocation.Error.Message">#NOTTRANSLATED#</sys:String>
     <sys:String x:Key="GameButton.ContextFlyout.Patches.Header">Zakrpe</sys:String>
     <sys:String x:Key="GameButton.ContextFlyout.Patches.Download.Header">Preuzmi</sys:String>
     <sys:String x:Key="GameButton.ContextFlyout.Patches.Download.ToolTip">Preuzmite zakrpe iz repozitorija</sys:String>

--- a/source/XeniaManager/Resources/Language/it.axaml
+++ b/source/XeniaManager/Resources/Language/it.axaml
@@ -19,6 +19,47 @@
     <sys:String x:Key="MainView.Navigation.Error.Title">Errore di navigazione</sys:String>
     <sys:String x:Key="MainView.Navigation.Error.Message">Impossibile navigare alla pagina designata.&#10;{0}</sys:String>
 
+    <!-- Game Groups -->
+    <sys:String x:Key="GroupNameDialog.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GroupNameDialog.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GroupNameDialog.Watermark">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GroupNameDialog.Save">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GroupSelectionDialog.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GroupSelectionDialog.Header">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GroupSelectionDialog.SubHeader">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GroupSelectionDialog.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GroupSelectionDialog.Confirm">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GroupSelectionDialog.NoGroups.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GroupSelectionDialog.NoGroups.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.Header">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.ToolTip">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.Success.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.Success.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.AlreadyExists.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.AlreadyExists.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.Multiple.Success.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.Multiple.Success.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.MultipleGroups.Success.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.Error.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.Error.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.RemoveFromGroup.Header">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.RemoveFromGroup.ToolTip">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.RemoveFromGroup.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.RemoveFromGroup.None.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.RemoveFromGroup.None.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.RemoveFromGroup.Success.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.RemoveFromGroup.Success.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.RemoveFromGroup.Error.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.RemoveFromGroup.Error.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="LibraryPage.AddSelectedToGroup.Button">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="LibraryPage.Groups.ToolTip">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="LibraryPage.Groups.New.Header">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="LibraryPage.Groups.Ungrouped">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="LibraryPage.Groups.Delete.ToolTip">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="LibraryPage.Groups.Delete.Confirmation.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="LibraryPage.Groups.Delete.Confirmation.Message">#NOTTRANSLATED#</sys:String>
+
+
     <!-- Library Page -->
     <sys:String x:Key="LibraryPage.Search.PlaceholderText">Cerca...</sys:String>
     <sys:String x:Key="LibraryPage.Refresh.ToolTip">Ricarica la libreria giochi</sys:String>
@@ -405,6 +446,12 @@
     <sys:String x:Key="GameButton.ContextFlyout.Content.Screenshots.NoScreenshots.Message">Nessuno screenshot trovato per {0}.</sys:String>
     <sys:String x:Key="GameButton.ContextFlyout.Content.Screenshots.Error.Title">Impossibile Aprire la Cartella</sys:String>
     <sys:String x:Key="GameButton.ContextFlyout.Content.Screenshots.Error.Message">Si è verificato un errore durante l'apertura della cartella screenshot.&#10;{0}</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.Content.GameLocation.Header">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.Content.GameLocation.ToolTip">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.Content.GameLocation.NoGameDir.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.Content.GameLocation.NoGameDir.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.Content.GameLocation.Error.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.Content.GameLocation.Error.Message">#NOTTRANSLATED#</sys:String>
     <sys:String x:Key="GameButton.ContextFlyout.Patches.Header">Patch</sys:String>
     <sys:String x:Key="GameButton.ContextFlyout.Patches.Download.Header">Scarica</sys:String>
     <sys:String x:Key="GameButton.ContextFlyout.Patches.Download.ToolTip">Scarica le patch dal repository</sys:String>

--- a/source/XeniaManager/Resources/Language/pt-BR.axaml
+++ b/source/XeniaManager/Resources/Language/pt-BR.axaml
@@ -19,6 +19,47 @@
     <sys:String x:Key="MainView.Navigation.Error.Title">Erro de Navegação</sys:String>
     <sys:String x:Key="MainView.Navigation.Error.Message">Falha ao navegar para página designada.&#10;{0}</sys:String>
 
+    <!-- Game Groups -->
+    <sys:String x:Key="GroupNameDialog.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GroupNameDialog.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GroupNameDialog.Watermark">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GroupNameDialog.Save">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GroupSelectionDialog.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GroupSelectionDialog.Header">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GroupSelectionDialog.SubHeader">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GroupSelectionDialog.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GroupSelectionDialog.Confirm">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GroupSelectionDialog.NoGroups.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GroupSelectionDialog.NoGroups.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.Header">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.ToolTip">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.Success.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.Success.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.AlreadyExists.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.AlreadyExists.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.Multiple.Success.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.Multiple.Success.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.MultipleGroups.Success.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.Error.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.Error.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.RemoveFromGroup.Header">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.RemoveFromGroup.ToolTip">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.RemoveFromGroup.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.RemoveFromGroup.None.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.RemoveFromGroup.None.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.RemoveFromGroup.Success.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.RemoveFromGroup.Success.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.RemoveFromGroup.Error.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.RemoveFromGroup.Error.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="LibraryPage.AddSelectedToGroup.Button">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="LibraryPage.Groups.ToolTip">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="LibraryPage.Groups.New.Header">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="LibraryPage.Groups.Ungrouped">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="LibraryPage.Groups.Delete.ToolTip">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="LibraryPage.Groups.Delete.Confirmation.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="LibraryPage.Groups.Delete.Confirmation.Message">#NOTTRANSLATED#</sys:String>
+
+
     <!-- Library Page -->
     <sys:String x:Key="LibraryPage.Search.PlaceholderText">Buscar...</sys:String>
     <sys:String x:Key="LibraryPage.Refresh.ToolTip">#NOTTRANSLATED#</sys:String>
@@ -405,6 +446,12 @@
     <sys:String x:Key="GameButton.ContextFlyout.Content.Screenshots.NoScreenshots.Message">Nenhuma captura de tela encontrada para {0}.</sys:String>
     <sys:String x:Key="GameButton.ContextFlyout.Content.Screenshots.Error.Title">Falha ao abrir a pasta</sys:String>
     <sys:String x:Key="GameButton.ContextFlyout.Content.Screenshots.Error.Message">Ocorreu um erro ao abrir a pasta de capturas de tela.&#10;{0}</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.Content.GameLocation.Header">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.Content.GameLocation.ToolTip">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.Content.GameLocation.NoGameDir.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.Content.GameLocation.NoGameDir.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.Content.GameLocation.Error.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.Content.GameLocation.Error.Message">#NOTTRANSLATED#</sys:String>
     <sys:String x:Key="GameButton.ContextFlyout.Patches.Header">Patches</sys:String>
     <sys:String x:Key="GameButton.ContextFlyout.Patches.Download.Header">Baixar</sys:String>
     <sys:String x:Key="GameButton.ContextFlyout.Patches.Download.ToolTip">Baixar patches do repositório</sys:String>

--- a/source/XeniaManager/Resources/Language/ru.axaml
+++ b/source/XeniaManager/Resources/Language/ru.axaml
@@ -19,6 +19,47 @@
     <sys:String x:Key="MainView.Navigation.Error.Title">Ошибка навигации</sys:String>
     <sys:String x:Key="MainView.Navigation.Error.Message">Не удалось перейти на указанную страницу.&#10;{0}</sys:String>
 
+    <!-- Game Groups -->
+    <sys:String x:Key="GroupNameDialog.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GroupNameDialog.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GroupNameDialog.Watermark">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GroupNameDialog.Save">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GroupSelectionDialog.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GroupSelectionDialog.Header">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GroupSelectionDialog.SubHeader">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GroupSelectionDialog.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GroupSelectionDialog.Confirm">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GroupSelectionDialog.NoGroups.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GroupSelectionDialog.NoGroups.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.Header">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.ToolTip">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.Success.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.Success.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.AlreadyExists.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.AlreadyExists.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.Multiple.Success.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.Multiple.Success.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.MultipleGroups.Success.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.Error.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.Error.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.RemoveFromGroup.Header">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.RemoveFromGroup.ToolTip">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.RemoveFromGroup.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.RemoveFromGroup.None.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.RemoveFromGroup.None.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.RemoveFromGroup.Success.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.RemoveFromGroup.Success.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.RemoveFromGroup.Error.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.RemoveFromGroup.Error.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="LibraryPage.AddSelectedToGroup.Button">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="LibraryPage.Groups.ToolTip">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="LibraryPage.Groups.New.Header">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="LibraryPage.Groups.Ungrouped">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="LibraryPage.Groups.Delete.ToolTip">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="LibraryPage.Groups.Delete.Confirmation.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="LibraryPage.Groups.Delete.Confirmation.Message">#NOTTRANSLATED#</sys:String>
+
+
     <!-- Library Page -->
     <sys:String x:Key="LibraryPage.Search.PlaceholderText">Поиск…</sys:String>
     <sys:String x:Key="LibraryPage.Refresh.ToolTip">#NOTTRANSLATED#</sys:String>
@@ -405,6 +446,12 @@
     <sys:String x:Key="GameButton.ContextFlyout.Content.Screenshots.NoScreenshots.Message">Не найдены скриншоты для {0}.</sys:String>
     <sys:String x:Key="GameButton.ContextFlyout.Content.Screenshots.Error.Title">Не удалось открыть папку</sys:String>
     <sys:String x:Key="GameButton.ContextFlyout.Content.Screenshots.Error.Message">Ошибка при открытии папки со скриншотами.&#10;{0}</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.Content.GameLocation.Header">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.Content.GameLocation.ToolTip">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.Content.GameLocation.NoGameDir.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.Content.GameLocation.NoGameDir.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.Content.GameLocation.Error.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.Content.GameLocation.Error.Message">#NOTTRANSLATED#</sys:String>
     <sys:String x:Key="GameButton.ContextFlyout.Patches.Header">Патчи</sys:String>
     <sys:String x:Key="GameButton.ContextFlyout.Patches.Download.Header">Скачать</sys:String>
     <sys:String x:Key="GameButton.ContextFlyout.Patches.Download.ToolTip">Скачать патчи из репозитория</sys:String>

--- a/source/XeniaManager/Resources/Language/tr.axaml
+++ b/source/XeniaManager/Resources/Language/tr.axaml
@@ -19,6 +19,47 @@
     <sys:String x:Key="MainView.Navigation.Error.Title">Gezinme Hatası</sys:String>
     <sys:String x:Key="MainView.Navigation.Error.Message">Belirtilen sayfaya yönlendirilemedi.&#10;{0}</sys:String>
 
+    <!-- Game Groups -->
+    <sys:String x:Key="GroupNameDialog.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GroupNameDialog.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GroupNameDialog.Watermark">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GroupNameDialog.Save">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GroupSelectionDialog.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GroupSelectionDialog.Header">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GroupSelectionDialog.SubHeader">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GroupSelectionDialog.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GroupSelectionDialog.Confirm">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GroupSelectionDialog.NoGroups.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GroupSelectionDialog.NoGroups.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.Header">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.ToolTip">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.Success.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.Success.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.AlreadyExists.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.AlreadyExists.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.Multiple.Success.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.Multiple.Success.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.MultipleGroups.Success.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.Error.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.Error.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.RemoveFromGroup.Header">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.RemoveFromGroup.ToolTip">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.RemoveFromGroup.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.RemoveFromGroup.None.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.RemoveFromGroup.None.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.RemoveFromGroup.Success.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.RemoveFromGroup.Success.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.RemoveFromGroup.Error.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.RemoveFromGroup.Error.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="LibraryPage.AddSelectedToGroup.Button">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="LibraryPage.Groups.ToolTip">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="LibraryPage.Groups.New.Header">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="LibraryPage.Groups.Ungrouped">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="LibraryPage.Groups.Delete.ToolTip">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="LibraryPage.Groups.Delete.Confirmation.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="LibraryPage.Groups.Delete.Confirmation.Message">#NOTTRANSLATED#</sys:String>
+
+
     <!-- Library Page -->
     <sys:String x:Key="LibraryPage.Search.PlaceholderText">Ara...</sys:String>
     <sys:String x:Key="LibraryPage.Refresh.ToolTip">#NOTTRANSLATED#</sys:String>
@@ -405,6 +446,12 @@
     <sys:String x:Key="GameButton.ContextFlyout.Content.Screenshots.NoScreenshots.Message">{0} için ekran görüntüsü bulunamadı.</sys:String>
     <sys:String x:Key="GameButton.ContextFlyout.Content.Screenshots.Error.Title">Klasör Açılamadı</sys:String>
     <sys:String x:Key="GameButton.ContextFlyout.Content.Screenshots.Error.Message">Ekran görüntüleri klasörü açılırken bir hata oluştu.&#10;{0}</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.Content.GameLocation.Header">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.Content.GameLocation.ToolTip">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.Content.GameLocation.NoGameDir.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.Content.GameLocation.NoGameDir.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.Content.GameLocation.Error.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.Content.GameLocation.Error.Message">#NOTTRANSLATED#</sys:String>
     <sys:String x:Key="GameButton.ContextFlyout.Patches.Header">Yamalar</sys:String>
     <sys:String x:Key="GameButton.ContextFlyout.Patches.Download.Header">İndir</sys:String>
     <sys:String x:Key="GameButton.ContextFlyout.Patches.Download.ToolTip">Depodan yama indirir</sys:String>

--- a/source/XeniaManager/Resources/Language/zh-CN.axaml
+++ b/source/XeniaManager/Resources/Language/zh-CN.axaml
@@ -19,6 +19,47 @@
     <sys:String x:Key="MainView.Navigation.Error.Title">导航错误</sys:String>
     <sys:String x:Key="MainView.Navigation.Error.Message">无法导航到指定页面。&#10;{0}</sys:String>
 
+    <!-- Game Groups -->
+    <sys:String x:Key="GroupNameDialog.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GroupNameDialog.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GroupNameDialog.Watermark">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GroupNameDialog.Save">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GroupSelectionDialog.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GroupSelectionDialog.Header">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GroupSelectionDialog.SubHeader">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GroupSelectionDialog.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GroupSelectionDialog.Confirm">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GroupSelectionDialog.NoGroups.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GroupSelectionDialog.NoGroups.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.Header">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.ToolTip">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.Success.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.Success.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.AlreadyExists.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.AlreadyExists.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.Multiple.Success.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.Multiple.Success.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.MultipleGroups.Success.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.Error.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.AddToGroup.Error.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.RemoveFromGroup.Header">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.RemoveFromGroup.ToolTip">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.RemoveFromGroup.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.RemoveFromGroup.None.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.RemoveFromGroup.None.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.RemoveFromGroup.Success.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.RemoveFromGroup.Success.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.RemoveFromGroup.Error.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.RemoveFromGroup.Error.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="LibraryPage.AddSelectedToGroup.Button">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="LibraryPage.Groups.ToolTip">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="LibraryPage.Groups.New.Header">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="LibraryPage.Groups.Ungrouped">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="LibraryPage.Groups.Delete.ToolTip">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="LibraryPage.Groups.Delete.Confirmation.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="LibraryPage.Groups.Delete.Confirmation.Message">#NOTTRANSLATED#</sys:String>
+
+
     <!-- Library Page -->
     <sys:String x:Key="LibraryPage.Search.PlaceholderText">搜索...</sys:String>
     <sys:String x:Key="LibraryPage.Refresh.ToolTip">重新加载游戏库</sys:String>
@@ -405,6 +446,12 @@
     <sys:String x:Key="GameButton.ContextFlyout.Content.Screenshots.NoScreenshots.Message">未找到 {0} 的屏幕截图。</sys:String>
     <sys:String x:Key="GameButton.ContextFlyout.Content.Screenshots.Error.Title">打开文件夹失败</sys:String>
     <sys:String x:Key="GameButton.ContextFlyout.Content.Screenshots.Error.Message">打开屏幕截图文件夹时出错。&#10;{0}</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.Content.GameLocation.Header">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.Content.GameLocation.ToolTip">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.Content.GameLocation.NoGameDir.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.Content.GameLocation.NoGameDir.Message">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.Content.GameLocation.Error.Title">#NOTTRANSLATED#</sys:String>
+    <sys:String x:Key="GameButton.ContextFlyout.Content.GameLocation.Error.Message">#NOTTRANSLATED#</sys:String>
     <sys:String x:Key="GameButton.ContextFlyout.Patches.Header">补丁</sys:String>
     <sys:String x:Key="GameButton.ContextFlyout.Patches.Download.Header">下载</sys:String>
     <sys:String x:Key="GameButton.ContextFlyout.Patches.Download.ToolTip">从仓库下载补丁</sys:String>

--- a/source/XeniaManager/Services/NavigationService.cs
+++ b/source/XeniaManager/Services/NavigationService.cs
@@ -10,7 +10,6 @@ using XeniaManager.Controls;
 using XeniaManager.Core.Logging;
 using XeniaManager.Core.Manage;
 using XeniaManager.Core.Models;
-using XeniaManager.Core.Models.Game;
 using XeniaManager.Core.Services;
 using XeniaManager.Core.Settings;
 using XeniaManager.Core.Utilities;
@@ -155,13 +154,8 @@ public class NavigationService
                 break;
             case "Library":
                 Logger.Debug<NavigationService>("Navigating to Library page");
-                GroupManager.SetActiveFilter(null);
                 frame.Navigate(typeof(LibraryPage), null, new FAEntranceNavigationTransitionInfo());
                 break;
-            case "AddGroup":
-                Logger.Info<NavigationService>("Processing 'AddGroup' tag");
-                await HandleAddGroupAsync(frame);
-                return;
             case "XeniaSettings":
                 Logger.Debug<NavigationService>("Navigating to Xenia Settings page");
                 Logger.Info<NavigationService>($"Found {installedVersions.Count} installed Xenia versions, allowing navigation to Xenia Settings");
@@ -180,12 +174,6 @@ public class NavigationService
                 frame.Navigate(typeof(SettingsPage), null, new FAEntranceNavigationTransitionInfo());
                 break;
             default:
-                if (tag.StartsWith("Group:", StringComparison.Ordinal))
-                {
-                    await HandleGroupFilterAsync(tag, frame);
-                    break;
-                }
-
                 Logger.Warning<NavigationService>($"Unknown navigation tag requested: {tag}");
                 break;
         }
@@ -209,59 +197,6 @@ public class NavigationService
 
         Navigated?.Invoke(this, tag);
         Logger.Info<NavigationService>($"Navigation to tag '{tag}' completed successfully");
-    }
-
-    /// <summary>
-    /// Prompts for a group name, creates the group, then selects it in the library.
-    /// </summary>
-    private async Task HandleAddGroupAsync(FAFrame frame)
-    {
-        string? name = await GroupNameDialog.ShowAsync();
-        if (string.IsNullOrWhiteSpace(name))
-        {
-            Logger.Info<NavigationService>("Add group cancelled or empty name");
-            // Restore previous library selection visually
-            string restoreTag = GroupManager.ActiveFilterGroupId is Guid activeId
-                ? $"Group:{activeId}"
-                : "Library";
-            UpdateSelection(restoreTag);
-            return;
-        }
-
-        GameGroup group = GroupManager.CreateGroup(name);
-        GroupManager.SetActiveFilter(group.Id);
-        frame.Navigate(typeof(LibraryPage), null, new FAEntranceNavigationTransitionInfo());
-        _currentPageTag = $"Group:{group.Id}";
-        UpdateSelection(_currentPageTag);
-        SetSelectedIcon(FindNavigationItemByTag("Library"));
-        Navigated?.Invoke(this, _currentPageTag);
-        Logger.Info<NavigationService>($"Created and selected group '{group.Name}'");
-    }
-
-    /// <summary>
-    /// Navigates to the library and filters it to the selected group.
-    /// </summary>
-    private async Task HandleGroupFilterAsync(string tag, FAFrame frame)
-    {
-        string idText = tag["Group:".Length..];
-        if (!Guid.TryParse(idText, out Guid groupId))
-        {
-            Logger.Warning<NavigationService>($"Invalid group navigation tag: {tag}");
-            await _messageBoxService.ShowWarningAsync(
-                LocalizationHelper.GetText("MainView.Navigation.Error.Title"),
-                $"Invalid group id in tag '{tag}'");
-            return;
-        }
-
-        if (GroupManager.Groups.All(g => g.Id != groupId))
-        {
-            Logger.Warning<NavigationService>($"Group not found for tag: {tag}");
-            return;
-        }
-
-        Logger.Info<NavigationService>($"Filtering library by group {groupId}");
-        GroupManager.SetActiveFilter(groupId);
-        frame.Navigate(typeof(LibraryPage), null, new FAEntranceNavigationTransitionInfo());
     }
 
     /// <summary>
@@ -335,8 +270,8 @@ public class NavigationService
             return null;
         }
 
-        FANavigationViewItem? menuItem = FindNavigationItemByTagRecursive(
-            _navigationView.MenuItems.OfType<FANavigationViewItem>(), tag);
+        // Search in menu items
+        FANavigationViewItem? menuItem = _navigationView.MenuItems.OfType<FANavigationViewItem>().FirstOrDefault(x => x.Tag?.ToString() == tag);
 
         if (menuItem != null)
         {
@@ -344,31 +279,10 @@ public class NavigationService
             return menuItem;
         }
 
-        FANavigationViewItem? footerItem = FindNavigationItemByTagRecursive(
-            _navigationView.FooterMenuItems.OfType<FANavigationViewItem>(), tag);
+        // Search in footer items
+        FANavigationViewItem? footerItem = _navigationView.FooterMenuItems.OfType<FANavigationViewItem>().FirstOrDefault(x => x.Tag?.ToString() == tag);
         Logger.Trace<NavigationService>(footerItem != null ? $"Found item '{tag}' in footer items" : $"Item '{tag}' not found in menu or footer");
 
         return footerItem;
-    }
-
-    private static FANavigationViewItem? FindNavigationItemByTagRecursive(
-        IEnumerable<FANavigationViewItem> items, string tag)
-    {
-        foreach (FANavigationViewItem item in items)
-        {
-            if (item.Tag?.ToString() == tag)
-            {
-                return item;
-            }
-
-            FANavigationViewItem? nested = FindNavigationItemByTagRecursive(
-                item.MenuItems.OfType<FANavigationViewItem>(), tag);
-            if (nested != null)
-            {
-                return nested;
-            }
-        }
-
-        return null;
     }
 }

--- a/source/XeniaManager/Services/NavigationService.cs
+++ b/source/XeniaManager/Services/NavigationService.cs
@@ -10,6 +10,7 @@ using XeniaManager.Controls;
 using XeniaManager.Core.Logging;
 using XeniaManager.Core.Manage;
 using XeniaManager.Core.Models;
+using XeniaManager.Core.Models.Game;
 using XeniaManager.Core.Services;
 using XeniaManager.Core.Settings;
 using XeniaManager.Core.Utilities;
@@ -154,8 +155,13 @@ public class NavigationService
                 break;
             case "Library":
                 Logger.Debug<NavigationService>("Navigating to Library page");
+                GroupManager.SetActiveFilter(null);
                 frame.Navigate(typeof(LibraryPage), null, new FAEntranceNavigationTransitionInfo());
                 break;
+            case "AddGroup":
+                Logger.Info<NavigationService>("Processing 'AddGroup' tag");
+                await HandleAddGroupAsync(frame);
+                return;
             case "XeniaSettings":
                 Logger.Debug<NavigationService>("Navigating to Xenia Settings page");
                 Logger.Info<NavigationService>($"Found {installedVersions.Count} installed Xenia versions, allowing navigation to Xenia Settings");
@@ -174,6 +180,12 @@ public class NavigationService
                 frame.Navigate(typeof(SettingsPage), null, new FAEntranceNavigationTransitionInfo());
                 break;
             default:
+                if (tag.StartsWith("Group:", StringComparison.Ordinal))
+                {
+                    await HandleGroupFilterAsync(tag, frame);
+                    break;
+                }
+
                 Logger.Warning<NavigationService>($"Unknown navigation tag requested: {tag}");
                 break;
         }
@@ -197,6 +209,59 @@ public class NavigationService
 
         Navigated?.Invoke(this, tag);
         Logger.Info<NavigationService>($"Navigation to tag '{tag}' completed successfully");
+    }
+
+    /// <summary>
+    /// Prompts for a group name, creates the group, then selects it in the library.
+    /// </summary>
+    private async Task HandleAddGroupAsync(FAFrame frame)
+    {
+        string? name = await GroupNameDialog.ShowAsync();
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            Logger.Info<NavigationService>("Add group cancelled or empty name");
+            // Restore previous library selection visually
+            string restoreTag = GroupManager.ActiveFilterGroupId is Guid activeId
+                ? $"Group:{activeId}"
+                : "Library";
+            UpdateSelection(restoreTag);
+            return;
+        }
+
+        GameGroup group = GroupManager.CreateGroup(name);
+        GroupManager.SetActiveFilter(group.Id);
+        frame.Navigate(typeof(LibraryPage), null, new FAEntranceNavigationTransitionInfo());
+        _currentPageTag = $"Group:{group.Id}";
+        UpdateSelection(_currentPageTag);
+        SetSelectedIcon(FindNavigationItemByTag("Library"));
+        Navigated?.Invoke(this, _currentPageTag);
+        Logger.Info<NavigationService>($"Created and selected group '{group.Name}'");
+    }
+
+    /// <summary>
+    /// Navigates to the library and filters it to the selected group.
+    /// </summary>
+    private async Task HandleGroupFilterAsync(string tag, FAFrame frame)
+    {
+        string idText = tag["Group:".Length..];
+        if (!Guid.TryParse(idText, out Guid groupId))
+        {
+            Logger.Warning<NavigationService>($"Invalid group navigation tag: {tag}");
+            await _messageBoxService.ShowWarningAsync(
+                LocalizationHelper.GetText("MainView.Navigation.Error.Title"),
+                $"Invalid group id in tag '{tag}'");
+            return;
+        }
+
+        if (GroupManager.Groups.All(g => g.Id != groupId))
+        {
+            Logger.Warning<NavigationService>($"Group not found for tag: {tag}");
+            return;
+        }
+
+        Logger.Info<NavigationService>($"Filtering library by group {groupId}");
+        GroupManager.SetActiveFilter(groupId);
+        frame.Navigate(typeof(LibraryPage), null, new FAEntranceNavigationTransitionInfo());
     }
 
     /// <summary>
@@ -270,8 +335,8 @@ public class NavigationService
             return null;
         }
 
-        // Search in menu items
-        FANavigationViewItem? menuItem = _navigationView.MenuItems.OfType<FANavigationViewItem>().FirstOrDefault(x => x.Tag?.ToString() == tag);
+        FANavigationViewItem? menuItem = FindNavigationItemByTagRecursive(
+            _navigationView.MenuItems.OfType<FANavigationViewItem>(), tag);
 
         if (menuItem != null)
         {
@@ -279,10 +344,31 @@ public class NavigationService
             return menuItem;
         }
 
-        // Search in footer items
-        FANavigationViewItem? footerItem = _navigationView.FooterMenuItems.OfType<FANavigationViewItem>().FirstOrDefault(x => x.Tag?.ToString() == tag);
+        FANavigationViewItem? footerItem = FindNavigationItemByTagRecursive(
+            _navigationView.FooterMenuItems.OfType<FANavigationViewItem>(), tag);
         Logger.Trace<NavigationService>(footerItem != null ? $"Found item '{tag}' in footer items" : $"Item '{tag}' not found in menu or footer");
 
         return footerItem;
+    }
+
+    private static FANavigationViewItem? FindNavigationItemByTagRecursive(
+        IEnumerable<FANavigationViewItem> items, string tag)
+    {
+        foreach (FANavigationViewItem item in items)
+        {
+            if (item.Tag?.ToString() == tag)
+            {
+                return item;
+            }
+
+            FANavigationViewItem? nested = FindNavigationItemByTagRecursive(
+                item.MenuItems.OfType<FANavigationViewItem>(), tag);
+            if (nested != null)
+            {
+                return nested;
+            }
+        }
+
+        return null;
     }
 }

--- a/source/XeniaManager/ViewModels/Items/GameGroupSectionViewModel.cs
+++ b/source/XeniaManager/ViewModels/Items/GameGroupSectionViewModel.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using XeniaManager.ViewModels.Pages;
+
+namespace XeniaManager.ViewModels.Items;
+
+/// <summary>
+/// A collapsible library section representing a game group (or the ungrouped bucket).
+/// </summary>
+public partial class GameGroupSectionViewModel : ViewModelBase
+{
+    private readonly LibraryPageViewModel _library;
+
+    /// <summary>
+    /// Group id, or null for the Ungrouped section.
+    /// </summary>
+    public Guid? GroupId { get; }
+
+    [ObservableProperty] private string _name = string.Empty;
+    [ObservableProperty] private bool _isExpanded = true;
+    [ObservableProperty] private ObservableCollection<GameItemViewModel> _games = [];
+
+    public bool IsUserGroup => GroupId.HasValue;
+
+    public string HeaderText => $"{Name} ({Games.Count})";
+
+    public GameGroupSectionViewModel(Guid? groupId, string name, LibraryPageViewModel library)
+    {
+        GroupId = groupId;
+        Name = name;
+        _library = library;
+    }
+
+    public void SetGames(IEnumerable<GameItemViewModel> games)
+    {
+        Games = new ObservableCollection<GameItemViewModel>(games);
+        OnPropertyChanged(nameof(HeaderText));
+    }
+
+    [RelayCommand]
+    private async Task DeleteGroup()
+    {
+        if (GroupId is Guid id)
+        {
+            await _library.DeleteGroupAsync(id, Name);
+        }
+    }
+}

--- a/source/XeniaManager/ViewModels/Items/GameItemViewModel.cs
+++ b/source/XeniaManager/ViewModels/Items/GameItemViewModel.cs
@@ -966,6 +966,13 @@ public partial class GameItemViewModel : ViewModelBase
     }
 
     [RelayCommand]
+    private async Task RemoveFromGroup()
+    {
+        List<GameItemViewModel> games = _library.GetGamesForGroupAction(this);
+        await _library.RemoveGamesFromGroupAsync(games);
+    }
+
+    [RelayCommand]
     private async Task RemoveGame()
     {
         if (await _messageBoxService.ShowConfirmationAsync(LocalizationHelper.GetText("GameButton.ContextFlyout.RemoveGame.Confirmation.Title"),

--- a/source/XeniaManager/ViewModels/Items/GameItemViewModel.cs
+++ b/source/XeniaManager/ViewModels/Items/GameItemViewModel.cs
@@ -958,6 +958,14 @@ public partial class GameItemViewModel : ViewModelBase
     }
 
     [RelayCommand]
+    private async Task AddToGroup()
+    {
+        // If this game is part of a multi-selection, add all selected games
+        List<GameItemViewModel> games = _library.GetGamesForGroupAction(this);
+        await _library.AddGamesToGroupAsync(games);
+    }
+
+    [RelayCommand]
     private async Task RemoveGame()
     {
         if (await _messageBoxService.ShowConfirmationAsync(LocalizationHelper.GetText("GameButton.ContextFlyout.RemoveGame.Confirmation.Title"),

--- a/source/XeniaManager/ViewModels/Pages/LibraryPageViewModel.cs
+++ b/source/XeniaManager/ViewModels/Pages/LibraryPageViewModel.cs
@@ -303,6 +303,11 @@ public partial class LibraryPageViewModel : ViewModelBase
     // Search
     [ObservableProperty] private string _searchQuery = string.Empty;
 
+    /// <summary>
+    /// Active group filter id. Null shows the full library.
+    /// </summary>
+    [ObservableProperty] private Guid? _activeGroupFilterId;
+
     partial void OnSearchQueryChanged(string value)
     {
         // Debounce search to avoid filtering on every keystroke
@@ -318,6 +323,11 @@ public partial class LibraryPageViewModel : ViewModelBase
                 FilterGames();
             }
         }, TaskScheduler.FromCurrentSynchronizationContext());
+    }
+
+    partial void OnActiveGroupFilterIdChanged(Guid? value)
+    {
+        FilterGames();
     }
 
     [RelayCommand]
@@ -337,10 +347,39 @@ public partial class LibraryPageViewModel : ViewModelBase
         // Load UI settings
         LoadUiSettings();
 
+        ActiveGroupFilterId = GroupManager.ActiveFilterGroupId;
         RefreshLibrary();
 
         _watcherService.NewGameFilesDetected += OnNewGameFilesDetected;
         EventManager.Instance.GameLibraryChanged += OnGameLibraryChanged;
+        EventManager.Instance.GroupFilterChanged += OnGroupFilterChanged;
+        EventManager.Instance.GameGroupsChanged += OnGameGroupsChanged;
+    }
+
+    private void OnGroupFilterChanged(Guid? groupId)
+    {
+        if (!Dispatcher.UIThread.CheckAccess())
+        {
+            Dispatcher.UIThread.Post(() => OnGroupFilterChanged(groupId));
+            return;
+        }
+
+        ActiveGroupFilterId = groupId;
+    }
+
+    private void OnGameGroupsChanged()
+    {
+        if (!Dispatcher.UIThread.CheckAccess())
+        {
+            Dispatcher.UIThread.Post(OnGameGroupsChanged);
+            return;
+        }
+
+        // Membership may have changed for the active filter
+        if (ActiveGroupFilterId.HasValue)
+        {
+            FilterGames();
+        }
     }
 
     /// <summary>
@@ -424,25 +463,27 @@ public partial class LibraryPageViewModel : ViewModelBase
     }
 
     /// <summary>
-    /// Filters the games collection based on the search query.
+    /// Filters the games collection based on the active group and search query.
     /// Searches by Game.Title and Game.GameId.
     /// </summary>
     private void FilterGames()
     {
-        List<GameItemViewModel> filtered;
-        if (string.IsNullOrWhiteSpace(SearchQuery))
+        IEnumerable<GameItemViewModel> query = _allGames;
+
+        if (ActiveGroupFilterId is Guid groupId)
         {
-            filtered = [.. _allGames];
+            query = query.Where(item => GroupManager.IsInGroup(groupId, item.Game));
         }
-        else
+
+        if (!string.IsNullOrWhiteSpace(SearchQuery))
         {
-            string query = SearchQuery.ToLowerInvariant();
-            filtered = _allGames
-                .Where(item =>
-                    item.Title.Contains(query, StringComparison.InvariantCultureIgnoreCase) ||
-                    item.Game.GameId.Contains(query, StringComparison.InvariantCultureIgnoreCase))
-                .ToList();
+            string search = SearchQuery.ToLowerInvariant();
+            query = query.Where(item =>
+                item.Title.Contains(search, StringComparison.InvariantCultureIgnoreCase) ||
+                item.Game.GameId.Contains(search, StringComparison.InvariantCultureIgnoreCase));
         }
+
+        List<GameItemViewModel> filtered = query.ToList();
 
         // Apply sorting
         filtered = SortOption switch
@@ -1782,6 +1823,116 @@ public partial class LibraryPageViewModel : ViewModelBase
         foreach (GameItemViewModel game in _allGames)
         {
             game.IsSelected = false;
+        }
+    }
+
+    /// <summary>
+    /// Returns the games that an Add-to-Group action should target.
+    /// If the clicked game is part of a multi-selection, all selected games are returned;
+    /// otherwise only the clicked game is returned.
+    /// </summary>
+    public List<GameItemViewModel> GetGamesForGroupAction(GameItemViewModel clickedGame)
+    {
+        List<GameItemViewModel> selectedGames = _allGames.Where(g => g.IsSelected).ToList();
+        if (selectedGames.Count > 1 && selectedGames.Contains(clickedGame))
+        {
+            return selectedGames;
+        }
+
+        return [clickedGame];
+    }
+
+    /// <summary>
+    /// Adds the currently selected games to a chosen (or newly created) group.
+    /// </summary>
+    [RelayCommand]
+    private async Task AddSelectedGamesToGroup()
+    {
+        List<GameItemViewModel> selectedGames = _allGames.Where(g => g.IsSelected).ToList();
+        if (selectedGames.Count == 0)
+        {
+            return;
+        }
+
+        await AddGamesToGroupAsync(selectedGames);
+    }
+
+    /// <summary>
+    /// Prompts for a group and adds the given games to it.
+    /// </summary>
+    public async Task AddGamesToGroupAsync(IReadOnlyList<GameItemViewModel> games)
+    {
+        if (games.Count == 0)
+        {
+            return;
+        }
+
+        try
+        {
+            Logger.Info<LibraryPageViewModel>($"Add to group requested for {games.Count} game(s)");
+
+            GameGroup? targetGroup = null;
+
+            if (GroupManager.Groups.Count == 0)
+            {
+                bool createGroup = await _messageBoxService.ShowConfirmationAsync(
+                    LocalizationHelper.GetText("GroupSelectionDialog.NoGroups.Title"),
+                    LocalizationHelper.GetText("GroupSelectionDialog.NoGroups.Message"));
+                if (!createGroup)
+                {
+                    return;
+                }
+
+                string? name = await GroupNameDialog.ShowAsync();
+                if (string.IsNullOrWhiteSpace(name))
+                {
+                    return;
+                }
+
+                targetGroup = GroupManager.CreateGroup(name);
+            }
+            else
+            {
+                targetGroup = await GroupSelectionDialog.ShowAsync(GroupManager.Groups
+                    .OrderBy(g => g.Name, StringComparer.CurrentCultureIgnoreCase)
+                    .ToList());
+                if (targetGroup == null)
+                {
+                    return;
+                }
+            }
+
+            int addedCount = GroupManager.AddGamesToGroup(targetGroup.Id, games.Select(g => g.Game));
+            int alreadyInGroup = games.Count - addedCount;
+
+            if (games.Count == 1)
+            {
+                await _messageBoxService.ShowInfoAsync(
+                    LocalizationHelper.GetText(addedCount > 0
+                        ? "GameButton.ContextFlyout.AddToGroup.Success.Title"
+                        : "GameButton.ContextFlyout.AddToGroup.AlreadyExists.Title"),
+                    string.Format(LocalizationHelper.GetText(addedCount > 0
+                            ? "GameButton.ContextFlyout.AddToGroup.Success.Message"
+                            : "GameButton.ContextFlyout.AddToGroup.AlreadyExists.Message"),
+                        games[0].Game.Title, targetGroup.Name));
+            }
+            else
+            {
+                await _messageBoxService.ShowInfoAsync(
+                    LocalizationHelper.GetText("GameButton.ContextFlyout.AddToGroup.Multiple.Success.Title"),
+                    string.Format(
+                        LocalizationHelper.GetText("GameButton.ContextFlyout.AddToGroup.Multiple.Success.Message"),
+                        addedCount, targetGroup.Name, alreadyInGroup));
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.Error<LibraryPageViewModel>("Failed to add games to a group");
+            Logger.LogExceptionDetails<LibraryPageViewModel>(ex);
+            await _messageBoxService.ShowErrorAsync(
+                LocalizationHelper.GetText("GameButton.ContextFlyout.AddToGroup.Error.Title"),
+                string.Format(LocalizationHelper.GetText("GameButton.ContextFlyout.AddToGroup.Error.Message"),
+                    games.Count == 1 ? games[0].Game.Title : $"{games.Count} games", ex.Message));
         }
     }
 

--- a/source/XeniaManager/ViewModels/Pages/LibraryPageViewModel.cs
+++ b/source/XeniaManager/ViewModels/Pages/LibraryPageViewModel.cs
@@ -60,6 +60,8 @@ public partial class LibraryPageViewModel : ViewModelBase
         _settings.Settings.Ui.Window.Library.ViewOption = ViewOption;
         _settings.SaveSettings();
         OnPropertyChanged(nameof(IsGridView));
+        OnPropertyChanged(nameof(IsFlatGridVisible));
+        OnPropertyChanged(nameof(IsFlatListVisible));
     }
 
     [RelayCommand]
@@ -281,7 +283,24 @@ public partial class LibraryPageViewModel : ViewModelBase
 
     // Games List
     [ObservableProperty] private ObservableCollection<GameItemViewModel> _games = [];
+    [ObservableProperty] private ObservableCollection<GameGroupSectionViewModel> _groupSections = [];
     private List<GameItemViewModel> _allGames = [];
+    private readonly Dictionary<Guid, bool> _expandedGroupState = [];
+    private bool _ungroupedExpanded = true;
+
+    /// <summary>
+    /// Whether any user-defined groups exist (switches library to sectioned view).
+    /// </summary>
+    public bool HasGroups => GroupManager.Groups.Count > 0;
+
+    public bool IsFlatGridVisible => IsGridView && !HasGroups;
+    public bool IsFlatListVisible => !IsGridView && !HasGroups;
+    public bool IsSectionedVisible => HasGroups;
+
+    /// <summary>
+    /// Groups for the toolbar flyout (name + delete).
+    /// </summary>
+    public ObservableCollection<GameGroup> AvailableGroups { get; } = [];
 
     // Selection properties for multiselect
     private int _selectedGamesCount;
@@ -303,11 +322,6 @@ public partial class LibraryPageViewModel : ViewModelBase
     // Search
     [ObservableProperty] private string _searchQuery = string.Empty;
 
-    /// <summary>
-    /// Active group filter id. Null shows the full library.
-    /// </summary>
-    [ObservableProperty] private Guid? _activeGroupFilterId;
-
     partial void OnSearchQueryChanged(string value)
     {
         // Debounce search to avoid filtering on every keystroke
@@ -323,11 +337,6 @@ public partial class LibraryPageViewModel : ViewModelBase
                 FilterGames();
             }
         }, TaskScheduler.FromCurrentSynchronizationContext());
-    }
-
-    partial void OnActiveGroupFilterIdChanged(Guid? value)
-    {
-        FilterGames();
     }
 
     [RelayCommand]
@@ -347,24 +356,11 @@ public partial class LibraryPageViewModel : ViewModelBase
         // Load UI settings
         LoadUiSettings();
 
-        ActiveGroupFilterId = GroupManager.ActiveFilterGroupId;
         RefreshLibrary();
 
         _watcherService.NewGameFilesDetected += OnNewGameFilesDetected;
         EventManager.Instance.GameLibraryChanged += OnGameLibraryChanged;
-        EventManager.Instance.GroupFilterChanged += OnGroupFilterChanged;
         EventManager.Instance.GameGroupsChanged += OnGameGroupsChanged;
-    }
-
-    private void OnGroupFilterChanged(Guid? groupId)
-    {
-        if (!Dispatcher.UIThread.CheckAccess())
-        {
-            Dispatcher.UIThread.Post(() => OnGroupFilterChanged(groupId));
-            return;
-        }
-
-        ActiveGroupFilterId = groupId;
     }
 
     private void OnGameGroupsChanged()
@@ -375,10 +371,17 @@ public partial class LibraryPageViewModel : ViewModelBase
             return;
         }
 
-        // Membership may have changed for the active filter
-        if (ActiveGroupFilterId.HasValue)
+        OnPropertyChanged(nameof(HasGroups));
+        RefreshAvailableGroups();
+        FilterGames();
+    }
+
+    private void RefreshAvailableGroups()
+    {
+        AvailableGroups.Clear();
+        foreach (GameGroup group in GroupManager.Groups.OrderBy(g => g.Name, StringComparer.CurrentCultureIgnoreCase))
         {
-            FilterGames();
+            AvailableGroups.Add(group);
         }
     }
 
@@ -463,17 +466,11 @@ public partial class LibraryPageViewModel : ViewModelBase
     }
 
     /// <summary>
-    /// Filters the games collection based on the active group and search query.
-    /// Searches by Game.Title and Game.GameId.
+    /// Filters and sorts games, then rebuilds the flat list and/or Steam-style group sections.
     /// </summary>
     private void FilterGames()
     {
         IEnumerable<GameItemViewModel> query = _allGames;
-
-        if (ActiveGroupFilterId is Guid groupId)
-        {
-            query = query.Where(item => GroupManager.IsInGroup(groupId, item.Game));
-        }
 
         if (!string.IsNullOrWhiteSpace(SearchQuery))
         {
@@ -511,6 +508,65 @@ public partial class LibraryPageViewModel : ViewModelBase
         {
             Games.Add(item);
         }
+
+        RebuildGroupSections(filtered);
+        OnPropertyChanged(nameof(HasGroups));
+        OnPropertyChanged(nameof(IsFlatGridVisible));
+        OnPropertyChanged(nameof(IsFlatListVisible));
+        OnPropertyChanged(nameof(IsSectionedVisible));
+        RefreshAvailableGroups();
+    }
+
+    /// <summary>
+    /// Rebuilds collapsible group sections from the filtered game list.
+    /// </summary>
+    private void RebuildGroupSections(List<GameItemViewModel> filtered)
+    {
+        // Remember expand state
+        foreach (GameGroupSectionViewModel existing in GroupSections)
+        {
+            if (existing.GroupId is Guid id)
+            {
+                _expandedGroupState[id] = existing.IsExpanded;
+            }
+            else
+            {
+                _ungroupedExpanded = existing.IsExpanded;
+            }
+        }
+
+        GroupSections.Clear();
+
+        if (GroupManager.Groups.Count == 0)
+        {
+            return;
+        }
+
+        foreach (GameGroup group in GroupManager.Groups.OrderBy(g => g.Name, StringComparer.CurrentCultureIgnoreCase))
+        {
+            List<GameItemViewModel> groupGames = filtered
+                .Where(g => GroupManager.IsInGroup(group.Id, g.Game))
+                .ToList();
+
+            GameGroupSectionViewModel section = new GameGroupSectionViewModel(group.Id, group.Name, this);
+            section.IsExpanded = _expandedGroupState.GetValueOrDefault(group.Id, true);
+            section.SetGames(groupGames);
+            GroupSections.Add(section);
+        }
+
+        List<GameItemViewModel> ungrouped = filtered
+            .Where(g => !GroupManager.IsInAnyGroup(g.Game))
+            .ToList();
+
+        GameGroupSectionViewModel ungroupedSection = new GameGroupSectionViewModel(
+            null,
+            LocalizationHelper.GetText("LibraryPage.Groups.Ungrouped"),
+            this)
+        {
+            IsExpanded = _ungroupedExpanded
+        };
+        ungroupedSection.SetGames(ungrouped);
+        GroupSections.Add(ungroupedSection);
     }
 
     [RelayCommand]
@@ -1843,7 +1899,53 @@ public partial class LibraryPageViewModel : ViewModelBase
     }
 
     /// <summary>
-    /// Adds the currently selected games to a chosen (or newly created) group.
+    /// Creates a new empty group from the Groups toolbar.
+    /// </summary>
+    [RelayCommand]
+    private async Task CreateGroup()
+    {
+        string? name = await GroupNameDialog.ShowAsync();
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return;
+        }
+
+        GroupManager.CreateGroup(name);
+    }
+
+    /// <summary>
+    /// Deletes a group after confirmation.
+    /// </summary>
+    public async Task DeleteGroupAsync(Guid groupId, string groupName)
+    {
+        bool confirmed = await _messageBoxService.ShowConfirmationAsync(
+            LocalizationHelper.GetText("LibraryPage.Groups.Delete.Confirmation.Title"),
+            string.Format(LocalizationHelper.GetText("LibraryPage.Groups.Delete.Confirmation.Message"), groupName));
+        if (!confirmed)
+        {
+            return;
+        }
+
+        GroupManager.DeleteGroup(groupId);
+        _expandedGroupState.Remove(groupId);
+    }
+
+    /// <summary>
+    /// Deletes a group selected from the Groups flyout (CommandParameter = GameGroup).
+    /// </summary>
+    [RelayCommand]
+    private async Task DeleteGroupFromFlyout(GameGroup? group)
+    {
+        if (group == null)
+        {
+            return;
+        }
+
+        await DeleteGroupAsync(group.Id, group.Name);
+    }
+
+    /// <summary>
+    /// Adds the currently selected games to chosen group(s).
     /// </summary>
     [RelayCommand]
     private async Task AddSelectedGamesToGroup()
@@ -1858,7 +1960,7 @@ public partial class LibraryPageViewModel : ViewModelBase
     }
 
     /// <summary>
-    /// Prompts for a group and adds the given games to it.
+    /// Prompts for one or more groups and adds the given games to each.
     /// </summary>
     public async Task AddGamesToGroupAsync(IReadOnlyList<GameItemViewModel> games)
     {
@@ -1871,7 +1973,7 @@ public partial class LibraryPageViewModel : ViewModelBase
         {
             Logger.Info<LibraryPageViewModel>($"Add to group requested for {games.Count} game(s)");
 
-            GameGroup? targetGroup = null;
+            List<GameGroup> targetGroups;
 
             if (GroupManager.Groups.Count == 0)
             {
@@ -1889,41 +1991,33 @@ public partial class LibraryPageViewModel : ViewModelBase
                     return;
                 }
 
-                targetGroup = GroupManager.CreateGroup(name);
+                targetGroups = [GroupManager.CreateGroup(name)];
             }
             else
             {
-                targetGroup = await GroupSelectionDialog.ShowAsync(GroupManager.Groups
+                List<GameGroup>? selected = await GroupSelectionDialog.ShowAsync(GroupManager.Groups
                     .OrderBy(g => g.Name, StringComparer.CurrentCultureIgnoreCase)
                     .ToList());
-                if (targetGroup == null)
+                if (selected == null || selected.Count == 0)
                 {
                     return;
                 }
+
+                targetGroups = selected;
             }
 
-            int addedCount = GroupManager.AddGamesToGroup(targetGroup.Id, games.Select(g => g.Game));
-            int alreadyInGroup = games.Count - addedCount;
+            int totalAdded = 0;
+            foreach (GameGroup group in targetGroups)
+            {
+                totalAdded += GroupManager.AddGamesToGroup(group.Id, games.Select(g => g.Game));
+            }
 
-            if (games.Count == 1)
-            {
-                await _messageBoxService.ShowInfoAsync(
-                    LocalizationHelper.GetText(addedCount > 0
-                        ? "GameButton.ContextFlyout.AddToGroup.Success.Title"
-                        : "GameButton.ContextFlyout.AddToGroup.AlreadyExists.Title"),
-                    string.Format(LocalizationHelper.GetText(addedCount > 0
-                            ? "GameButton.ContextFlyout.AddToGroup.Success.Message"
-                            : "GameButton.ContextFlyout.AddToGroup.AlreadyExists.Message"),
-                        games[0].Game.Title, targetGroup.Name));
-            }
-            else
-            {
-                await _messageBoxService.ShowInfoAsync(
-                    LocalizationHelper.GetText("GameButton.ContextFlyout.AddToGroup.Multiple.Success.Title"),
-                    string.Format(
-                        LocalizationHelper.GetText("GameButton.ContextFlyout.AddToGroup.Multiple.Success.Message"),
-                        addedCount, targetGroup.Name, alreadyInGroup));
-            }
+            string groupNames = string.Join(", ", targetGroups.Select(g => g.Name));
+            await _messageBoxService.ShowInfoAsync(
+                LocalizationHelper.GetText("GameButton.ContextFlyout.AddToGroup.Multiple.Success.Title"),
+                string.Format(
+                    LocalizationHelper.GetText("GameButton.ContextFlyout.AddToGroup.MultipleGroups.Success.Message"),
+                    totalAdded, groupNames));
         }
         catch (Exception ex)
         {
@@ -1933,6 +2027,73 @@ public partial class LibraryPageViewModel : ViewModelBase
                 LocalizationHelper.GetText("GameButton.ContextFlyout.AddToGroup.Error.Title"),
                 string.Format(LocalizationHelper.GetText("GameButton.ContextFlyout.AddToGroup.Error.Message"),
                     games.Count == 1 ? games[0].Game.Title : $"{games.Count} games", ex.Message));
+        }
+    }
+
+    /// <summary>
+    /// Removes games from one or more groups they belong to.
+    /// </summary>
+    public async Task RemoveGamesFromGroupAsync(IReadOnlyList<GameItemViewModel> games)
+    {
+        if (games.Count == 0)
+        {
+            return;
+        }
+
+        try
+        {
+            HashSet<Guid> candidateIds = [];
+            foreach (GameItemViewModel gameVm in games)
+            {
+                foreach (GameGroup group in GroupManager.GetGroupsContaining(gameVm.Game))
+                {
+                    candidateIds.Add(group.Id);
+                }
+            }
+
+            List<GameGroup> candidateGroups = GroupManager.Groups
+                .Where(g => candidateIds.Contains(g.Id))
+                .OrderBy(g => g.Name, StringComparer.CurrentCultureIgnoreCase)
+                .ToList();
+
+            if (candidateGroups.Count == 0)
+            {
+                await _messageBoxService.ShowInfoAsync(
+                    LocalizationHelper.GetText("GameButton.ContextFlyout.RemoveFromGroup.None.Title"),
+                    LocalizationHelper.GetText("GameButton.ContextFlyout.RemoveFromGroup.None.Message"));
+                return;
+            }
+
+            List<GameGroup>? selected = await GroupSelectionDialog.ShowAsync(
+                candidateGroups,
+                LocalizationHelper.GetText("GameButton.ContextFlyout.RemoveFromGroup.Header"),
+                LocalizationHelper.GetText("GameButton.ContextFlyout.RemoveFromGroup.Message"),
+                LocalizationHelper.GetText("MessageBox.Ok"));
+            if (selected == null || selected.Count == 0)
+            {
+                return;
+            }
+
+            int removed = 0;
+            foreach (GameGroup group in selected)
+            {
+                removed += GroupManager.RemoveGamesFromGroup(group.Id, games.Select(g => g.Game));
+            }
+
+            await _messageBoxService.ShowInfoAsync(
+                LocalizationHelper.GetText("GameButton.ContextFlyout.RemoveFromGroup.Success.Title"),
+                string.Format(
+                    LocalizationHelper.GetText("GameButton.ContextFlyout.RemoveFromGroup.Success.Message"),
+                    removed, string.Join(", ", selected.Select(g => g.Name))));
+        }
+        catch (Exception ex)
+        {
+            Logger.Error<LibraryPageViewModel>("Failed to remove games from a group");
+            Logger.LogExceptionDetails<LibraryPageViewModel>(ex);
+            await _messageBoxService.ShowErrorAsync(
+                LocalizationHelper.GetText("GameButton.ContextFlyout.RemoveFromGroup.Error.Title"),
+                string.Format(LocalizationHelper.GetText("GameButton.ContextFlyout.RemoveFromGroup.Error.Message"),
+                    ex.Message));
         }
     }
 

--- a/source/XeniaManager/Views/MainView.axaml
+++ b/source/XeniaManager/Views/MainView.axaml
@@ -30,12 +30,9 @@
                 </controls:FANavigationViewItem.IconSource>
             </controls:FANavigationViewItem>
 
-            <!-- Game Library (groups are added as nested items in code-behind) -->
-            <controls:FANavigationViewItem x:Name="LibraryNavItem"
-                                         Content="{DynamicResource MainView.Navigation.Library}"
-                                         Tag="Library"
-                                         SelectsOnInvoked="True"
-                                         IsExpanded="True">
+            <!-- Game Library -->
+            <controls:FANavigationViewItem Content="{DynamicResource MainView.Navigation.Library}"
+                                         Tag="Library">
                 <controls:FANavigationViewItem.IconSource>
                     <ic:SymbolIconSource Symbol="Archive" />
                 </controls:FANavigationViewItem.IconSource>

--- a/source/XeniaManager/Views/MainView.axaml
+++ b/source/XeniaManager/Views/MainView.axaml
@@ -30,9 +30,12 @@
                 </controls:FANavigationViewItem.IconSource>
             </controls:FANavigationViewItem>
 
-            <!-- Game Library -->
-            <controls:FANavigationViewItem Content="{DynamicResource MainView.Navigation.Library}"
-                                         Tag="Library">
+            <!-- Game Library (groups are added as nested items in code-behind) -->
+            <controls:FANavigationViewItem x:Name="LibraryNavItem"
+                                         Content="{DynamicResource MainView.Navigation.Library}"
+                                         Tag="Library"
+                                         SelectsOnInvoked="True"
+                                         IsExpanded="True">
                 <controls:FANavigationViewItem.IconSource>
                     <ic:SymbolIconSource Symbol="Archive" />
                 </controls:FANavigationViewItem.IconSource>

--- a/source/XeniaManager/Views/MainView.axaml.cs
+++ b/source/XeniaManager/Views/MainView.axaml.cs
@@ -5,15 +5,9 @@ using System.Linq;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Media;
-using Avalonia.Threading;
 using FluentAvalonia.UI.Controls;
-using FluentIcons.Avalonia.Fluent;
-using FluentIcons.Common;
 using Microsoft.Extensions.DependencyInjection;
 using XeniaManager.Core.Logging;
-using XeniaManager.Core.Manage;
-using XeniaManager.Core.Models.Game;
-using XeniaManager.Core.Services;
 using XeniaManager.Core.Utilities;
 using XeniaManager.Services;
 using XeniaManager.ViewModels;
@@ -43,63 +37,11 @@ public partial class MainView : UserControl
         // Auto-fit pane width to content when opening
         NavigationView.PaneOpening += NavigationView_OnPaneOpening;
 
-        RefreshGroupNavigationItems();
-        EventManager.Instance.GameGroupsChanged += OnGameGroupsChanged;
-
         // Navigate to Library (Default Page)
         _ = _navigationService.NavigateToTag("Library");
     }
 
     // Functions
-    private void OnGameGroupsChanged()
-    {
-        if (!Dispatcher.UIThread.CheckAccess())
-        {
-            Dispatcher.UIThread.Post(RefreshGroupNavigationItems);
-            return;
-        }
-
-        RefreshGroupNavigationItems();
-    }
-
-    /// <summary>
-    /// Rebuilds nested Library navigation items for each game group plus "New Group".
-    /// </summary>
-    private void RefreshGroupNavigationItems()
-    {
-        try
-        {
-            LibraryNavItem.MenuItems.Clear();
-
-            foreach (GameGroup group in GroupManager.Groups.OrderBy(g => g.Name, StringComparer.CurrentCultureIgnoreCase))
-            {
-                FANavigationViewItem groupItem = new FANavigationViewItem
-                {
-                    Content = group.Name,
-                    Tag = $"Group:{group.Id}",
-                    IconSource = new SymbolIconSource { Symbol = Symbol.Folder }
-                };
-                LibraryNavItem.MenuItems.Add(groupItem);
-            }
-
-            FANavigationViewItem addGroupItem = new FANavigationViewItem
-            {
-                Content = LocalizationHelper.GetText("MainView.Navigation.AddGroup"),
-                Tag = "AddGroup",
-                IconSource = new SymbolIconSource { Symbol = Symbol.Add }
-            };
-            LibraryNavItem.MenuItems.Add(addGroupItem);
-
-            LibraryNavItem.IsExpanded = true;
-            Logger.Debug<MainView>($"Refreshed group navigation items ({GroupManager.Groups.Count} groups)");
-        }
-        catch (Exception ex)
-        {
-            Logger.Error<MainView>("Failed to refresh group navigation items");
-            Logger.LogExceptionDetails<MainView>(ex);
-        }
-    }
-
     private void NavigationView_OnPaneOpening(FANavigationView sender, EventArgs args)
     {
         try
@@ -120,7 +62,6 @@ public partial class MainView : UserControl
         IEnumerable<FANavigationViewItem> items = NavigationView.MenuItems
             .Concat(NavigationView.FooterMenuItems)
             .OfType<FANavigationViewItem>()
-            .SelectMany(FlattenNavigationItems)
             .Where(i => i.Content is string text && !string.IsNullOrEmpty(text));
 
         double maxTextWidth = 0;
@@ -149,18 +90,6 @@ public partial class MainView : UserControl
         double clampedWidth = Math.Clamp(maxTextWidth + nonTextWidth, 180, 500);
         Logger.Debug<MainView>($"Max text width: {maxTextWidth:F1}px, total: {maxTextWidth + nonTextWidth:F0}px, clamped: {clampedWidth:F0}px");
         return clampedWidth;
-    }
-
-    private static IEnumerable<FANavigationViewItem> FlattenNavigationItems(FANavigationViewItem item)
-    {
-        yield return item;
-        foreach (FANavigationViewItem child in item.MenuItems.OfType<FANavigationViewItem>())
-        {
-            foreach (FANavigationViewItem nested in FlattenNavigationItems(child))
-            {
-                yield return nested;
-            }
-        }
     }
 
     private async void NavigationView_OnItemInvoked(object? sender, FANavigationViewItemInvokedEventArgs e)

--- a/source/XeniaManager/Views/MainView.axaml.cs
+++ b/source/XeniaManager/Views/MainView.axaml.cs
@@ -5,9 +5,15 @@ using System.Linq;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Media;
+using Avalonia.Threading;
 using FluentAvalonia.UI.Controls;
+using FluentIcons.Avalonia.Fluent;
+using FluentIcons.Common;
 using Microsoft.Extensions.DependencyInjection;
 using XeniaManager.Core.Logging;
+using XeniaManager.Core.Manage;
+using XeniaManager.Core.Models.Game;
+using XeniaManager.Core.Services;
 using XeniaManager.Core.Utilities;
 using XeniaManager.Services;
 using XeniaManager.ViewModels;
@@ -37,11 +43,63 @@ public partial class MainView : UserControl
         // Auto-fit pane width to content when opening
         NavigationView.PaneOpening += NavigationView_OnPaneOpening;
 
+        RefreshGroupNavigationItems();
+        EventManager.Instance.GameGroupsChanged += OnGameGroupsChanged;
+
         // Navigate to Library (Default Page)
         _ = _navigationService.NavigateToTag("Library");
     }
 
     // Functions
+    private void OnGameGroupsChanged()
+    {
+        if (!Dispatcher.UIThread.CheckAccess())
+        {
+            Dispatcher.UIThread.Post(RefreshGroupNavigationItems);
+            return;
+        }
+
+        RefreshGroupNavigationItems();
+    }
+
+    /// <summary>
+    /// Rebuilds nested Library navigation items for each game group plus "New Group".
+    /// </summary>
+    private void RefreshGroupNavigationItems()
+    {
+        try
+        {
+            LibraryNavItem.MenuItems.Clear();
+
+            foreach (GameGroup group in GroupManager.Groups.OrderBy(g => g.Name, StringComparer.CurrentCultureIgnoreCase))
+            {
+                FANavigationViewItem groupItem = new FANavigationViewItem
+                {
+                    Content = group.Name,
+                    Tag = $"Group:{group.Id}",
+                    IconSource = new SymbolIconSource { Symbol = Symbol.Folder }
+                };
+                LibraryNavItem.MenuItems.Add(groupItem);
+            }
+
+            FANavigationViewItem addGroupItem = new FANavigationViewItem
+            {
+                Content = LocalizationHelper.GetText("MainView.Navigation.AddGroup"),
+                Tag = "AddGroup",
+                IconSource = new SymbolIconSource { Symbol = Symbol.Add }
+            };
+            LibraryNavItem.MenuItems.Add(addGroupItem);
+
+            LibraryNavItem.IsExpanded = true;
+            Logger.Debug<MainView>($"Refreshed group navigation items ({GroupManager.Groups.Count} groups)");
+        }
+        catch (Exception ex)
+        {
+            Logger.Error<MainView>("Failed to refresh group navigation items");
+            Logger.LogExceptionDetails<MainView>(ex);
+        }
+    }
+
     private void NavigationView_OnPaneOpening(FANavigationView sender, EventArgs args)
     {
         try
@@ -62,6 +120,7 @@ public partial class MainView : UserControl
         IEnumerable<FANavigationViewItem> items = NavigationView.MenuItems
             .Concat(NavigationView.FooterMenuItems)
             .OfType<FANavigationViewItem>()
+            .SelectMany(FlattenNavigationItems)
             .Where(i => i.Content is string text && !string.IsNullOrEmpty(text));
 
         double maxTextWidth = 0;
@@ -90,6 +149,18 @@ public partial class MainView : UserControl
         double clampedWidth = Math.Clamp(maxTextWidth + nonTextWidth, 180, 500);
         Logger.Debug<MainView>($"Max text width: {maxTextWidth:F1}px, total: {maxTextWidth + nonTextWidth:F0}px, clamped: {clampedWidth:F0}px");
         return clampedWidth;
+    }
+
+    private static IEnumerable<FANavigationViewItem> FlattenNavigationItems(FANavigationViewItem item)
+    {
+        yield return item;
+        foreach (FANavigationViewItem child in item.MenuItems.OfType<FANavigationViewItem>())
+        {
+            foreach (FANavigationViewItem nested in FlattenNavigationItems(child))
+            {
+                yield return nested;
+            }
+        }
     }
 
     private async void NavigationView_OnItemInvoked(object? sender, FANavigationViewItemInvokedEventArgs e)

--- a/source/XeniaManager/Views/Pages/LibraryPage.axaml
+++ b/source/XeniaManager/Views/Pages/LibraryPage.axaml
@@ -11,383 +11,8 @@
              x:Class="XeniaManager.Views.Pages.LibraryPage"
              x:DataType="vm:LibraryPageViewModel"
              x:Name="Root">
-    <Design.DataContext>
-        <vm:LibraryPageViewModel />
-    </Design.DataContext>
-
-    <!-- UI -->
-    <Grid RowDefinitions="48,Auto,*,Auto"
-          DragDrop.AllowDrop="True"
-          DragDrop.DragEnter="OnDragEnter"
-          DragDrop.DragOver="OnDragOver"
-          DragDrop.DragLeave="OnDragLeave"
-          DragDrop.Drop="OnDrop">
-        <!-- Search & Menu -->
-        <Grid Grid.Row="0">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="Auto" />
-                <ColumnDefinition Width="Auto" />
-                <ColumnDefinition Width="Auto" />
-                <ColumnDefinition Width="Auto" />
-            </Grid.ColumnDefinitions>
-
-            <!-- Search -->
-            <Panel Grid.Column="0">
-                <TextBox x:Name="SearchTextBox"
-                         Padding="12,0"
-                         VerticalContentAlignment="Center"
-                         BorderThickness="0"
-                         FontSize="24"
-                         PlaceholderText="{DynamicResource LibraryPage.Search.PlaceholderText}"
-                         Text="{Binding SearchQuery, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                <Button Background="Transparent"
-                        BorderThickness="0"
-                        Cursor="Hand"
-                        HorizontalAlignment="Right"
-                        VerticalAlignment="Center"
-                        Margin="0,0,8,0"
-                        Width="40"
-                        Height="40"
-                        Command="{Binding ClearSearchCommand}"
-                        IsVisible="{Binding SearchQuery, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
-                    <icons:SymbolIcon Symbol="PenDismiss"
-                                      FontSize="18" />
-                </Button>
-            </Panel>
-
-            <!-- Refresh -->
-            <Button Grid.Column="1"
-                    Background="Transparent"
-                    BorderThickness="0"
-                    Cursor="Hand"
-                    HorizontalAlignment="Stretch"
-                    VerticalAlignment="Stretch"
-                    Command="{Binding RefreshCommand}"
-                    ToolTip.Tip="{DynamicResource LibraryPage.Refresh.ToolTip}">
-                <icons:SymbolIcon Symbol="ArrowSync" />
-            </Button>
-
-            <!-- Toggle Grid/List View -->
-            <Button Grid.Column="2"
-                    Background="Transparent"
-                    BorderThickness="0"
-                    Cursor="Hand"
-                    HorizontalAlignment="Stretch"
-                    VerticalAlignment="Stretch"
-                    Command="{Binding ToggleGridViewCommand}">
-                <Panel>
-                    <!-- Show List icon when in Grid view (click to switch to list) -->
-                    <icons:SymbolIcon Symbol="List"
-                                      IsVisible="{Binding IsGridView}"
-                                      ToolTip.Tip="{DynamicResource LibraryPage.ToggleView.ToolTip.ListView}" />
-                    <!-- Show Grid icon when in List view (click to switch to grid) -->
-                    <icons:SymbolIcon Symbol="Grid"
-                                      IsVisible="{Binding !IsGridView}"
-                                      ToolTip.Tip="{DynamicResource LibraryPage.ToggleView.ToolTip.GridView}" />
-                </Panel>
-            </Button>
-
-            <!-- Sort -->
-            <Button Grid.Column="3"
-                    Background="Transparent"
-                    BorderThickness="0"
-                    Cursor="Hand"
-                    HorizontalAlignment="Stretch"
-                    VerticalAlignment="Stretch"
-                    ToolTip.Tip="{DynamicResource LibraryPage.Sort.ToolTip}">
-                <icons:SymbolIcon Symbol="ArrowSort" />
-                <Button.Flyout>
-                    <MenuFlyout Placement="BottomEdgeAlignedRight">
-                        <!-- Sort Direction Toggle -->
-                        <MenuItem Header="{DynamicResource LibraryPage.Sort.Direction}"
-                                  Command="{Binding ToggleSortDirectionCommand}">
-                            <MenuItem.Icon>
-                                <icons:SymbolIcon Symbol="{Binding SortDirectionIcon}" />
-                            </MenuItem.Icon>
-                        </MenuItem>
-                        <Separator />
-                        <!-- Sort Options -->
-                        <MenuItem Header="{DynamicResource LibraryPage.Sort.Title}"
-                                  Command="{Binding SetSortOptionCommand}"
-                                  CommandParameter="{x:Static models:GameSortOption.Title}"
-                                  ToggleType="CheckBox"
-                                  IsChecked="{Binding SortOption, Converter={StaticResource EnumToValueConverter}, ConverterParameter=Title}">
-                            <MenuItem.Icon>
-                                <icons:SymbolIcon Symbol="TextSortAscending" />
-                            </MenuItem.Icon>
-                        </MenuItem>
-                        <MenuItem Header="{DynamicResource LibraryPage.Sort.Compatibility}"
-                                  Command="{Binding SetSortOptionCommand}"
-                                  CommandParameter="{x:Static models:GameSortOption.Compatibility}"
-                                  ToggleType="CheckBox"
-                                  IsChecked="{Binding SortOption, Converter={StaticResource EnumToValueConverter}, ConverterParameter=Compatibility}">
-                            <MenuItem.Icon>
-                                <icons:SymbolIcon Symbol="HeartPulse" />
-                            </MenuItem.Icon>
-                        </MenuItem>
-                        <MenuItem Header="{DynamicResource LibraryPage.Sort.Playtime}"
-                                  Command="{Binding SetSortOptionCommand}"
-                                  CommandParameter="{x:Static models:GameSortOption.Playtime}"
-                                  ToggleType="CheckBox"
-                                  IsChecked="{Binding SortOption, Converter={StaticResource EnumToValueConverter}, ConverterParameter=Playtime}">
-                            <MenuItem.Icon>
-                                <icons:SymbolIcon Symbol="Timer" />
-                            </MenuItem.Icon>
-                        </MenuItem>
-                        <MenuItem Header="{DynamicResource LibraryPage.Sort.XeniaVersion}"
-                                  Command="{Binding SetSortOptionCommand}"
-                                  CommandParameter="{x:Static models:GameSortOption.XeniaVersion}"
-                                  ToggleType="CheckBox"
-                                  IsChecked="{Binding SortOption, Converter={StaticResource EnumToValueConverter}, ConverterParameter=XeniaVersion}">
-                            <MenuItem.Icon>
-                                <icons:SymbolIcon Symbol="AppFolder" />
-                            </MenuItem.Icon>
-                        </MenuItem>
-                        <MenuItem Header="{DynamicResource LibraryPage.Sort.LastPlayed}"
-                                  Command="{Binding SetSortOptionCommand}"
-                                  CommandParameter="{x:Static models:GameSortOption.LastPlayed}"
-                                  ToggleType="CheckBox"
-                                  IsChecked="{Binding SortOption, Converter={StaticResource EnumToValueConverter}, ConverterParameter=LastPlayed}">
-                            <MenuItem.Icon>
-                                <icons:SymbolIcon Symbol="History" />
-                            </MenuItem.Icon>
-                        </MenuItem>
-                    </MenuFlyout>
-                </Button.Flyout>
-            </Button>
-
-            <!-- Menu -->
-            <Button Grid.Column="4"
-                    Background="Transparent"
-                    BorderThickness="0"
-                    Cursor="Hand"
-                    HorizontalAlignment="Stretch"
-                    VerticalAlignment="Stretch">
-                <icons:SymbolIcon Symbol="MoreVertical" />
-                <Button.Flyout>
-                    <MenuFlyout Placement="BottomEdgeAlignedRight">
-                        <!-- Edit Grid View -->
-                        <MenuItem Header="{DynamicResource LibraryPage.Options.EditGridView.Header}"
-                                  ToolTip.Tip="{DynamicResource LibraryPage.Options.EditGridView.ToolTip}"
-                                  IsVisible="{Binding IsGridView}">
-                            <MenuItem.Icon>
-                                <icons:SymbolIcon Symbol="Eye" />
-                            </MenuItem.Icon>
-                            <!-- Game Title -->
-                            <MenuItem Header="{DynamicResource LibraryPage.Options.EditGridView.Title.Header}"
-                                      Command="{Binding ToggleGameTitleCommand}"
-                                      ToggleType="CheckBox"
-                                      IsChecked="{Binding ShowGameTitle}">
-                                <MenuItem.Icon>
-                                    <icons:SymbolIcon Symbol="SlideTextTitle" />
-                                </MenuItem.Icon>
-                            </MenuItem>
-                            <!-- Compatibility Rating -->
-                            <MenuItem Header="{DynamicResource LibraryPage.Options.EditGridView.CompatibilityRating.Header}"
-                                      Command="{Binding ToggleCompatibilityRatingCommand}"
-                                      ToggleType="CheckBox"
-                                      IsChecked="{Binding ShowCompatibilityRating}">
-                                <MenuItem.Icon>
-                                    <icons:SymbolIcon Symbol="WindowDevTools" />
-                                </MenuItem.Icon>
-                            </MenuItem>
-                            <!-- Xenia Version -->
-                            <MenuItem Header="{DynamicResource LibraryPage.Options.EditGridView.XeniaVersion.Header}"
-                                      Command="{Binding ToggleXeniaVersionCommand}"
-                                      ToggleType="CheckBox"
-                                      IsChecked="{Binding ShowXeniaVersion}"
-                                      ToolTip.Tip="{DynamicResource LibraryPage.Options.EditGridView.XeniaVersion.ToolTip}">
-                                <MenuItem.Icon>
-                                    <icons:SymbolIcon Symbol="Apps" />
-                                </MenuItem.Icon>
-                            </MenuItem>
-                            <!-- Double Click Launch -->
-                            <MenuItem Header="{DynamicResource LibraryPage.Options.DoubleClickLaunch.Header}"
-                                      ToolTip.Tip="{DynamicResource LibraryPage.Options.DoubleClickLaunch.ToolTip}"
-                                      Command="{Binding ToggleDoubleClickLaunchCommand}"
-                                      ToggleType="CheckBox"
-                                      IsChecked="{Binding DoubleClickLaunch}">
-                                <MenuItem.Icon>
-                                    <icons:SymbolIcon Symbol="CursorClick" />
-                                </MenuItem.Icon>
-                            </MenuItem>
-                        </MenuItem>
-                        <!-- Edit List View -->
-                        <MenuItem Header="{DynamicResource LibraryPage.Options.EditListView.Header}"
-                                  ToolTip.Tip="{DynamicResource LibraryPage.Options.EditListView.ToolTip}"
-                                  IsVisible="{Binding !IsGridView}">
-                            <MenuItem.Icon>
-                                <icons:SymbolIcon Symbol="List" />
-                            </MenuItem.Icon>
-                            <!-- Compatibility Rating -->
-                            <MenuItem Header="{DynamicResource LibraryPage.Options.EditListView.CompatibilityRating.Header}"
-                                      Command="{Binding ToggleListCompatibilityRatingCommand}"
-                                      ToggleType="CheckBox"
-                                      IsChecked="{Binding ShowListCompatibilityRating}">
-                                <MenuItem.Icon>
-                                    <icons:SymbolIcon Symbol="WindowDevTools" />
-                                </MenuItem.Icon>
-                            </MenuItem>
-                            <!-- Icon -->
-                            <MenuItem Header="{DynamicResource LibraryPage.Options.EditListView.Icon.Header}"
-                                      Command="{Binding ToggleListIconCommand}"
-                                      ToggleType="CheckBox"
-                                      IsChecked="{Binding ShowListIcon}">
-                                <MenuItem.Icon>
-                                    <icons:SymbolIcon Symbol="Image" />
-                                </MenuItem.Icon>
-                            </MenuItem>
-                            <!-- Playtime -->
-                            <MenuItem Header="{DynamicResource LibraryPage.Options.EditListView.Playtime.Header}"
-                                      Command="{Binding ToggleListPlaytimeCommand}"
-                                      ToggleType="CheckBox"
-                                      IsChecked="{Binding ShowListPlaytime}">
-                                <MenuItem.Icon>
-                                    <icons:SymbolIcon Symbol="Timer" />
-                                </MenuItem.Icon>
-                            </MenuItem>
-                            <!-- Last Played -->
-                            <MenuItem Header="{DynamicResource LibraryPage.Options.EditListView.LastPlayed.Header}"
-                                      Command="{Binding ToggleListLastPlayedCommand}"
-                                      ToggleType="CheckBox"
-                                      IsChecked="{Binding ShowListLastPlayed}">
-                                <MenuItem.Icon>
-                                    <icons:SymbolIcon Symbol="Clock" />
-                                </MenuItem.Icon>
-                            </MenuItem>
-                            <!-- Xenia Version -->
-                            <MenuItem Header="{DynamicResource LibraryPage.Options.EditListView.XeniaVersion.Header}"
-                                      Command="{Binding ToggleListXeniaVersionCommand}"
-                                      ToggleType="CheckBox"
-                                      IsChecked="{Binding ShowListXeniaVersion}"
-                                      ToolTip.Tip="{DynamicResource LibraryPage.Options.EditListView.XeniaVersion.ToolTip}">
-                                <MenuItem.Icon>
-                                    <icons:SymbolIcon Symbol="Apps" />
-                                </MenuItem.Icon>
-                            </MenuItem>
-                            <!-- Title ID -->
-                            <MenuItem Header="{DynamicResource LibraryPage.Options.EditListView.TitleId.Header}"
-                                      Command="{Binding ToggleListTitleIdCommand}"
-                                      ToggleType="CheckBox"
-                                      IsChecked="{Binding ShowListTitleId}">
-                                <MenuItem.Icon>
-                                    <icons:SymbolIcon Symbol="Tag" />
-                                </MenuItem.Icon>
-                            </MenuItem>
-                            <!-- Media ID -->
-                            <MenuItem Header="{DynamicResource LibraryPage.Options.EditListView.MediaId.Header}"
-                                      Command="{Binding ToggleListMediaIdCommand}"
-                                      ToggleType="CheckBox"
-                                      IsChecked="{Binding ShowListMediaId}">
-                                <MenuItem.Icon>
-                                    <icons:SymbolIcon Symbol="Bookmark" />
-                                </MenuItem.Icon>
-                            </MenuItem>
-                        </MenuItem>
-                        <Separator />
-                        <!-- Export Shortcuts -->
-                        <!-- TODO: Add support for Linux/Proton/Wine-->
-                        <MenuItem Header="{DynamicResource LibraryPage.Options.ExportShortcuts.Header}"
-                                  Command="{Binding ExportGameShortcutsCommand}"
-                                  ToolTip.Tip="{DynamicResource LibraryPage.Options.ExportShortcuts.ToolTip}"
-                                  IsVisible="{Binding SupportsShortcuts}">
-                            <MenuItem.Icon>
-                                <icons:SymbolIcon Symbol="ArrowExport" />
-                            </MenuItem.Icon>
-                        </MenuItem>
-                        <!-- Update Compatibility Ratings -->
-                        <MenuItem Header="{DynamicResource LibraryPage.Options.UpdateCompatibilityRatings.Header}"
-                                  Command="{Binding UpdateCompatibilityRatingsCommand}"
-                                  ToolTip.Tip="{DynamicResource LibraryPage.Options.UpdateCompatibilityRatings.ToolTip}">
-                            <MenuItem.Icon>
-                                <icons:SymbolIcon Symbol="ArrowSync" />
-                            </MenuItem.Icon>
-                        </MenuItem>
-                        <!-- Optimize Game Settings -->
-                        <MenuItem Header="{DynamicResource LibraryPage.Options.OptimizeGameSettings.Header}"
-                                  Command="{Binding UpdateOptimizedSettingsCommand}"
-                                  ToolTip.Tip="{DynamicResource LibraryPage.Options.OptimizeGameSettings.ToolTip}">
-                            <MenuItem.Icon>
-                                <icons:SymbolIcon Symbol="CloudSync" />
-                            </MenuItem.Icon>
-                        </MenuItem>
-                        <Separator />
-                        <!-- Scan Directory -->
-                        <MenuItem Header="{DynamicResource LibraryPage.Options.ScanDirectory.Header}"
-                                  Command="{Binding ScanDirectoryCommand}"
-                                  ToolTip.Tip="{DynamicResource LibraryPage.Options.ScanDirectory.ToolTip}">
-                            <MenuItem.Icon>
-                                <icons:SymbolIcon Symbol="FolderAdd" />
-                            </MenuItem.Icon>
-                        </MenuItem>
-                        <!-- Add Game -->
-                        <MenuItem Header="{DynamicResource LibraryPage.Options.AddGame.Header}"
-                                  Command="{Binding AddGameCommand}"
-                                  ToolTip.Tip="{DynamicResource LibraryPage.Options.AddGame.ToolTip}">
-                            <MenuItem.Icon>
-                                <icons:SymbolIcon Symbol="Add" />
-                            </MenuItem.Icon>
-                        </MenuItem>
-                        <Separator />
-                        <!-- Remove Invalid Games -->
-                        <MenuItem Header="{DynamicResource LibraryPage.Options.RemoveInvalidGames.Header}"
-                                  Command="{Binding RemoveInvalidGamesCommand}"
-                                  ToolTip.Tip="{DynamicResource LibraryPage.Options.RemoveInvalidGames.ToolTip}">
-                            <MenuItem.Icon>
-                                <icons:SymbolIcon Symbol="Delete" />
-                            </MenuItem.Icon>
-                        </MenuItem>
-                    </MenuFlyout>
-                </Button.Flyout>
-            </Button>
-        </Grid>
-
-        <!-- Zoom Slider -->
-        <Grid Grid.Row="1" Margin="10,0"
-              IsVisible="{Binding IsGridView}">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="Auto" />
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="Auto" />
-            </Grid.ColumnDefinitions>
-            <icons:SymbolIcon Grid.Column="0"
-                              Symbol="ZoomOut"
-                              FontSize="14"
-                              Margin="0,0,8,0" />
-            <Slider Grid.Column="1"
-                    VerticalAlignment="Center"
-                    IsSnapToTickEnabled="True"
-                    Maximum="{Binding ZoomMaximum}"
-                    Minimum="{Binding ZoomMinimum}"
-                    MinHeight="0"
-                    Padding="0"
-                    TickFrequency="{Binding ZoomTickFrequency}"
-                    Value="{Binding ZoomValue}"
-                    ToolTip.Tip="{Binding ZoomToolTip}" />
-            <icons:SymbolIcon Grid.Column="2"
-                              Symbol="ZoomIn"
-                              FontSize="14"
-                              Margin="8,0,0,0" />
-        </Grid>
-
-        <!-- Games (Grid View) -->
-        <ScrollViewer Grid.Row="2"
-                      Padding="8"
-                      IsVisible="{Binding IsGridView}"
-                      PointerReleased="OnScrollViewerPointerReleased">
-            <controls:FAItemsRepeater Margin="0,0,10,0"
-                                      ItemsSource="{Binding Games}">
-                <controls:FAItemsRepeater.Layout>
-                    <controls:FAUniformGridLayout MinItemWidth="{Binding MinItemWidth}"
-                                                  MinItemHeight="{Binding MinItemHeight}"
-                                                  MinRowSpacing="{Binding ItemSpacing}"
-                                                  MinColumnSpacing="{Binding ItemSpacing}"
-                                                  ItemsStretch="Uniform" />
-                </controls:FAItemsRepeater.Layout>
-
-                <controls:FAItemsRepeater.ItemTemplate>
-                    <DataTemplate x:DataType="itemVm:GameItemViewModel">
+    <UserControl.Resources>
+        <DataTemplate x:Key="GameGridItemTemplate" x:DataType="itemVm:GameItemViewModel">
                         <Button Padding="0"
                                 BorderThickness="3"
                                 CornerRadius="8"
@@ -721,6 +346,16 @@
                                             <TextBlock Text="{DynamicResource GameButton.ContextFlyout.AddToGroup.ToolTip}" />
                                         </ToolTip.Tip>
                                     </MenuItem>
+                                    <!-- Remove from Group -->
+                                    <MenuItem Header="{DynamicResource GameButton.ContextFlyout.RemoveFromGroup.Header}"
+                                              Command="{Binding RemoveFromGroupCommand}">
+                                        <MenuItem.Icon>
+                                            <icons:SymbolIcon Symbol="FolderArrowRight" />
+                                        </MenuItem.Icon>
+                                        <ToolTip.Tip>
+                                            <TextBlock Text="{DynamicResource GameButton.ContextFlyout.RemoveFromGroup.ToolTip}" />
+                                        </ToolTip.Tip>
+                                    </MenuItem>
                                     <!-- Remove Game Command-->
                                     <MenuItem Header="{DynamicResource GameButton.ContextFlyout.RemoveGame.Header}"
                                               Command="{Binding RemoveGameCommand}">
@@ -827,21 +462,8 @@
                                 </Grid>
                             </Border>
                         </Button>
-                    </DataTemplate>
-                </controls:FAItemsRepeater.ItemTemplate>
-            </controls:FAItemsRepeater>
-        </ScrollViewer>
-
-        <!-- Games (List View) -->
-        <ScrollViewer Grid.Row="2"
-                      Padding="8,8,18,8"
-                      Background="Transparent"
-                      IsVisible="{Binding !IsGridView}"
-                      PointerReleased="OnListPointerReleased"
-                      HorizontalScrollBarVisibility="Disabled">
-            <controls:FAItemsRepeater ItemsSource="{Binding Games}">
-                <controls:FAItemsRepeater.ItemTemplate>
-                    <DataTemplate x:DataType="itemVm:GameItemViewModel">
+        </DataTemplate>
+        <DataTemplate x:Key="GameListItemTemplate" x:DataType="itemVm:GameItemViewModel">
                         <Border Background="Transparent"
                                 Padding="8,6"
                                 Margin="0,0"
@@ -1068,6 +690,16 @@
                                             <TextBlock Text="{DynamicResource GameButton.ContextFlyout.AddToGroup.ToolTip}" />
                                         </ToolTip.Tip>
                                     </MenuItem>
+                                    <!-- Remove from Group -->
+                                    <MenuItem Header="{DynamicResource GameButton.ContextFlyout.RemoveFromGroup.Header}"
+                                              Command="{Binding RemoveFromGroupCommand}">
+                                        <MenuItem.Icon>
+                                            <icons:SymbolIcon Symbol="FolderArrowRight" />
+                                        </MenuItem.Icon>
+                                        <ToolTip.Tip>
+                                            <TextBlock Text="{DynamicResource GameButton.ContextFlyout.RemoveFromGroup.ToolTip}" />
+                                        </ToolTip.Tip>
+                                    </MenuItem>
                                     <!-- Remove Game Command-->
                                     <MenuItem Header="{DynamicResource GameButton.ContextFlyout.RemoveGame.Header}"
                                               Command="{Binding RemoveGameCommand}">
@@ -1235,9 +867,477 @@
                                 </StackPanel>
                             </Grid>
                         </Border>
-                    </DataTemplate>
-                </controls:FAItemsRepeater.ItemTemplate>
+        </DataTemplate>
+    </UserControl.Resources>
+
+    <Design.DataContext>
+        <vm:LibraryPageViewModel />
+    </Design.DataContext>
+
+    <!-- UI -->
+    <Grid RowDefinitions="48,Auto,*,Auto"
+          DragDrop.AllowDrop="True"
+          DragDrop.DragEnter="OnDragEnter"
+          DragDrop.DragOver="OnDragOver"
+          DragDrop.DragLeave="OnDragLeave"
+          DragDrop.Drop="OnDrop">
+        <!-- Search & Menu -->
+        <Grid Grid.Row="0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+
+            <!-- Search -->
+            <Panel Grid.Column="0">
+                <TextBox x:Name="SearchTextBox"
+                         Padding="12,0"
+                         VerticalContentAlignment="Center"
+                         BorderThickness="0"
+                         FontSize="24"
+                         PlaceholderText="{DynamicResource LibraryPage.Search.PlaceholderText}"
+                         Text="{Binding SearchQuery, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                <Button Background="Transparent"
+                        BorderThickness="0"
+                        Cursor="Hand"
+                        HorizontalAlignment="Right"
+                        VerticalAlignment="Center"
+                        Margin="0,0,8,0"
+                        Width="40"
+                        Height="40"
+                        Command="{Binding ClearSearchCommand}"
+                        IsVisible="{Binding SearchQuery, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
+                    <icons:SymbolIcon Symbol="PenDismiss"
+                                      FontSize="18" />
+                </Button>
+            </Panel>
+
+
+            <!-- Groups -->
+            <Button Grid.Column="1"
+                    Background="Transparent"
+                    BorderThickness="0"
+                    Cursor="Hand"
+                    HorizontalAlignment="Stretch"
+                    VerticalAlignment="Stretch"
+                    ToolTip.Tip="{DynamicResource LibraryPage.Groups.ToolTip}">
+                <icons:SymbolIcon Symbol="Folder" />
+                <Button.Flyout>
+                    <MenuFlyout Placement="BottomEdgeAlignedRight">
+                        <MenuItem Header="{DynamicResource LibraryPage.Groups.New.Header}"
+                                  Command="{Binding CreateGroupCommand}">
+                            <MenuItem.Icon>
+                                <icons:SymbolIcon Symbol="Add" />
+                            </MenuItem.Icon>
+                        </MenuItem>
+                    </MenuFlyout>
+                </Button.Flyout>
+            </Button>
+
+            <!-- Refresh -->
+            <Button Grid.Column="2"
+                    Background="Transparent"
+                    BorderThickness="0"
+                    Cursor="Hand"
+                    HorizontalAlignment="Stretch"
+                    VerticalAlignment="Stretch"
+                    Command="{Binding RefreshCommand}"
+                    ToolTip.Tip="{DynamicResource LibraryPage.Refresh.ToolTip}">
+                <icons:SymbolIcon Symbol="ArrowSync" />
+            </Button>
+
+            <!-- Toggle Grid/List View -->
+            <Button Grid.Column="3"
+                    Background="Transparent"
+                    BorderThickness="0"
+                    Cursor="Hand"
+                    HorizontalAlignment="Stretch"
+                    VerticalAlignment="Stretch"
+                    Command="{Binding ToggleGridViewCommand}">
+                <Panel>
+                    <!-- Show List icon when in Grid view (click to switch to list) -->
+                    <icons:SymbolIcon Symbol="List"
+                                      IsVisible="{Binding IsGridView}"
+                                      ToolTip.Tip="{DynamicResource LibraryPage.ToggleView.ToolTip.ListView}" />
+                    <!-- Show Grid icon when in List view (click to switch to grid) -->
+                    <icons:SymbolIcon Symbol="Grid"
+                                      IsVisible="{Binding !IsGridView}"
+                                      ToolTip.Tip="{DynamicResource LibraryPage.ToggleView.ToolTip.GridView}" />
+                </Panel>
+            </Button>
+
+            <!-- Sort -->
+            <Button Grid.Column="4"
+                    Background="Transparent"
+                    BorderThickness="0"
+                    Cursor="Hand"
+                    HorizontalAlignment="Stretch"
+                    VerticalAlignment="Stretch"
+                    ToolTip.Tip="{DynamicResource LibraryPage.Sort.ToolTip}">
+                <icons:SymbolIcon Symbol="ArrowSort" />
+                <Button.Flyout>
+                    <MenuFlyout Placement="BottomEdgeAlignedRight">
+                        <!-- Sort Direction Toggle -->
+                        <MenuItem Header="{DynamicResource LibraryPage.Sort.Direction}"
+                                  Command="{Binding ToggleSortDirectionCommand}">
+                            <MenuItem.Icon>
+                                <icons:SymbolIcon Symbol="{Binding SortDirectionIcon}" />
+                            </MenuItem.Icon>
+                        </MenuItem>
+                        <Separator />
+                        <!-- Sort Options -->
+                        <MenuItem Header="{DynamicResource LibraryPage.Sort.Title}"
+                                  Command="{Binding SetSortOptionCommand}"
+                                  CommandParameter="{x:Static models:GameSortOption.Title}"
+                                  ToggleType="CheckBox"
+                                  IsChecked="{Binding SortOption, Converter={StaticResource EnumToValueConverter}, ConverterParameter=Title}">
+                            <MenuItem.Icon>
+                                <icons:SymbolIcon Symbol="TextSortAscending" />
+                            </MenuItem.Icon>
+                        </MenuItem>
+                        <MenuItem Header="{DynamicResource LibraryPage.Sort.Compatibility}"
+                                  Command="{Binding SetSortOptionCommand}"
+                                  CommandParameter="{x:Static models:GameSortOption.Compatibility}"
+                                  ToggleType="CheckBox"
+                                  IsChecked="{Binding SortOption, Converter={StaticResource EnumToValueConverter}, ConverterParameter=Compatibility}">
+                            <MenuItem.Icon>
+                                <icons:SymbolIcon Symbol="HeartPulse" />
+                            </MenuItem.Icon>
+                        </MenuItem>
+                        <MenuItem Header="{DynamicResource LibraryPage.Sort.Playtime}"
+                                  Command="{Binding SetSortOptionCommand}"
+                                  CommandParameter="{x:Static models:GameSortOption.Playtime}"
+                                  ToggleType="CheckBox"
+                                  IsChecked="{Binding SortOption, Converter={StaticResource EnumToValueConverter}, ConverterParameter=Playtime}">
+                            <MenuItem.Icon>
+                                <icons:SymbolIcon Symbol="Timer" />
+                            </MenuItem.Icon>
+                        </MenuItem>
+                        <MenuItem Header="{DynamicResource LibraryPage.Sort.XeniaVersion}"
+                                  Command="{Binding SetSortOptionCommand}"
+                                  CommandParameter="{x:Static models:GameSortOption.XeniaVersion}"
+                                  ToggleType="CheckBox"
+                                  IsChecked="{Binding SortOption, Converter={StaticResource EnumToValueConverter}, ConverterParameter=XeniaVersion}">
+                            <MenuItem.Icon>
+                                <icons:SymbolIcon Symbol="AppFolder" />
+                            </MenuItem.Icon>
+                        </MenuItem>
+                        <MenuItem Header="{DynamicResource LibraryPage.Sort.LastPlayed}"
+                                  Command="{Binding SetSortOptionCommand}"
+                                  CommandParameter="{x:Static models:GameSortOption.LastPlayed}"
+                                  ToggleType="CheckBox"
+                                  IsChecked="{Binding SortOption, Converter={StaticResource EnumToValueConverter}, ConverterParameter=LastPlayed}">
+                            <MenuItem.Icon>
+                                <icons:SymbolIcon Symbol="History" />
+                            </MenuItem.Icon>
+                        </MenuItem>
+                    </MenuFlyout>
+                </Button.Flyout>
+            </Button>
+
+            <!-- Menu -->
+            <Button Grid.Column="5"
+                    Background="Transparent"
+                    BorderThickness="0"
+                    Cursor="Hand"
+                    HorizontalAlignment="Stretch"
+                    VerticalAlignment="Stretch">
+                <icons:SymbolIcon Symbol="MoreVertical" />
+                <Button.Flyout>
+                    <MenuFlyout Placement="BottomEdgeAlignedRight">
+                        <!-- Edit Grid View -->
+                        <MenuItem Header="{DynamicResource LibraryPage.Options.EditGridView.Header}"
+                                  ToolTip.Tip="{DynamicResource LibraryPage.Options.EditGridView.ToolTip}"
+                                  IsVisible="{Binding IsGridView}">
+                            <MenuItem.Icon>
+                                <icons:SymbolIcon Symbol="Eye" />
+                            </MenuItem.Icon>
+                            <!-- Game Title -->
+                            <MenuItem Header="{DynamicResource LibraryPage.Options.EditGridView.Title.Header}"
+                                      Command="{Binding ToggleGameTitleCommand}"
+                                      ToggleType="CheckBox"
+                                      IsChecked="{Binding ShowGameTitle}">
+                                <MenuItem.Icon>
+                                    <icons:SymbolIcon Symbol="SlideTextTitle" />
+                                </MenuItem.Icon>
+                            </MenuItem>
+                            <!-- Compatibility Rating -->
+                            <MenuItem Header="{DynamicResource LibraryPage.Options.EditGridView.CompatibilityRating.Header}"
+                                      Command="{Binding ToggleCompatibilityRatingCommand}"
+                                      ToggleType="CheckBox"
+                                      IsChecked="{Binding ShowCompatibilityRating}">
+                                <MenuItem.Icon>
+                                    <icons:SymbolIcon Symbol="WindowDevTools" />
+                                </MenuItem.Icon>
+                            </MenuItem>
+                            <!-- Xenia Version -->
+                            <MenuItem Header="{DynamicResource LibraryPage.Options.EditGridView.XeniaVersion.Header}"
+                                      Command="{Binding ToggleXeniaVersionCommand}"
+                                      ToggleType="CheckBox"
+                                      IsChecked="{Binding ShowXeniaVersion}"
+                                      ToolTip.Tip="{DynamicResource LibraryPage.Options.EditGridView.XeniaVersion.ToolTip}">
+                                <MenuItem.Icon>
+                                    <icons:SymbolIcon Symbol="Apps" />
+                                </MenuItem.Icon>
+                            </MenuItem>
+                            <!-- Double Click Launch -->
+                            <MenuItem Header="{DynamicResource LibraryPage.Options.DoubleClickLaunch.Header}"
+                                      ToolTip.Tip="{DynamicResource LibraryPage.Options.DoubleClickLaunch.ToolTip}"
+                                      Command="{Binding ToggleDoubleClickLaunchCommand}"
+                                      ToggleType="CheckBox"
+                                      IsChecked="{Binding DoubleClickLaunch}">
+                                <MenuItem.Icon>
+                                    <icons:SymbolIcon Symbol="CursorClick" />
+                                </MenuItem.Icon>
+                            </MenuItem>
+                        </MenuItem>
+                        <!-- Edit List View -->
+                        <MenuItem Header="{DynamicResource LibraryPage.Options.EditListView.Header}"
+                                  ToolTip.Tip="{DynamicResource LibraryPage.Options.EditListView.ToolTip}"
+                                  IsVisible="{Binding !IsGridView}">
+                            <MenuItem.Icon>
+                                <icons:SymbolIcon Symbol="List" />
+                            </MenuItem.Icon>
+                            <!-- Compatibility Rating -->
+                            <MenuItem Header="{DynamicResource LibraryPage.Options.EditListView.CompatibilityRating.Header}"
+                                      Command="{Binding ToggleListCompatibilityRatingCommand}"
+                                      ToggleType="CheckBox"
+                                      IsChecked="{Binding ShowListCompatibilityRating}">
+                                <MenuItem.Icon>
+                                    <icons:SymbolIcon Symbol="WindowDevTools" />
+                                </MenuItem.Icon>
+                            </MenuItem>
+                            <!-- Icon -->
+                            <MenuItem Header="{DynamicResource LibraryPage.Options.EditListView.Icon.Header}"
+                                      Command="{Binding ToggleListIconCommand}"
+                                      ToggleType="CheckBox"
+                                      IsChecked="{Binding ShowListIcon}">
+                                <MenuItem.Icon>
+                                    <icons:SymbolIcon Symbol="Image" />
+                                </MenuItem.Icon>
+                            </MenuItem>
+                            <!-- Playtime -->
+                            <MenuItem Header="{DynamicResource LibraryPage.Options.EditListView.Playtime.Header}"
+                                      Command="{Binding ToggleListPlaytimeCommand}"
+                                      ToggleType="CheckBox"
+                                      IsChecked="{Binding ShowListPlaytime}">
+                                <MenuItem.Icon>
+                                    <icons:SymbolIcon Symbol="Timer" />
+                                </MenuItem.Icon>
+                            </MenuItem>
+                            <!-- Last Played -->
+                            <MenuItem Header="{DynamicResource LibraryPage.Options.EditListView.LastPlayed.Header}"
+                                      Command="{Binding ToggleListLastPlayedCommand}"
+                                      ToggleType="CheckBox"
+                                      IsChecked="{Binding ShowListLastPlayed}">
+                                <MenuItem.Icon>
+                                    <icons:SymbolIcon Symbol="Clock" />
+                                </MenuItem.Icon>
+                            </MenuItem>
+                            <!-- Xenia Version -->
+                            <MenuItem Header="{DynamicResource LibraryPage.Options.EditListView.XeniaVersion.Header}"
+                                      Command="{Binding ToggleListXeniaVersionCommand}"
+                                      ToggleType="CheckBox"
+                                      IsChecked="{Binding ShowListXeniaVersion}"
+                                      ToolTip.Tip="{DynamicResource LibraryPage.Options.EditListView.XeniaVersion.ToolTip}">
+                                <MenuItem.Icon>
+                                    <icons:SymbolIcon Symbol="Apps" />
+                                </MenuItem.Icon>
+                            </MenuItem>
+                            <!-- Title ID -->
+                            <MenuItem Header="{DynamicResource LibraryPage.Options.EditListView.TitleId.Header}"
+                                      Command="{Binding ToggleListTitleIdCommand}"
+                                      ToggleType="CheckBox"
+                                      IsChecked="{Binding ShowListTitleId}">
+                                <MenuItem.Icon>
+                                    <icons:SymbolIcon Symbol="Tag" />
+                                </MenuItem.Icon>
+                            </MenuItem>
+                            <!-- Media ID -->
+                            <MenuItem Header="{DynamicResource LibraryPage.Options.EditListView.MediaId.Header}"
+                                      Command="{Binding ToggleListMediaIdCommand}"
+                                      ToggleType="CheckBox"
+                                      IsChecked="{Binding ShowListMediaId}">
+                                <MenuItem.Icon>
+                                    <icons:SymbolIcon Symbol="Bookmark" />
+                                </MenuItem.Icon>
+                            </MenuItem>
+                        </MenuItem>
+                        <Separator />
+                        <!-- Export Shortcuts -->
+                        <!-- TODO: Add support for Linux/Proton/Wine-->
+                        <MenuItem Header="{DynamicResource LibraryPage.Options.ExportShortcuts.Header}"
+                                  Command="{Binding ExportGameShortcutsCommand}"
+                                  ToolTip.Tip="{DynamicResource LibraryPage.Options.ExportShortcuts.ToolTip}"
+                                  IsVisible="{Binding SupportsShortcuts}">
+                            <MenuItem.Icon>
+                                <icons:SymbolIcon Symbol="ArrowExport" />
+                            </MenuItem.Icon>
+                        </MenuItem>
+                        <!-- Update Compatibility Ratings -->
+                        <MenuItem Header="{DynamicResource LibraryPage.Options.UpdateCompatibilityRatings.Header}"
+                                  Command="{Binding UpdateCompatibilityRatingsCommand}"
+                                  ToolTip.Tip="{DynamicResource LibraryPage.Options.UpdateCompatibilityRatings.ToolTip}">
+                            <MenuItem.Icon>
+                                <icons:SymbolIcon Symbol="ArrowSync" />
+                            </MenuItem.Icon>
+                        </MenuItem>
+                        <!-- Optimize Game Settings -->
+                        <MenuItem Header="{DynamicResource LibraryPage.Options.OptimizeGameSettings.Header}"
+                                  Command="{Binding UpdateOptimizedSettingsCommand}"
+                                  ToolTip.Tip="{DynamicResource LibraryPage.Options.OptimizeGameSettings.ToolTip}">
+                            <MenuItem.Icon>
+                                <icons:SymbolIcon Symbol="CloudSync" />
+                            </MenuItem.Icon>
+                        </MenuItem>
+                        <Separator />
+                        <!-- Scan Directory -->
+                        <MenuItem Header="{DynamicResource LibraryPage.Options.ScanDirectory.Header}"
+                                  Command="{Binding ScanDirectoryCommand}"
+                                  ToolTip.Tip="{DynamicResource LibraryPage.Options.ScanDirectory.ToolTip}">
+                            <MenuItem.Icon>
+                                <icons:SymbolIcon Symbol="FolderAdd" />
+                            </MenuItem.Icon>
+                        </MenuItem>
+                        <!-- Add Game -->
+                        <MenuItem Header="{DynamicResource LibraryPage.Options.AddGame.Header}"
+                                  Command="{Binding AddGameCommand}"
+                                  ToolTip.Tip="{DynamicResource LibraryPage.Options.AddGame.ToolTip}">
+                            <MenuItem.Icon>
+                                <icons:SymbolIcon Symbol="Add" />
+                            </MenuItem.Icon>
+                        </MenuItem>
+                        <Separator />
+                        <!-- Remove Invalid Games -->
+                        <MenuItem Header="{DynamicResource LibraryPage.Options.RemoveInvalidGames.Header}"
+                                  Command="{Binding RemoveInvalidGamesCommand}"
+                                  ToolTip.Tip="{DynamicResource LibraryPage.Options.RemoveInvalidGames.ToolTip}">
+                            <MenuItem.Icon>
+                                <icons:SymbolIcon Symbol="Delete" />
+                            </MenuItem.Icon>
+                        </MenuItem>
+                    </MenuFlyout>
+                </Button.Flyout>
+            </Button>
+        </Grid>
+
+        <!-- Zoom Slider -->
+        <Grid Grid.Row="1" Margin="10,0"
+              IsVisible="{Binding IsGridView}">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            <icons:SymbolIcon Grid.Column="0"
+                              Symbol="ZoomOut"
+                              FontSize="14"
+                              Margin="0,0,8,0" />
+            <Slider Grid.Column="1"
+                    VerticalAlignment="Center"
+                    IsSnapToTickEnabled="True"
+                    Maximum="{Binding ZoomMaximum}"
+                    Minimum="{Binding ZoomMinimum}"
+                    MinHeight="0"
+                    Padding="0"
+                    TickFrequency="{Binding ZoomTickFrequency}"
+                    Value="{Binding ZoomValue}"
+                    ToolTip.Tip="{Binding ZoomToolTip}" />
+            <icons:SymbolIcon Grid.Column="2"
+                              Symbol="ZoomIn"
+                              FontSize="14"
+                              Margin="8,0,0,0" />
+        </Grid>
+
+        <!-- Games (Grid View - flat when no groups) -->
+        <ScrollViewer Grid.Row="2"
+                      Padding="8"
+                      IsVisible="{Binding IsFlatGridVisible}"
+                      PointerReleased="OnScrollViewerPointerReleased">
+            <controls:FAItemsRepeater Margin="0,0,10,0"
+                                      ItemsSource="{Binding Games}"
+                                      ItemTemplate="{StaticResource GameGridItemTemplate}">
+                <controls:FAItemsRepeater.Layout>
+                    <controls:FAUniformGridLayout MinItemWidth="{Binding MinItemWidth}"
+                                                  MinItemHeight="{Binding MinItemHeight}"
+                                                  MinRowSpacing="{Binding ItemSpacing}"
+                                                  MinColumnSpacing="{Binding ItemSpacing}"
+                                                  ItemsStretch="Uniform" />
+                </controls:FAItemsRepeater.Layout>
+
             </controls:FAItemsRepeater>
+        </ScrollViewer>
+
+        <!-- Games (List View - flat when no groups) -->
+        <ScrollViewer Grid.Row="2"
+                      Padding="8,8,18,8"
+                      Background="Transparent"
+                      IsVisible="{Binding IsFlatListVisible}"
+                      PointerReleased="OnListPointerReleased"
+                      HorizontalScrollBarVisibility="Disabled">
+            <controls:FAItemsRepeater ItemsSource="{Binding Games}"
+                                      ItemTemplate="{StaticResource GameListItemTemplate}">
+
+            </controls:FAItemsRepeater>
+        </ScrollViewer>
+
+
+        <!-- Games (sectioned by group) -->
+        <ScrollViewer Grid.Row="2"
+                      Padding="8"
+                      IsVisible="{Binding IsSectionedVisible}"
+                      PointerReleased="OnScrollViewerPointerReleased"
+                      HorizontalScrollBarVisibility="Disabled">
+            <ItemsControl ItemsSource="{Binding GroupSections}">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate x:DataType="itemVm:GameGroupSectionViewModel">
+                        <Expander Margin="0,0,0,8"
+                                  IsExpanded="{Binding IsExpanded, Mode=TwoWay}">
+                            <Expander.Header>
+                                <Grid ColumnDefinitions="*,Auto">
+                                    <TextBlock Text="{Binding HeaderText}"
+                                               FontWeight="SemiBold"
+                                               FontSize="16"
+                                               VerticalAlignment="Center" />
+                                    <Button Grid.Column="1"
+                                            Background="Transparent"
+                                            BorderThickness="0"
+                                            Cursor="Hand"
+                                            Padding="8,4"
+                                            IsVisible="{Binding IsUserGroup}"
+                                            Command="{Binding DeleteGroupCommand}"
+                                            ToolTip.Tip="{DynamicResource LibraryPage.Groups.Delete.ToolTip}">
+                                        <icons:SymbolIcon Symbol="Delete" FontSize="16" />
+                                    </Button>
+                                </Grid>
+                            </Expander.Header>
+                            <Panel>
+                                <!-- Grid inside section -->
+                                <controls:FAItemsRepeater Margin="0,0,10,0"
+                                                          ItemsSource="{Binding Games}"
+                                                          ItemTemplate="{StaticResource GameGridItemTemplate}"
+                                                          IsVisible="{Binding DataContext.IsGridView, ElementName=Root}">
+                                    <controls:FAItemsRepeater.Layout>
+                                        <controls:FAUniformGridLayout MinItemWidth="{Binding DataContext.MinItemWidth, ElementName=Root}"
+                                                                      MinItemHeight="{Binding DataContext.MinItemHeight, ElementName=Root}"
+                                                                      MinRowSpacing="{Binding DataContext.ItemSpacing, ElementName=Root}"
+                                                                      MinColumnSpacing="{Binding DataContext.ItemSpacing, ElementName=Root}"
+                                                                      ItemsStretch="Uniform" />
+                                    </controls:FAItemsRepeater.Layout>
+                                </controls:FAItemsRepeater>
+                                <!-- List inside section -->
+                                <controls:FAItemsRepeater ItemsSource="{Binding Games}"
+                                                          ItemTemplate="{StaticResource GameListItemTemplate}"
+                                                          IsVisible="{Binding !DataContext.IsGridView, ElementName=Root}" />
+                            </Panel>
+                        </Expander>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
         </ScrollViewer>
 
         <!-- Bulk Delete Toolbar (shown when games are selected) -->

--- a/source/XeniaManager/Views/Pages/LibraryPage.axaml
+++ b/source/XeniaManager/Views/Pages/LibraryPage.axaml
@@ -711,6 +711,16 @@
                                             </ToolTip.Tip>
                                         </MenuItem>
                                     </MenuItem>
+                                    <!-- Add to Group -->
+                                    <MenuItem Header="{DynamicResource GameButton.ContextFlyout.AddToGroup.Header}"
+                                              Command="{Binding AddToGroupCommand}">
+                                        <MenuItem.Icon>
+                                            <icons:SymbolIcon Symbol="FolderAdd" />
+                                        </MenuItem.Icon>
+                                        <ToolTip.Tip>
+                                            <TextBlock Text="{DynamicResource GameButton.ContextFlyout.AddToGroup.ToolTip}" />
+                                        </ToolTip.Tip>
+                                    </MenuItem>
                                     <!-- Remove Game Command-->
                                     <MenuItem Header="{DynamicResource GameButton.ContextFlyout.RemoveGame.Header}"
                                               Command="{Binding RemoveGameCommand}">
@@ -1048,6 +1058,16 @@
                                             </ToolTip.Tip>
                                         </MenuItem>
                                     </MenuItem>
+                                    <!-- Add to Group -->
+                                    <MenuItem Header="{DynamicResource GameButton.ContextFlyout.AddToGroup.Header}"
+                                              Command="{Binding AddToGroupCommand}">
+                                        <MenuItem.Icon>
+                                            <icons:SymbolIcon Symbol="FolderAdd" />
+                                        </MenuItem.Icon>
+                                        <ToolTip.Tip>
+                                            <TextBlock Text="{DynamicResource GameButton.ContextFlyout.AddToGroup.ToolTip}" />
+                                        </ToolTip.Tip>
+                                    </MenuItem>
                                     <!-- Remove Game Command-->
                                     <MenuItem Header="{DynamicResource GameButton.ContextFlyout.RemoveGame.Header}"
                                               Command="{Binding RemoveGameCommand}">
@@ -1231,6 +1251,16 @@
                 <TextBlock Text="{Binding SelectedGamesCountText}"
                            VerticalAlignment="Center"
                            FontWeight="SemiBold" />
+                <Button Command="{Binding AddSelectedGamesToGroupCommand}"
+                        HorizontalAlignment="Right">
+                    <Button.Content>
+                        <StackPanel Orientation="Horizontal"
+                                    Spacing="4">
+                            <icons:SymbolIcon Symbol="FolderAdd" />
+                            <TextBlock Text="{DynamicResource LibraryPage.AddSelectedToGroup.Button}" />
+                        </StackPanel>
+                    </Button.Content>
+                </Button>
                 <Button Command="{Binding PromptDeleteSelectedGamesCommand}"
                         HorizontalAlignment="Right">
                     <Button.Content>


### PR DESCRIPTION
## Summary
- Add named game groups persisted in `Config/groups.json`, creatable from the Game Library sidebar (New Group)
- Add games to a group from the right-click context menu or the multi-select toolbar (supports bulk add)
- Clicking a group in the left sidebar filters the library to that group's games; selecting Game Library clears the filter

## Why
Makes it easier to organize large libraries into custom collections without changing how games are stored on disk.

## Test plan
- [ ] Create a new group from **Game Library → New Group**; confirm it appears in the sidebar and persists after restart
- [ ] Right-click a game → **Add to Group**; confirm filter shows only that game
- [ ] Multi-select several games (Ctrl/Shift) → **Add to Group** from context menu or selection bar; confirm all are added
- [ ] Click **Game Library** to clear the filter and show the full library
- [ ] Confirm existing `Config` / `GameData` installs continue to load normally

## Notes
- English strings added; other languages fall back to English via existing localization

Made with [Cursor](https://cursor.com)