### PR TITLE
feat(content): Support installing content as package files

### DIFF
--- a/source/XeniaManager.BigScreen/Controls/Cards/ContentRow.axaml
+++ b/source/XeniaManager.BigScreen/Controls/Cards/ContentRow.axaml
@@ -24,10 +24,19 @@
         </ControlTemplate>
     </Button.Template>
     <Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="20">
-        <fluent:SymbolIcon Symbol="Document"
-                           FontSize="26"
-                           Foreground="{DynamicResource TextSecondary}"
-                           VerticalAlignment="Center" />
+        <!-- Icon: package thumbnail when available, document fallback otherwise -->
+        <Panel VerticalAlignment="Center">
+            <Image Source="{Binding ThumbnailImage}"
+                   IsVisible="{Binding HasThumbnail}"
+                   Width="48"
+                   Height="48"
+                   Stretch="Uniform" />
+            <fluent:SymbolIcon Symbol="Document"
+                               FontSize="26"
+                               Foreground="{DynamicResource TextSecondary}"
+                               VerticalAlignment="Center"
+                               IsVisible="{Binding !HasThumbnail}" />
+        </Panel>
         <StackPanel Grid.Column="1"
                     VerticalAlignment="Center"
                     Spacing="2">

--- a/source/XeniaManager.BigScreen/ViewModels/Items/ContentItemViewModel.cs
+++ b/source/XeniaManager.BigScreen/ViewModels/Items/ContentItemViewModel.cs
@@ -1,8 +1,11 @@
+using System;
 using System.IO;
 using System.Text.RegularExpressions;
+using Avalonia.Media.Imaging;
 using CommunityToolkit.Mvvm.ComponentModel;
 using XeniaManager.BigScreen.Utilities;
 using XeniaManager.Core.Files;
+using XeniaManager.Core.Logging;
 using XeniaManager.Core.Models.Files.Stfs;
 
 namespace XeniaManager.BigScreen.ViewModels.Items;
@@ -23,6 +26,16 @@ public partial class ContentItemViewModel : ObservableObject, ISelectable
     /// </summary>
     [ObservableProperty]
     public partial bool IsSelected { get; set; }
+
+    /// <summary>
+    /// The thumbnail image embedded in the package (only available for package entries).
+    /// </summary>
+    [ObservableProperty] private Bitmap? _thumbnailImage;
+
+    /// <summary>
+    /// Gets whether a thumbnail image is available for display.
+    /// </summary>
+    public bool HasThumbnail => ThumbnailImage != null;
 
     /// <summary>
     /// The content's display name.
@@ -52,6 +65,12 @@ public partial class ContentItemViewModel : ObservableObject, ISelectable
     {
         get
         {
+            // Package-file content points directly at the package itself (no sidecar header)
+            if (Header.IsPackageEntry)
+            {
+                return Header.FilePath;
+            }
+
             string basePath = Regex.Split(HeaderFilePath, @"\\Headers", RegexOptions.IgnoreCase)[0];
             string primaryPath = Path.Combine(basePath, Header.ContentType.ToHexString(), Header.FileName);
             if (ExistsOnDisk(primaryPath))
@@ -74,5 +93,20 @@ public partial class ContentItemViewModel : ObservableObject, ISelectable
     public ContentItemViewModel(HeaderFile header)
     {
         Header = header;
+
+        // Package entries carry their icon inside the package metadata
+        if (header.IsPackageEntry && header.ThumbnailImage.Length > 0)
+        {
+            try
+            {
+                using MemoryStream ms = new MemoryStream(header.ThumbnailImage);
+                ThumbnailImage = new Bitmap(ms);
+            }
+            catch (Exception ex)
+            {
+                Logger.Error<ContentItemViewModel>($"Failed to load package thumbnail for '{header.FileName}'");
+                Logger.LogExceptionDetails<ContentItemViewModel>(ex);
+            }
+        }
     }
 }

--- a/source/XeniaManager.Core/Files/HeaderFile.cs
+++ b/source/XeniaManager.Core/Files/HeaderFile.cs
@@ -79,8 +79,22 @@ public class HeaderFile
 
     /// <summary>
     /// Gets or sets the file path.
+    /// For regular entries this is the sidecar .header file path.
+    /// For package entries (<see cref="IsPackageEntry"/>) this is the package file itself.
     /// </summary>
     public string FilePath { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets whether this entry represents a package file kept intact in Xenia's content directory
+    /// (XContent package support, Xenia Canary b11458e+) instead of an extracted directory with a sidecar .header file.
+    /// </summary>
+    public bool IsPackageEntry { get; set; }
+
+    /// <summary>
+    /// Gets or sets the thumbnail image data embedded in the package.
+    /// Only populated for package entries (<see cref="IsPackageEntry"/>); empty for extracted content.
+    /// </summary>
+    public byte[] ThumbnailImage { get; set; } = [];
 
     /// <summary>
     /// Gets or sets the XUID (defaults to 0 for installed content).

--- a/source/XeniaManager.Core/Manage/ContentPackageManager.cs
+++ b/source/XeniaManager.Core/Manage/ContentPackageManager.cs
@@ -1,0 +1,67 @@
+using XeniaManager.Core.Logging;
+
+namespace XeniaManager.Core.Manage;
+
+/// <summary>
+/// Installs STFS content packages into Xenia's content directory as package files.
+/// Package files keep their original form (metadata stays embedded), which requires
+/// a Xenia build with XContent package support.
+/// </summary>
+public class ContentPackageManager
+{
+    /// <summary>
+    /// The size of a single copy chunk (1 MiB).
+    /// </summary>
+    private const int CopyChunkSize = 1024 * 1024;
+
+    /// <summary>
+    /// Installs an STFS package file into Xenia's content directory by copying it to:
+    /// outputDirectory/TitleId/ContentType/[original file name]
+    /// </summary>
+    /// <param name="packageFilePath">Path to the STFS package file to install.</param>
+    /// <param name="outputDirectory">The content directory of the target XUID (e.g. ContentFolder/0000000000000000).</param>
+    /// <param name="titleIdHex">Title ID in hex string format (e.g. "4D5309C9").</param>
+    /// <param name="contentTypeHex">Content type in hex string format (e.g. "00009000").</param>
+    /// <param name="progressCallback">Optional callback reporting (bytes copied, total bytes).</param>
+    public static void InstallPackageAsFile(string packageFilePath, string outputDirectory, string titleIdHex, string contentTypeHex,
+        Action<long, long>? progressCallback = null)
+    {
+        Logger.Debug<ContentPackageManager>($"Installing package file: {packageFilePath}");
+
+        if (!File.Exists(packageFilePath))
+        {
+            Logger.Error<ContentPackageManager>($"Package file does not exist: {packageFilePath}");
+            throw new FileNotFoundException($"Package file does not exist at {packageFilePath}", packageFilePath);
+        }
+
+        // Create the content type folder: outputDirectory/TitleId/ContentType/
+        string contentTypeFolderPath = Path.Combine(outputDirectory, titleIdHex.ToUpperInvariant(), contentTypeHex.ToUpperInvariant());
+        Directory.CreateDirectory(contentTypeFolderPath);
+
+        string destinationPath = Path.Combine(contentTypeFolderPath, Path.GetFileName(packageFilePath));
+        long totalBytes = new FileInfo(packageFilePath).Length;
+        Logger.Info<ContentPackageManager>($"Copying {totalBytes} bytes to {destinationPath}");
+
+        long copiedBytes = 0;
+        using (FileStream source = new FileStream(packageFilePath, FileMode.Open, FileAccess.Read, FileShare.Read))
+        using (FileStream destination = new FileStream(destinationPath, FileMode.Create, FileAccess.Write, FileShare.None))
+        {
+            byte[] buffer = new byte[CopyChunkSize];
+            int bytesRead;
+            while ((bytesRead = source.Read(buffer, 0, buffer.Length)) > 0)
+            {
+                destination.Write(buffer, 0, bytesRead);
+                copiedBytes += bytesRead;
+                progressCallback?.Invoke(copiedBytes, totalBytes);
+            }
+        }
+
+        if (copiedBytes != totalBytes)
+        {
+            Logger.Error<ContentPackageManager>($"Incomplete copy: {copiedBytes} out of {totalBytes} bytes written to {destinationPath}");
+            throw new IOException($"Failed to copy the whole package file ({copiedBytes} out of {totalBytes} bytes)");
+        }
+
+        Logger.Info<ContentPackageManager>($"Successfully installed package file to {destinationPath} ({copiedBytes} bytes)");
+    }
+}

--- a/source/XeniaManager.Core/Models/ContentInstallationMethod.cs
+++ b/source/XeniaManager.Core/Models/ContentInstallationMethod.cs
@@ -1,0 +1,17 @@
+namespace XeniaManager.Core.Models;
+
+/// <summary>
+/// Defines how content packages get installed into Xenia's content directory.
+/// </summary>
+public enum ContentInstallationMethod
+{
+    /// <summary>
+    /// Extracts the package contents into Xenia's directory structure (compatible with every Xenia version)
+    /// </summary>
+    ExtractedFolder,
+
+    /// <summary>
+    /// Copies the package file into Xenia's content directory as-is (requires a Xenia Canary build with XContent package support)
+    /// </summary>
+    PackageFile
+}

--- a/source/XeniaManager.Core/Models/Items/GameContent.cs
+++ b/source/XeniaManager.Core/Models/Items/GameContent.cs
@@ -85,8 +85,8 @@ public class GameContent : AccountContent
         InstallerHeaderFiles = [];
         List<string> installerFolderContent =
         [
-            ..Directory.GetDirectories(installerFolder),
-            ..Directory.GetFiles(installerFolder)
+            .. Directory.GetDirectories(installerFolder),
+            .. Directory.GetFiles(installerFolder)
         ];
 
         Logger.Debug<GameContent>($"Found {installerFolderContent.Count} installer items to process");
@@ -94,12 +94,23 @@ public class GameContent : AccountContent
         foreach (string content in installerFolderContent)
         {
             string contentName = Path.GetFileName(content);
-            string contentHeaderFile = Path.Combine(installerHeaderFolder, $"{contentName}.header");
             try
             {
-                // Load the HeaderFile and add it to the InstallerHeaderFiles list
-                Logger.Debug<GameContent>($"Loading header file for {contentName}");
-                HeaderFile header = HeaderFile.Load(contentHeaderFile);
+                HeaderFile header;
+                if (File.Exists(content))
+                {
+                    // Package file entry: read the metadata directly from the package
+                    Logger.Debug<GameContent>($"Loading package metadata for {contentName}");
+                    header = LoadHeaderFromPackage(content);
+                }
+                else
+                {
+                    // Directory entry: load the sidecar header file
+                    string contentHeaderFile = Path.Combine(installerHeaderFolder, $"{contentName}.header");
+                    Logger.Debug<GameContent>($"Loading header file for {contentName}");
+                    header = HeaderFile.Load(contentHeaderFile);
+                }
+
                 InstallerHeaderFiles.Add(header);
                 Logger.Debug<GameContent>($"Successfully loaded header for {contentName}");
             }
@@ -153,8 +164,8 @@ public class GameContent : AccountContent
         MarketplaceContentHeaderFiles = [];
         List<string> marketplaceContentFolderContent =
         [
-            ..Directory.GetDirectories(marketplaceContentFolder),
-            ..Directory.GetFiles(marketplaceContentFolder)
+            .. Directory.GetDirectories(marketplaceContentFolder),
+            .. Directory.GetFiles(marketplaceContentFolder)
         ];
 
         Logger.Debug<GameContent>($"Found {marketplaceContentFolderContent.Count} marketplace content items to process");
@@ -162,12 +173,23 @@ public class GameContent : AccountContent
         foreach (string content in marketplaceContentFolderContent)
         {
             string contentName = Path.GetFileName(content);
-            string contentHeaderFile = Path.Combine(marketplaceContentHeaderFolder, $"{contentName}.header");
             try
             {
-                // Load the HeaderFile and add it to the MarketplaceContentHeaderFiles list
-                Logger.Debug<GameContent>($"Loading header file for {contentName}");
-                HeaderFile header = HeaderFile.Load(contentHeaderFile);
+                HeaderFile header;
+                if (File.Exists(content))
+                {
+                    // Package file entry: read the metadata directly from the package
+                    Logger.Debug<GameContent>($"Loading package metadata for {contentName}");
+                    header = LoadHeaderFromPackage(content);
+                }
+                else
+                {
+                    // Directory entry: load the sidecar header file
+                    string contentHeaderFile = Path.Combine(marketplaceContentHeaderFolder, $"{contentName}.header");
+                    Logger.Debug<GameContent>($"Loading header file for {contentName}");
+                    header = HeaderFile.Load(contentHeaderFile);
+                }
+
                 MarketplaceContentHeaderFiles.Add(header);
                 Logger.Debug<GameContent>($"Successfully loaded header for {contentName}");
             }
@@ -191,5 +213,31 @@ public class GameContent : AccountContent
         }
 
         Logger.Info<GameContent>($"Loaded {MarketplaceContentHeaderFiles.Count} marketplace content headers for Title ID {titleId}");
+    }
+
+    /// <summary>
+    /// Loads content metadata directly from an STFS package file kept intact in the content directory
+    /// (XContent package support, Xenia Canary b11458e+).
+    /// </summary>
+    /// <param name="packageFilePath">Path to the package file.</param>
+    /// <returns>A HeaderFile describing the package.</returns>
+    private static HeaderFile LoadHeaderFromPackage(string packageFilePath)
+    {
+        using StfsFile package = StfsFile.LoadHeaderOnly(packageFilePath);
+        return new HeaderFile
+        {
+            DeviceId = 1,
+            ContentType = package.Metadata.ContentType,
+            DisplayName = package.Metadata.DisplayName,
+            FileName = Path.GetFileName(packageFilePath),
+            FilePath = packageFilePath,
+            TitleId = unchecked((uint)package.Metadata.TitleId),
+            AccountXuid = new AccountXuid(0), // Universal XUID for installed content
+            HeaderSize = HeaderFile.FullHeaderSize,
+            IsPackageEntry = true,
+            ThumbnailImage = package.Metadata.ThumbnailImage.Length > 0
+                ? package.Metadata.ThumbnailImage
+                : package.Metadata.TitleThumbnailImage
+        };
     }
 }

--- a/source/XeniaManager/Controls/ContentViewerDialog.axaml
+++ b/source/XeniaManager/Controls/ContentViewerDialog.axaml
@@ -95,15 +95,23 @@
                         <DataTemplate x:DataType="itemsvm:HeaderFileViewModel">
                             <Border Padding="12,8" Margin="4,2">
                                 <Grid ColumnDefinitions="Auto,*,Auto">
-                                    <!-- Icon -->
-                                    <fluent:SymbolIcon Symbol="Document"
-                                                       Grid.Column="0"
-                                                       VerticalAlignment="Center"
-                                                       Margin="0,0,12,0">
-                                        <fluent:SymbolIcon.Foreground>
-                                            <DynamicResource ResourceKey="TextFillColorSecondaryBrush" />
-                                        </fluent:SymbolIcon.Foreground>
-                                    </fluent:SymbolIcon>
+                                    <!-- Icon: package thumbnail when available, document fallback otherwise -->
+                                    <Panel Grid.Column="0"
+                                           Width="32"
+                                           Height="32"
+                                           VerticalAlignment="Center"
+                                           Margin="0,0,12,0">
+                                        <Image Source="{Binding ThumbnailImage}"
+                                               IsVisible="{Binding HasThumbnail}"
+                                               Stretch="Uniform" />
+                                        <fluent:SymbolIcon Symbol="Document"
+                                                           VerticalAlignment="Center"
+                                                           IsVisible="{Binding HasThumbnail, Converter={StaticResource InverseBoolConverter}}">
+                                            <fluent:SymbolIcon.Foreground>
+                                                <DynamicResource ResourceKey="TextFillColorSecondaryBrush" />
+                                            </fluent:SymbolIcon.Foreground>
+                                        </fluent:SymbolIcon>
+                                    </Panel>
 
                                     <!-- Content details -->
                                     <StackPanel Grid.Column="1"

--- a/source/XeniaManager/Controls/InstallContentDialog.axaml
+++ b/source/XeniaManager/Controls/InstallContentDialog.axaml
@@ -150,18 +150,36 @@
                 </ListBox.ItemTemplate>
             </ListBox>
 
-            <!-- Add Content Button -->
-            <Button Grid.Row="1"
-                    x:Name="AddContentButton"
-                    HorizontalAlignment="Right"
-                    Margin="8">
-                <ToolTip.Tip>
-                    <TextBlock Text="{DynamicResource InstallContentDialog.AddContent.Button}" />
-                </ToolTip.Tip>
-                <Button.Content>
-                    <fluent:SymbolIcon Symbol="Add" />
-                </Button.Content>
-            </Button>
+            <!-- Install and Add Content Buttons -->
+            <Grid Grid.Row="1"
+                  ColumnDefinitions="Auto,*,Auto"
+                  Margin="8">
+                <StackPanel Grid.Column="0"
+                            Orientation="Horizontal"
+                            Spacing="8">
+                    <!-- Extract install button (compatible with all Xenia versions) -->
+                    <Button x:Name="InstallExtractedButton"
+                            Content="{DynamicResource InstallContentDialog.InstallExtracted.Button}"
+                            IsEnabled="{Binding CanInstall}" />
+                    <!-- Package install button (requires the latest Xenia Canary) -->
+                    <Button x:Name="InstallPackageButton"
+                            Content="{DynamicResource InstallContentDialog.InstallPackage.Button}"
+                            ToolTip.Tip="{DynamicResource InstallContentDialog.Method.Package.ToolTip}"
+                            IsEnabled="{Binding CanInstall}" />
+                </StackPanel>
+
+                <!-- Add Content Button -->
+                <Button Grid.Column="2"
+                        x:Name="AddContentButton"
+                        HorizontalAlignment="Right">
+                    <ToolTip.Tip>
+                        <TextBlock Text="{DynamicResource InstallContentDialog.AddContent.Button}" />
+                    </ToolTip.Tip>
+                    <Button.Content>
+                        <fluent:SymbolIcon Symbol="Add" />
+                    </Button.Content>
+                </Button>
+            </Grid>
         </Grid>
     </cards:CustomCard>
 </UserControl>

--- a/source/XeniaManager/Controls/InstallContentDialog.axaml.cs
+++ b/source/XeniaManager/Controls/InstallContentDialog.axaml.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Platform.Storage;
-using FluentAvalonia.Core;
 using FluentAvalonia.UI.Controls;
 using Microsoft.Extensions.DependencyInjection;
 using XeniaManager.Core.Files;
@@ -58,60 +57,22 @@ public partial class InstallContentDialog : UserControl
         {
             Title = LocalizationHelper.GetText("InstallContentDialog.ContentDialog.Title"),
             Content = dialog,
-            PrimaryButtonText = LocalizationHelper.GetText("InstallContentDialog.ContentDialog.InstallButton.Text"),
             CloseButtonText = LocalizationHelper.GetText("InstallContentDialog.ContentDialog.CancelButton.Text"),
-            FullSizeDesired = true,
-            DefaultButton = FAContentDialogButton.Primary
+            FullSizeDesired = true
         };
 
         // Controlling ContentDialog
         contentDialog.Resources.Add("ContentDialogMinWidth", 600.0);
         contentDialog.Resources.Add("ContentDialogMaxWidth", 1000.0);
 
-        // Set the initial button state (disabled when no content items)
-        contentDialog.IsPrimaryButtonEnabled = dialog._viewModel.CanInstall;
-
-        // Bind button states to ViewModel
-        dialog._viewModel.PropertyChanged += (s, e) =>
+        // Handle install buttons click
+        dialog.InstallExtractedButton.Click += async (_, _) =>
         {
-            if (e.PropertyName == nameof(InstallContentDialogViewModel.CanInstall))
-            {
-                contentDialog.IsPrimaryButtonEnabled = dialog._viewModel.CanInstall;
-            }
+            await ExecuteInstallation(contentDialog, dialog._viewModel, ContentInstallationMethod.ExtractedFolder);
         };
-
-        // Handle primary button (Install) using deferral to properly handle async operation
-        contentDialog.PrimaryButtonClick += async (_, e) =>
+        dialog.InstallPackageButton.Click += async (_, _) =>
         {
-            FADeferral? deferral = e.GetDeferral();
-            try
-            {
-                // Start the installation
-                await dialog._viewModel.InstallCommand.ExecuteAsync(null);
-
-                // Wait for installation to complete
-                while (dialog._viewModel.IsInstalling)
-                {
-                    await Task.Delay(100);
-                }
-
-                // Show the messagebox with installation results
-                await ShowInstallationResults(dialog._viewModel);
-            }
-            catch (Exception ex)
-            {
-                Logger.Error<InstallContentDialog>("Installation failed");
-                Logger.LogExceptionDetails<InstallContentDialog>(ex);
-                e.Cancel = true;
-                IMessageBoxService messageBox = App.Services.GetRequiredService<IMessageBoxService>();
-                await messageBox.ShowErrorAsync(
-                    LocalizationHelper.GetText("InstallContentDialog.Results.Failed.Title"),
-                    ex.Message);
-            }
-            finally
-            {
-                deferral.Complete();
-            }
+            await ExecuteInstallation(contentDialog, dialog._viewModel, ContentInstallationMethod.PackageFile);
         };
 
         // Handle Add Content button click
@@ -128,6 +89,33 @@ public partial class InstallContentDialog : UserControl
         {
             Logger.Error<InstallContentDialog>("Error showing install content dialog");
             Logger.LogExceptionDetails<InstallContentDialog>(ex);
+        }
+    }
+
+    /// <summary>
+    /// Runs the installation with the given method, closes the dialog and shows the installation results.
+    /// </summary>
+    private static async Task ExecuteInstallation(FAContentDialog contentDialog, InstallContentDialogViewModel viewModel,
+        ContentInstallationMethod installationMethod)
+    {
+        try
+        {
+            // Start the installation
+            await viewModel.InstallCommand.ExecuteAsync(installationMethod);
+
+            contentDialog.Hide();
+
+            // Show the messagebox with installation results
+            await ShowInstallationResults(viewModel);
+        }
+        catch (Exception ex)
+        {
+            Logger.Error<InstallContentDialog>("Installation failed");
+            Logger.LogExceptionDetails<InstallContentDialog>(ex);
+            IMessageBoxService messageBox = App.Services.GetRequiredService<IMessageBoxService>();
+            await messageBox.ShowErrorAsync(
+                LocalizationHelper.GetText("InstallContentDialog.Results.Failed.Title"),
+                ex.Message);
         }
     }
 

--- a/source/XeniaManager/Resources/Language/en.axaml
+++ b/source/XeniaManager/Resources/Language/en.axaml
@@ -646,10 +646,12 @@
 
     <!-- Install Content Dialog -->
     <sys:String x:Key="InstallContentDialog.ContentDialog.Title">Install Content</sys:String>
-    <sys:String x:Key="InstallContentDialog.ContentDialog.InstallButton.Text">Install</sys:String>
     <sys:String x:Key="InstallContentDialog.ContentDialog.CancelButton.Text">Cancel</sys:String>
     <sys:String x:Key="InstallContentDialog.AddContent.Button">Add Content</sys:String>
     <sys:String x:Key="InstallContentDialog.FilePicker.Title">Select Content Files</sys:String>
+    <sys:String x:Key="InstallContentDialog.InstallExtracted.Button">Install (Extract)</sys:String>
+    <sys:String x:Key="InstallContentDialog.InstallPackage.Button">Install (Package)</sys:String>
+    <sys:String x:Key="InstallContentDialog.Method.Package.ToolTip">Keeps the package file intact. Requires the latest Xenia Canary.</sys:String>
     <sys:String x:Key="InstallContentDialog.Results.Success.Title">Installation Successful</sys:String>
     <sys:String x:Key="InstallContentDialog.Results.Success.Message">The following content was installed successfully:</sys:String>
     <sys:String x:Key="InstallContentDialog.Results.Partial.Title">Installation Partially Successful</sys:String>

--- a/source/XeniaManager/Resources/Language/hr.axaml
+++ b/source/XeniaManager/Resources/Language/hr.axaml
@@ -646,10 +646,12 @@
 
     <!-- Install Content Dialog -->
     <sys:String x:Key="InstallContentDialog.ContentDialog.Title">Instaliraj sadržaj</sys:String>
-    <sys:String x:Key="InstallContentDialog.ContentDialog.InstallButton.Text">Instaliraj</sys:String>
     <sys:String x:Key="InstallContentDialog.ContentDialog.CancelButton.Text">Otkaži</sys:String>
     <sys:String x:Key="InstallContentDialog.AddContent.Button">Dodaj sadržaj</sys:String>
     <sys:String x:Key="InstallContentDialog.FilePicker.Title">Odaberite datoteke sadržaja</sys:String>
+    <sys:String x:Key="InstallContentDialog.InstallExtracted.Button">Instaliraj (Raspakiraj)</sys:String>
+    <sys:String x:Key="InstallContentDialog.InstallPackage.Button">Instaliraj (Paket)</sys:String>
+    <sys:String x:Key="InstallContentDialog.Method.Package.ToolTip">Zadržava paketnu datoteku netaknutom. Potreban je najnoviji Xenia Canary.</sys:String>
     <sys:String x:Key="InstallContentDialog.Results.Success.Title">Instalacija uspješna</sys:String>
     <sys:String x:Key="InstallContentDialog.Results.Success.Message">Sljedeći sadržaj je uspješno instaliran:</sys:String>
     <sys:String x:Key="InstallContentDialog.Results.Partial.Title">Instalacija djelomično uspješna</sys:String>

--- a/source/XeniaManager/ViewModels/Controls/InstallContentDialogViewModel.cs
+++ b/source/XeniaManager/ViewModels/Controls/InstallContentDialogViewModel.cs
@@ -8,7 +8,9 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using XeniaManager.Core.Files;
 using XeniaManager.Core.Logging;
+using XeniaManager.Core.Manage;
 using XeniaManager.Core.Models;
+using XeniaManager.Core.Models.Files.Stfs;
 using XeniaManager.Core.Services;
 using XeniaManager.Core.Utilities;
 using XeniaManager.ViewModels.Items;
@@ -109,10 +111,11 @@ public partial class InstallContentDialogViewModel : ViewModelBase
     }
 
     /// <summary>
-    /// Starts the installation of all content items in the list.
+    /// Starts the installation of all content items in the list using the given installation method.
     /// </summary>
+    /// <param name="installationMethod">The installation method to use for the content items.</param>
     [RelayCommand]
-    private async Task InstallAsync()
+    private async Task InstallAsync(ContentInstallationMethod installationMethod)
     {
         if (ContentItems.Count == 0)
         {
@@ -155,21 +158,42 @@ public partial class InstallContentDialogViewModel : ViewModelBase
                     string contentFolder = Path.Combine(AppPathResolver.GetFullPath(XeniaVersionInfo.GetXeniaVersionInfo(XeniaVersion).ContentFolderLocation),
                         "0000000000000000");
 
-                    // Extract the STFS file to Xenia's structure with progress reporting on a background thread
+                    // Install with progress reporting on a background thread
                     await Task.Run(() =>
                     {
-                        stfsFile.ExtractToXeniaStructure(
-                            contentFolder,
-                            progressCallback: (extractedFiles, totalFiles) =>
-                            {
-                                // Update progress based on extracted files count
-                                // Must be dispatched to UI thread
-                                double progress = (extractedFiles / (double)totalFiles) * 100;
-                                Dispatcher.UIThread.Post(() =>
+                        if (installationMethod == ContentInstallationMethod.PackageFile)
+                        {
+                            // Copy the package file into Xenia's content directory as-is
+                            ContentPackageManager.InstallPackageAsFile(
+                                stfsFile.PackagePath ?? throw new InvalidOperationException("Package file path is unknown"),
+                                contentFolder,
+                                stfsFile.Metadata.TitleIdHex,
+                                stfsFile.Metadata.ContentType.ToHexString(),
+                                (copiedBytes, totalBytes) =>
                                 {
-                                    contentItem.InstallationProgress = progress;
+                                    double progress = totalBytes > 0 ? copiedBytes * 100.0 / totalBytes : 100;
+                                    Dispatcher.UIThread.Post(() =>
+                                    {
+                                        contentItem.InstallationProgress = Math.Min(progress, 100);
+                                    });
                                 });
-                            });
+                        }
+                        else
+                        {
+                            // Extract the STFS file to Xenia's structure with progress reporting
+                            stfsFile.ExtractToXeniaStructure(
+                                contentFolder,
+                                progressCallback: (extractedFiles, totalFiles) =>
+                                {
+                                    // Update progress based on extracted files count
+                                    // Must be dispatched to UI thread
+                                    double progress = (extractedFiles / (double)totalFiles) * 100;
+                                    Dispatcher.UIThread.Post(() =>
+                                    {
+                                        contentItem.InstallationProgress = progress;
+                                    });
+                                });
+                        }
                     });
 
                     // Mark as complete

--- a/source/XeniaManager/ViewModels/Items/HeaderFileViewModel.cs
+++ b/source/XeniaManager/ViewModels/Items/HeaderFileViewModel.cs
@@ -1,8 +1,10 @@
 using System;
 using System.IO;
 using System.Text.RegularExpressions;
+using Avalonia.Media.Imaging;
+using CommunityToolkit.Mvvm.ComponentModel;
 using XeniaManager.Core.Files;
-using XeniaManager.Core.Models.Files;
+using XeniaManager.Core.Logging;
 using XeniaManager.Core.Models.Files.Stfs;
 
 namespace XeniaManager.ViewModels.Items;
@@ -16,6 +18,16 @@ public partial class HeaderFileViewModel : ViewModelBase
     /// The underlying header file.
     /// </summary>
     public HeaderFile Header { get; }
+
+    /// <summary>
+    /// The thumbnail image embedded in the package (only available for package entries).
+    /// </summary>
+    [ObservableProperty] private Bitmap? _thumbnailImage;
+
+    /// <summary>
+    /// Gets whether a thumbnail image is available for display.
+    /// </summary>
+    public bool HasThumbnail => ThumbnailImage != null;
 
     /// <summary>
     /// Gets the display name of the header file.
@@ -49,6 +61,12 @@ public partial class HeaderFileViewModel : ViewModelBase
     {
         get
         {
+            // Package-file content points directly at the package itself (no sidecar header)
+            if (Header.IsPackageEntry)
+            {
+                return Header.FilePath;
+            }
+
             // Split the path to get the base directory (remove "\Headers\...")
             string[] parts = Regex.Split(HeaderFilePath, @"\\Headers", RegexOptions.IgnoreCase);
             string basePath = parts[0];
@@ -83,5 +101,20 @@ public partial class HeaderFileViewModel : ViewModelBase
     public HeaderFileViewModel(HeaderFile header)
     {
         Header = header;
+
+        // Package entries carry their icon inside the package metadata
+        if (header.IsPackageEntry && header.ThumbnailImage.Length > 0)
+        {
+            try
+            {
+                using MemoryStream ms = new MemoryStream(header.ThumbnailImage);
+                ThumbnailImage = new Bitmap(ms);
+            }
+            catch (Exception ex)
+            {
+                Logger.Error<HeaderFileViewModel>($"Failed to load package thumbnail for '{header.FileName}'");
+                Logger.LogExceptionDetails<HeaderFileViewModel>(ex);
+            }
+        }
     }
 }

--- a/tests/XeniaManager.Tests/ContentPackageManagerTests.cs
+++ b/tests/XeniaManager.Tests/ContentPackageManagerTests.cs
@@ -1,0 +1,99 @@
+using XeniaManager.Core.Manage;
+
+namespace XeniaManager.Tests;
+
+[TestFixture]
+public class ContentPackageManagerTests
+{
+    private string _tempDirectory = string.Empty;
+    private string _sourcePackagePath = string.Empty;
+    private byte[] _packageData = [];
+
+    [SetUp]
+    public void Setup()
+    {
+        _tempDirectory = Path.Combine(Path.GetTempPath(), $"xenia_manager_pkg_tests_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDirectory);
+
+        // The installer copies package bytes as-is without parsing them,
+        // so a synthetic payload is enough to verify the copy behavior.
+        _packageData = new byte[3 * 1024 * 1024 + 123];
+        new Random(1234).NextBytes(_packageData);
+        _sourcePackagePath = Path.Combine(_tempDirectory, "SourceDLC.live");
+        File.WriteAllBytes(_sourcePackagePath, _packageData);
+    }
+
+    [TearDown]
+    public void Teardown()
+    {
+        if (Directory.Exists(_tempDirectory))
+        {
+            Directory.Delete(_tempDirectory, true);
+        }
+    }
+
+    [Test]
+    public void Install_CopiesPackageIntoContentTypeFolder_KeepingOriginalFileName()
+    {
+        // Act
+        ContentPackageManager.InstallPackageAsFile(_sourcePackagePath, _tempDirectory, "4D5309C9", "00009000");
+
+        // Assert
+        string destinationPath = Path.Combine(_tempDirectory, "4D5309C9", "00009000", "SourceDLC.live");
+        Assert.That(File.Exists(destinationPath), Is.True, "Package file was not copied to the content type folder");
+        Assert.That(File.ReadAllBytes(destinationPath), Is.EqualTo(_packageData), "Copied package content differs from the source");
+    }
+
+    [Test]
+    public void Install_NormalizesTitleIdAndContentTypeToUppercaseFolders()
+    {
+        // Act
+        ContentPackageManager.InstallPackageAsFile(_sourcePackagePath, _tempDirectory, "4d5309c9", "00009000");
+
+        // Assert
+        Assert.That(File.Exists(Path.Combine(_tempDirectory, "4D5309C9", "00009000", "SourceDLC.live")), Is.True);
+    }
+
+    [Test]
+    public void Install_OverwritesExistingDestinationFile()
+    {
+        // Arrange
+        string destinationFolder = Path.Combine(_tempDirectory, "4D5309C9", "00009000");
+        Directory.CreateDirectory(destinationFolder);
+        string destinationPath = Path.Combine(destinationFolder, "SourceDLC.live");
+        File.WriteAllBytes(destinationPath, [1, 2, 3]);
+
+        // Act
+        ContentPackageManager.InstallPackageAsFile(_sourcePackagePath, _tempDirectory, "4D5309C9", "00009000");
+
+        // Assert
+        Assert.That(File.ReadAllBytes(destinationPath), Is.EqualTo(_packageData), "Existing package was not overwritten");
+    }
+
+    [Test]
+    public void Install_MissingSourceFile_ThrowsFileNotFoundException()
+    {
+        // Arrange
+        string missingPath = Path.Combine(_tempDirectory, "missing.live");
+
+        // Act & Assert
+        Assert.Throws<FileNotFoundException>(() =>
+            ContentPackageManager.InstallPackageAsFile(missingPath, _tempDirectory, "4D5309C9", "00009000"));
+    }
+
+    [Test]
+    public void Install_ReportsProgressEndingWithTotalByteCount()
+    {
+        // Arrange
+        (long Copied, long Total) lastProgress = (0, 0);
+
+        // Act
+        ContentPackageManager.InstallPackageAsFile(_sourcePackagePath, _tempDirectory, "4D5309C9", "00009000",
+            (copied, total) => lastProgress = (copied, total));
+
+        // Assert
+        long expectedTotal = new FileInfo(_sourcePackagePath).Length;
+        Assert.That(lastProgress.Total, Is.EqualTo(expectedTotal));
+        Assert.That(lastProgress.Copied, Is.EqualTo(expectedTotal));
+    }
+}


### PR DESCRIPTION
## Description

Since [b11458e](https://github.com/xenia-canary/xenia-canary/commit/b11458e49b8d3cac4b920b119169e34e4e8e1d80), Xenia Canary can load content directly from CON/LIVE/PIRS package files kept intact in the content directory, instead of requiring extraction into directories with `.header` files.
This adds support for the new installation method alongside the old one, so both layouts are fully supported.

### Installing content
The Install Content dialog now has two separate buttons:
- **Install (Extract)** – extracts into Xenia's directory structure (compatible with all Xenia versions)
- **Install (Package)** – copies the package file as-is into `content\0000000000000000\{TITLE_ID}\{CONTENT_TYPE}\{filename}`, matching how Xenia itself installs packages (requires a Xenia build with [b11458e](https://github.com/xenia-canary/xenia-canary/commit/b11458e49b8d3cac4b920b119169e34e4e8e1d80) changes)

The dialog footer button was replaced by these two in-content buttons; Cancel remains in the dialog footer. Package installation reports progress by bytes copied.

### Reading installed content
- Package entries are listed by parsing the embedded STFS metadata directly (`StfsFile.LoadHeaderOnly`, header-only read), so display name/title ID come from the package itself instead of a filename-based fallback
- Extracted directories keep using sidecar `.header` files, unchanged
- Both desktop content viewer and Big Screen installed-content pane show the thumbnail embedded in the package for package entries, with the document icon fallback otherwise
- Deleting package entries removes the package file; deleting extracted content still removes the folder plus its `.header`

### Backwards compatibility
- Extraction remains fully supported and unchanged for older Xenia builds and forks (Netplay/Mousehook/Custom)
- Note: package-installed content is invisible to Xenia builds without [b11458e](https://github.com/xenia-canary/xenia-canary/commit/b11458e49b8d3cac4b920b119169e34e4e8e1d80) and for those builds, use Install (Extract) when targeting those